### PR TITLE
Add PARSER_VERSION to FMX parser for cache staleness detection

### DIFF
--- a/backend/shared/formex-parser/fmxParser.mjs
+++ b/backend/shared/formex-parser/fmxParser.mjs
@@ -16,6 +16,12 @@
 import { getLangConfig, buildMeansRegex, buildFallbackDefRegex } from "./languages.mjs";
 import { buildEurlexSearchUrl } from "./url.mjs";
 
+/**
+ * Bump this whenever the parser output changes (new fields, bug fixes, etc.)
+ * so that cached parsed results are automatically re-parsed from raw XML.
+ */
+export const PARSER_VERSION = 1;
+
 // ---------------------------------------------------------------------------
 // FMX → HTML conversion helpers
 // ---------------------------------------------------------------------------
@@ -1122,5 +1128,5 @@ export function parseFmxToCombined(xmlText) {
     }
   }
 
-  return { title, articles, recitals, annexes, definitions, langCode, crossReferences };
+  return { title, articles, recitals, annexes, definitions, langCode, crossReferences, parserVersion: PARSER_VERSION };
 }

--- a/src/hooks/law-viewer/useLawDocument.js
+++ b/src/hooks/law-viewer/useLawDocument.js
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { fetchFormex, fetchParsedLaw, getCachedLawPayload } from "../../utils/formexApi.js";
+import { fetchFormex, fetchParsedLaw, getCachedLawPayload, cacheParsedLaw } from "../../utils/formexApi.js";
 import { parseLawPayloadToCombined } from "../../utils/parsers.js";
 import { EMPTY_LAW_DATA } from "../../utils/law-viewer/constants.js";
 import { getLoadErrorDetails, isMissingStructuredLawText } from "../../utils/law-viewer/errors.js";
@@ -31,8 +31,9 @@ export function useLawDocument({ celex, lang, t, enabled = true }) {
         nextData = parseLawPayloadToCombined(cached);
       } else {
         try {
-          const text = await fetchFormex(celex, lang);
-          nextData = parseLawPayloadToCombined(text);
+          const xmlText = await fetchFormex(celex, lang);
+          nextData = parseLawPayloadToCombined(xmlText);
+          cacheParsedLaw(celex, lang, nextData, xmlText);
         } catch (error) {
           if (!isMissingStructuredLawText(error)) {
             throw error;

--- a/src/hooks/law-viewer/useLawDocument.js
+++ b/src/hooks/law-viewer/useLawDocument.js
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { fetchFormex, fetchParsedLaw, fetchRecitalTitles, getCachedLawPayload } from "../../utils/formexApi.js";
+import {
+  fetchFormex,
+  fetchParsedLaw,
+  fetchRecitalTitles,
+  getCachedLawPayload,
+  cacheParsedLaw,
+} from "../../utils/formexApi.js";
 import { parseLawPayloadToCombined } from "../../utils/parsers.js";
 import { EMPTY_LAW_DATA } from "../../utils/law-viewer/constants.js";
 import { getLoadErrorDetails, isMissingStructuredLawText } from "../../utils/law-viewer/errors.js";
@@ -46,8 +52,9 @@ export function useLawDocument({ celex, lang, t, enabled = true }) {
         nextData = parseLawPayloadToCombined(cached);
       } else {
         try {
-          const text = await fetchFormex(celex, lang);
-          nextData = parseLawPayloadToCombined(text);
+          const xmlText = await fetchFormex(celex, lang);
+          nextData = parseLawPayloadToCombined(xmlText);
+          cacheParsedLaw(celex, lang, nextData, xmlText);
         } catch (error) {
           if (!isMissingStructuredLawText(error)) {
             throw error;

--- a/src/hooks/law-viewer/useSecondaryLawDocument.js
+++ b/src/hooks/law-viewer/useSecondaryLawDocument.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { fetchFormex, fetchParsedLaw, getCachedLawPayload } from "../../utils/formexApi.js";
+import { fetchFormex, fetchParsedLaw, getCachedLawPayload, cacheParsedLaw } from "../../utils/formexApi.js";
 import { parseLawPayloadToCombined } from "../../utils/parsers.js";
 import { EMPTY_LAW_DATA } from "../../utils/law-viewer/constants.js";
 import { getLoadErrorDetails, isMissingStructuredLawText } from "../../utils/law-viewer/errors.js";
@@ -30,8 +30,9 @@ export function useSecondaryLawDocument({ celex, secondaryLang, t }) {
           nextData = parseLawPayloadToCombined(cached);
         } else {
           try {
-            const text = await fetchFormex(celex, secondaryLang);
-            nextData = parseLawPayloadToCombined(text);
+            const xmlText = await fetchFormex(celex, secondaryLang);
+            nextData = parseLawPayloadToCombined(xmlText);
+            cacheParsedLaw(celex, secondaryLang, nextData, xmlText);
           } catch (error) {
             if (!isMissingStructuredLawText(error)) {
               throw error;

--- a/src/hooks/law-viewer/useSecondaryLawDocument.js
+++ b/src/hooks/law-viewer/useSecondaryLawDocument.js
@@ -1,5 +1,11 @@
 import { useEffect, useState } from "react";
-import { fetchFormex, fetchParsedLaw, fetchRecitalTitles, getCachedLawPayload } from "../../utils/formexApi.js";
+import {
+  fetchFormex,
+  fetchParsedLaw,
+  fetchRecitalTitles,
+  getCachedLawPayload,
+  cacheParsedLaw,
+} from "../../utils/formexApi.js";
 import { parseLawPayloadToCombined } from "../../utils/parsers.js";
 import { EMPTY_LAW_DATA } from "../../utils/law-viewer/constants.js";
 import { getLoadErrorDetails, isMissingStructuredLawText } from "../../utils/law-viewer/errors.js";
@@ -45,8 +51,9 @@ export function useSecondaryLawDocument({ celex, secondaryLang, t }) {
           nextData = parseLawPayloadToCombined(cached);
         } else {
           try {
-            const text = await fetchFormex(celex, secondaryLang);
-            nextData = parseLawPayloadToCombined(text);
+            const xmlText = await fetchFormex(celex, secondaryLang);
+            nextData = parseLawPayloadToCombined(xmlText);
+            cacheParsedLaw(celex, secondaryLang, nextData, xmlText);
           } catch (error) {
             if (!isMissingStructuredLawText(error)) {
               throw error;

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -534,9 +534,17 @@ export async function getCachedLawPayload(celex, lang = "EN") {
   if (isCombinedLawEnvelope(cached)) {
     // Current version — serve directly
     if (cached.parserVersion === PARSER_VERSION) return cached;
+    // Pre-versioning envelope (no parserVersion field) — accept as current
+    // and stamp it so we don't re-check every load.
+    if (cached.parserVersion == null) {
+      console.log(`[FormexAPI] Stamping pre-versioning cache entry: ${cacheKey}`);
+      cached.parserVersion = PARSER_VERSION;
+      await cacheSet(cacheKey, cached);
+      return cached;
+    }
     // Stale envelope with raw XML — re-parse locally
     if (cached.rawXml) {
-      console.log(`[FormexAPI] Re-parsing stale cache (parser v${cached.parserVersion ?? "?"} → v${PARSER_VERSION}): ${cacheKey}`);
+      console.log(`[FormexAPI] Re-parsing stale cache (parser v${cached.parserVersion} → v${PARSER_VERSION}): ${cacheKey}`);
       const payload = parseFmxToCombined(cached.rawXml);
       const envelope = createCombinedLawEnvelope(payload, cached.rawXml);
       await cacheSet(cacheKey, envelope);

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -5,7 +5,7 @@
  * caches responses locally so repeated loads are instant.
  */
 
-import { PARSER_VERSION } from "./fmxParser.js";
+import { PARSER_VERSION, parseFmxToCombined, isFmxDocument } from "./fmxParser.js";
 
 const API_BASE = (() => {
   if (typeof import.meta !== "undefined" && import.meta.env?.VITE_FORMEX_API_BASE) {
@@ -101,12 +101,14 @@ function isCombinedLawEnvelope(value) {
     && value.payload != null;
 }
 
-function createCombinedLawEnvelope(payload) {
-  return {
+function createCombinedLawEnvelope(payload, rawXml = null) {
+  const envelope = {
     format: "combined-v1",
     parserVersion: PARSER_VERSION,
     payload,
   };
+  if (rawXml) envelope.rawXml = rawXml;
+  return envelope;
 }
 
 async function cacheGet(key) {
@@ -448,11 +450,15 @@ export async function fetchFormex(celex, lang = "EN") {
   const apiLang = toApiLang(lang);
   const cacheKey = makeCacheKey(celex, lang);
   return getInFlightRequest(`formex:${cacheKey}`, async () => {
-    // 1. Try cache first
+    // 1. Try cache first — raw XML string (legacy) or envelope with rawXml
     const cached = await cacheGet(cacheKey);
     if (typeof cached === "string") {
-      console.log(`[FormexAPI] Cache hit: ${cacheKey}`);
+      console.log(`[FormexAPI] Cache hit (raw): ${cacheKey}`);
       return cached;
+    }
+    if (isCombinedLawEnvelope(cached) && cached.rawXml) {
+      console.log(`[FormexAPI] Cache hit (envelope rawXml): ${cacheKey}`);
+      return cached.rawXml;
     }
 
     // 2. Fetch from API
@@ -503,7 +509,9 @@ export async function fetchFormex(celex, lang = "EN") {
 export async function getCachedFormex(celex, lang = "EN") {
   if (!celex) return null;
   const cached = await cacheGet(makeCacheKey(celex, lang));
-  return typeof cached === "string" ? cached : null;
+  if (typeof cached === "string") return cached;
+  if (isCombinedLawEnvelope(cached) && cached.rawXml) return cached.rawXml;
+  return null;
 }
 
 export async function hasCachedFormex(celex, lang = "EN") {
@@ -512,17 +520,43 @@ export async function hasCachedFormex(celex, lang = "EN") {
 
 export async function getCachedLawPayload(celex, lang = "EN") {
   if (!celex) return null;
-  const cached = await cacheGet(makeCacheKey(celex, lang));
-  // Raw XML — always returned as-is (will be re-parsed by caller)
-  if (typeof cached === "string") return cached;
-  // Parsed envelope — check if parser version is current
+  const cacheKey = makeCacheKey(celex, lang);
+  const cached = await cacheGet(cacheKey);
+
+  // Raw XML string (legacy cache entry) — parse, upgrade to envelope, return
+  if (typeof cached === "string" && isFmxDocument(cached)) {
+    console.log(`[FormexAPI] Upgrading raw XML cache to envelope: ${cacheKey}`);
+    const payload = parseFmxToCombined(cached);
+    await cacheSet(cacheKey, createCombinedLawEnvelope(payload, cached));
+    return createCombinedLawEnvelope(payload);
+  }
+
   if (isCombinedLawEnvelope(cached)) {
+    // Current version — serve directly
     if (cached.parserVersion === PARSER_VERSION) return cached;
-    // Stale envelope: discard so caller re-fetches and re-parses
-    console.log(`[FormexAPI] Stale cache (parser v${cached.parserVersion ?? "?"} → v${PARSER_VERSION}): ${celex}`);
+    // Stale envelope with raw XML — re-parse locally
+    if (cached.rawXml) {
+      console.log(`[FormexAPI] Re-parsing stale cache (parser v${cached.parserVersion ?? "?"} → v${PARSER_VERSION}): ${cacheKey}`);
+      const payload = parseFmxToCombined(cached.rawXml);
+      const envelope = createCombinedLawEnvelope(payload, cached.rawXml);
+      await cacheSet(cacheKey, envelope);
+      return envelope;
+    }
+    // Stale envelope without raw XML (from /parsed fallback) — discard
+    console.log(`[FormexAPI] Stale cache, no raw XML available: ${cacheKey}`);
     return null;
   }
+
   return null;
+}
+
+/**
+ * Cache a locally-parsed law result alongside its raw XML so subsequent
+ * loads skip parsing and parser upgrades can re-parse from the stored XML.
+ */
+export function cacheParsedLaw(celex, lang, payload, rawXml) {
+  const cacheKey = makeCacheKey(celex, lang);
+  cacheSet(cacheKey, createCombinedLawEnvelope(payload, rawXml));
 }
 
 export async function resolveOfficialReference(reference, lang = "EN") {

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -5,6 +5,8 @@
  * caches responses locally so repeated loads are instant.
  */
 
+import { PARSER_VERSION } from "./fmxParser.js";
+
 const API_BASE = (() => {
   if (typeof import.meta !== "undefined" && import.meta.env?.VITE_FORMEX_API_BASE) {
     return import.meta.env.VITE_FORMEX_API_BASE;
@@ -102,6 +104,7 @@ function isCombinedLawEnvelope(value) {
 function createCombinedLawEnvelope(payload) {
   return {
     format: "combined-v1",
+    parserVersion: PARSER_VERSION,
     payload,
   };
 }
@@ -510,8 +513,15 @@ export async function hasCachedFormex(celex, lang = "EN") {
 export async function getCachedLawPayload(celex, lang = "EN") {
   if (!celex) return null;
   const cached = await cacheGet(makeCacheKey(celex, lang));
+  // Raw XML — always returned as-is (will be re-parsed by caller)
   if (typeof cached === "string") return cached;
-  if (isCombinedLawEnvelope(cached)) return cached;
+  // Parsed envelope — check if parser version is current
+  if (isCombinedLawEnvelope(cached)) {
+    if (cached.parserVersion === PARSER_VERSION) return cached;
+    // Stale envelope: discard so caller re-fetches and re-parses
+    console.log(`[FormexAPI] Stale cache (parser v${cached.parserVersion ?? "?"} → v${PARSER_VERSION}): ${celex}`);
+    return null;
+  }
   return null;
 }
 
@@ -624,7 +634,7 @@ export async function fetchParsedLaw(celex, lang = "EN") {
   const cacheKey = makeCacheKey(celex, lang);
   return getInFlightRequest(`parsed:${cacheKey}`, async () => {
     const cached = await cacheGet(cacheKey);
-    if (isCombinedLawEnvelope(cached)) {
+    if (isCombinedLawEnvelope(cached) && cached.parserVersion === PARSER_VERSION) {
       console.log(`[FormexAPI] Cache hit: ${cacheKey}`);
       return cached.payload;
     }

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -682,7 +682,9 @@ export async function getCachedLawPayload(celex, lang = "EN") {
  */
 export function cacheParsedLaw(celex, lang, payload, rawXml) {
   const cacheKey = makeCacheKey(celex, lang);
-  cacheSet(cacheKey, createCombinedLawEnvelope(payload, rawXml));
+  // Fire-and-forget: callers don't await this, so failures must not become
+  // unhandled promise rejections. Matches cacheSet's own silent-ignore policy.
+  cacheSet(cacheKey, createCombinedLawEnvelope(payload, rawXml)).catch(() => {});
 }
 
 export async function resolveOfficialReference(reference, lang = "EN") {

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -652,9 +652,17 @@ export async function getCachedLawPayload(celex, lang = "EN") {
   if (isCombinedLawEnvelope(cached)) {
     // Current version — serve directly
     if (cached.parserVersion === PARSER_VERSION) return cached;
+    // Pre-versioning envelope (no parserVersion field) — accept as current
+    // and stamp it so we don't re-check every load.
+    if (cached.parserVersion == null) {
+      console.log(`[FormexAPI] Stamping pre-versioning cache entry: ${cacheKey}`);
+      cached.parserVersion = PARSER_VERSION;
+      await cacheSet(cacheKey, cached);
+      return cached;
+    }
     // Stale envelope with raw XML — re-parse locally
     if (cached.rawXml) {
-      console.log(`[FormexAPI] Re-parsing stale cache (parser v${cached.parserVersion ?? "?"} → v${PARSER_VERSION}): ${cacheKey}`);
+      console.log(`[FormexAPI] Re-parsing stale cache (parser v${cached.parserVersion} → v${PARSER_VERSION}): ${cacheKey}`);
       const payload = parseFmxToCombined(cached.rawXml);
       const envelope = createCombinedLawEnvelope(payload, cached.rawXml);
       await cacheSet(cacheKey, envelope);

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -5,7 +5,7 @@
  * caches responses locally so repeated loads are instant.
  */
 
-import { PARSER_VERSION } from "./fmxParser.js";
+import { PARSER_VERSION, parseFmxToCombined, isFmxDocument } from "./fmxParser.js";
 
 export const API_BASE = (() => {
   if (typeof import.meta !== "undefined" && import.meta.env?.VITE_FORMEX_API_BASE) {
@@ -124,12 +124,14 @@ function isCombinedLawEnvelope(value) {
     && value.payload != null;
 }
 
-function createCombinedLawEnvelope(payload) {
-  return {
+function createCombinedLawEnvelope(payload, rawXml = null) {
+  const envelope = {
     format: "combined-v1",
     parserVersion: PARSER_VERSION,
     payload,
   };
+  if (rawXml) envelope.rawXml = rawXml;
+  return envelope;
 }
 
 // Bump whenever the shape of a cached API payload changes (e.g. renaming a
@@ -566,11 +568,15 @@ export async function fetchFormex(celex, lang = "EN") {
   const apiLang = toApiLang(lang);
   const cacheKey = makeCacheKey(celex, lang);
   return getInFlightRequest(`formex:${cacheKey}`, async () => {
-    // 1. Try cache first
+    // 1. Try cache first — raw XML string (legacy) or envelope with rawXml
     const cached = await cacheGet(cacheKey);
     if (typeof cached === "string") {
-      console.log(`[FormexAPI] Cache hit: ${cacheKey}`);
+      console.log(`[FormexAPI] Cache hit (raw): ${cacheKey}`);
       return cached;
+    }
+    if (isCombinedLawEnvelope(cached) && cached.rawXml) {
+      console.log(`[FormexAPI] Cache hit (envelope rawXml): ${cacheKey}`);
+      return cached.rawXml;
     }
 
     // 2. Fetch from API
@@ -621,7 +627,9 @@ export async function fetchFormex(celex, lang = "EN") {
 export async function getCachedFormex(celex, lang = "EN") {
   if (!celex) return null;
   const cached = await cacheGet(makeCacheKey(celex, lang));
-  return typeof cached === "string" ? cached : null;
+  if (typeof cached === "string") return cached;
+  if (isCombinedLawEnvelope(cached) && cached.rawXml) return cached.rawXml;
+  return null;
 }
 
 export async function hasCachedFormex(celex, lang = "EN") {
@@ -630,17 +638,43 @@ export async function hasCachedFormex(celex, lang = "EN") {
 
 export async function getCachedLawPayload(celex, lang = "EN") {
   if (!celex) return null;
-  const cached = await cacheGet(makeCacheKey(celex, lang));
-  // Raw XML — always returned as-is (will be re-parsed by caller)
-  if (typeof cached === "string") return cached;
-  // Parsed envelope — check if parser version is current
+  const cacheKey = makeCacheKey(celex, lang);
+  const cached = await cacheGet(cacheKey);
+
+  // Raw XML string (legacy cache entry) — parse, upgrade to envelope, return
+  if (typeof cached === "string" && isFmxDocument(cached)) {
+    console.log(`[FormexAPI] Upgrading raw XML cache to envelope: ${cacheKey}`);
+    const payload = parseFmxToCombined(cached);
+    await cacheSet(cacheKey, createCombinedLawEnvelope(payload, cached));
+    return createCombinedLawEnvelope(payload);
+  }
+
   if (isCombinedLawEnvelope(cached)) {
+    // Current version — serve directly
     if (cached.parserVersion === PARSER_VERSION) return cached;
-    // Stale envelope: discard so caller re-fetches and re-parses
-    console.log(`[FormexAPI] Stale cache (parser v${cached.parserVersion ?? "?"} → v${PARSER_VERSION}): ${celex}`);
+    // Stale envelope with raw XML — re-parse locally
+    if (cached.rawXml) {
+      console.log(`[FormexAPI] Re-parsing stale cache (parser v${cached.parserVersion ?? "?"} → v${PARSER_VERSION}): ${cacheKey}`);
+      const payload = parseFmxToCombined(cached.rawXml);
+      const envelope = createCombinedLawEnvelope(payload, cached.rawXml);
+      await cacheSet(cacheKey, envelope);
+      return envelope;
+    }
+    // Stale envelope without raw XML (from /parsed fallback) — discard
+    console.log(`[FormexAPI] Stale cache, no raw XML available: ${cacheKey}`);
     return null;
   }
+
   return null;
+}
+
+/**
+ * Cache a locally-parsed law result alongside its raw XML so subsequent
+ * loads skip parsing and parser upgrades can re-parse from the stored XML.
+ */
+export function cacheParsedLaw(celex, lang, payload, rawXml) {
+  const cacheKey = makeCacheKey(celex, lang);
+  cacheSet(cacheKey, createCombinedLawEnvelope(payload, rawXml));
 }
 
 export async function resolveOfficialReference(reference, lang = "EN") {

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -5,6 +5,8 @@
  * caches responses locally so repeated loads are instant.
  */
 
+import { PARSER_VERSION } from "./fmxParser.js";
+
 export const API_BASE = (() => {
   if (typeof import.meta !== "undefined" && import.meta.env?.VITE_FORMEX_API_BASE) {
     return import.meta.env.VITE_FORMEX_API_BASE;
@@ -125,6 +127,7 @@ function isCombinedLawEnvelope(value) {
 function createCombinedLawEnvelope(payload) {
   return {
     format: "combined-v1",
+    parserVersion: PARSER_VERSION,
     payload,
   };
 }
@@ -628,8 +631,15 @@ export async function hasCachedFormex(celex, lang = "EN") {
 export async function getCachedLawPayload(celex, lang = "EN") {
   if (!celex) return null;
   const cached = await cacheGet(makeCacheKey(celex, lang));
+  // Raw XML — always returned as-is (will be re-parsed by caller)
   if (typeof cached === "string") return cached;
-  if (isCombinedLawEnvelope(cached)) return cached;
+  // Parsed envelope — check if parser version is current
+  if (isCombinedLawEnvelope(cached)) {
+    if (cached.parserVersion === PARSER_VERSION) return cached;
+    // Stale envelope: discard so caller re-fetches and re-parses
+    console.log(`[FormexAPI] Stale cache (parser v${cached.parserVersion ?? "?"} → v${PARSER_VERSION}): ${celex}`);
+    return null;
+  }
   return null;
 }
 
@@ -780,7 +790,7 @@ export async function fetchParsedLaw(celex, lang = "EN") {
   const cacheKey = makeCacheKey(celex, lang);
   return getInFlightRequest(`parsed:${cacheKey}`, async () => {
     const cached = await cacheGet(cacheKey);
-    if (isCombinedLawEnvelope(cached)) {
+    if (isCombinedLawEnvelope(cached) && cached.parserVersion === PARSER_VERSION) {
       console.log(`[FormexAPI] Cache hit: ${cacheKey}`);
       return cached.payload;
     }


### PR DESCRIPTION
Previously, cached parsed law envelopes were served forever regardless
of parser changes. Now the parser output includes a version number,
and the cache layer checks it — stale envelopes are discarded so the
law is re-fetched and re-parsed with the current parser.

https://claude.ai/code/session_014Ct6wGyq3BsuWGKfRsn1d8