### PR TITLE
Support parsing and displaying Commission (COM) proposals

### DIFF
--- a/backend/shared/eurlex-html-parser.js
+++ b/backend/shared/eurlex-html-parser.js
@@ -669,6 +669,154 @@ function parseLegacyXhtmlToCombined(document, langCode, langConfig, injectCrossR
   };
 }
 
+// Commission / preparatory documents (proposals, communications) are published
+// in EUR-Lex using the LegisWrite "manifestation" markup rather than the OJ
+// `oj-*` classes. Articles are `<p class="Titrearticle">`, recitals are
+// `<p class="li ManualConsidrant">`, divisions are `<p class="SectionTitle">`,
+// and annexes start with `<p class="Annexetitre">`.
+function parseLegisWriteToCombined(document, langCode, langConfig, injectCrossRefLinks) {
+  const getText = (element) => normalizeText(element?.textContent);
+  const hasClass = (element, name) => element.classList && element.classList.contains(name);
+
+  const titleParts = ["Statut", "Typedudocument", "Titreobjet"]
+    .map((cls) => getText(document.querySelector(`p.${cls}`)))
+    .filter(Boolean);
+  const title = normalizeText(titleParts.join(" "));
+
+  const recitals = [];
+  for (const element of document.querySelectorAll("p.li.ManualConsidrant")) {
+    const numText = getText(element.querySelector(".num"));
+    const numberMatch = numText.match(/(\d+)/);
+    const recital_number = numberMatch ? numberMatch[1] : String(recitals.length + 1);
+    const text = stripLeadingMarker(getText(element), /^\(\d+\)\s*/);
+    recitals.push(buildRecital(recital_number, text, `<p>${escapeHtml(text)}</p>`));
+  }
+
+  const articles = [];
+  const annexes = [];
+  let currentChapter = { number: "", title: "" };
+  let currentSection = { number: "", title: "" };
+  let pendingDivision = null;
+  let currentArticle = null;
+  let currentAnnex = null;
+  let inEnactingTerms = false;
+
+  const finalizeArticle = () => {
+    if (!currentArticle) return;
+    const html = paragraphsToHtml(currentArticle.bodyParagraphs, { title: currentArticle.article_title });
+    articles.push({
+      article_number: currentArticle.article_number,
+      article_title: currentArticle.article_title,
+      division: currentArticle.division,
+      article_html: injectCrossRefLinks(html, langConfig),
+      bodyParagraphs: currentArticle.bodyParagraphs.filter(Boolean),
+    });
+    currentArticle = null;
+  };
+
+  const finalizeAnnex = () => {
+    if (!currentAnnex) return;
+    annexes.push({
+      annex_id: currentAnnex.annex_id,
+      annex_title: currentAnnex.annex_title,
+      annex_html: injectCrossRefLinks(paragraphsToHtml(currentAnnex.bodyParagraphs), langConfig),
+    });
+    currentAnnex = null;
+  };
+
+  for (const element of document.body.querySelectorAll("p")) {
+    const text = getText(element);
+    if (!text) continue;
+
+    if (hasClass(element, "Formuledadoption")) {
+      inEnactingTerms = true;
+      continue;
+    }
+
+    if (hasClass(element, "Annexetitre")) {
+      finalizeArticle();
+      finalizeAnnex();
+      inEnactingTerms = true;
+      pendingDivision = null;
+      const annexMatch = text.match(/^ANNEX\s*([IVXLCDM]+|\d+)?/i);
+      currentAnnex = {
+        annex_id: normalizeText(annexMatch?.[1] || "") || text,
+        annex_title: text,
+        bodyParagraphs: [],
+      };
+      continue;
+    }
+
+    if (hasClass(element, "Titrearticle")) {
+      finalizeAnnex();
+      finalizeArticle();
+      inEnactingTerms = true;
+      pendingDivision = null;
+      const numberMatch = text.match(/^Article\s+(\d+[A-Za-z]*)\s*(.*)$/i);
+      currentArticle = {
+        article_number: numberMatch ? numberMatch[1] : String(articles.length + 1),
+        article_title: numberMatch ? normalizeText(numberMatch[2]) : "",
+        division: {
+          chapter: { ...currentChapter },
+          section: currentSection.number ? { ...currentSection } : null,
+        },
+        bodyParagraphs: [],
+      };
+      continue;
+    }
+
+    if (hasClass(element, "SectionTitle")) {
+      if (!inEnactingTerms) continue;
+      const divisionMarker = parseDivisionMarker(text);
+      if (divisionMarker) {
+        finalizeArticle();
+        if (divisionMarker.kind === "section") {
+          currentSection = { number: divisionMarker.number, title: divisionMarker.title };
+          pendingDivision = currentSection;
+        } else {
+          currentChapter = { number: divisionMarker.number, title: divisionMarker.title };
+          currentSection = { number: "", title: "" };
+          pendingDivision = currentChapter;
+        }
+      } else if (pendingDivision && !pendingDivision.title) {
+        pendingDivision.title = text;
+        pendingDivision = null;
+      }
+      continue;
+    }
+
+    if (currentAnnex) {
+      currentAnnex.bodyParagraphs.push(text);
+      continue;
+    }
+
+    if (currentArticle) {
+      currentArticle.bodyParagraphs.push(text);
+    }
+  }
+
+  finalizeArticle();
+  finalizeAnnex();
+
+  const definitions = articles.flatMap((article) => parseDefinitions(article));
+
+  recitals.sort((left, right) => {
+    const leftNum = Number.parseInt(String(left.recital_number).replace(/\D+/g, ""), 10) || 0;
+    const rightNum = Number.parseInt(String(right.recital_number).replace(/\D+/g, ""), 10) || 0;
+    return leftNum - rightNum;
+  });
+
+  return {
+    title,
+    articles: articles.map(({ bodyParagraphs, ...article }) => article),
+    recitals,
+    annexes,
+    definitions,
+    langCode,
+    crossReferences: {},
+  };
+}
+
 async function loadHelpers() {
   if (!helperPromise) {
     helperPromise = (async () => {
@@ -718,6 +866,16 @@ async function parseEurlexHtmlToCombined(htmlText, lang = "ENG") {
     const parsedLegacyXhtml = parseLegacyXhtmlToCombined(document, langCode, langConfig, injectCrossRefLinks);
     if (parsedLegacyXhtml.articles.length || parsedLegacyXhtml.recitals.length || parsedLegacyXhtml.annexes.length) {
       return parsedLegacyXhtml;
+    }
+  }
+
+  const hasLegisWriteLayout = Boolean(
+    document.querySelector("p.Titrearticle, p.li.ManualConsidrant")
+  );
+  if (hasLegisWriteLayout) {
+    const parsedLegisWrite = parseLegisWriteToCombined(document, langCode, langConfig, injectCrossRefLinks);
+    if (parsedLegisWrite.articles.length || parsedLegisWrite.recitals.length || parsedLegisWrite.annexes.length) {
+      return parsedLegisWrite;
     }
   }
 

--- a/backend/shared/eurlex-html-parser.test.js
+++ b/backend/shared/eurlex-html-parser.test.js
@@ -107,6 +107,50 @@ const FLAT_DIVISION_HTML = `<!DOCTYPE html>
 </body>
 </html>`;
 
+const LEGISWRITE_COM_HTML = `<!DOCTYPE html>
+<html lang="EN">
+<body>
+  <div class="content">
+    <p class="Statut"><span>Proposal for a</span></p>
+    <p class="Typedudocument"><span>REGULATION OF THE EUROPEAN PARLIAMENT AND OF THE COUNCIL</span></p>
+    <p class="Titreobjet"><span>ON A SAMPLE MATTER</span></p>
+    <p class="li ManualHeading1"><span>1.</span><span>EXPLANATORY MEMORANDUM</span></p>
+    <p class="Normal"><span>Some explanatory prose that must not become a recital.</span></p>
+    <p class="li ManualConsidrant"><span class="num"><span>(1)</span></span><span>First recital text.</span></p>
+    <p class="li ManualConsidrant"><span class="num"><span>(2)</span></span><span>Second recital mentioning Article 2.</span></p>
+    <p class="Formuledadoption"><span>HAVE ADOPTED THIS REGULATION:</span></p>
+    <p class="SectionTitle"><span>TITLE I</span></p>
+    <p class="SectionTitle"><span>GENERAL PROVISIONS</span></p>
+    <p class="Titrearticle"><span>Article 1</span><span> <br>Subject matter</span></p>
+    <p class="Normal"><span>This Regulation lays down rules.</span></p>
+    <p class="Titrearticle"><span>Article 2</span><span> <br>Definitions</span></p>
+    <p class="Normal"><span>For the purposes of this Regulation, the following definitions apply.</span></p>
+    <p class="Annexetitre"><span>ANNEX </span><span>I</span><br><span>SAMPLE ANNEX</span></p>
+    <p class="Normal"><span>Annex body content.</span></p>
+  </div>
+</body>
+</html>`;
+
+test("parseEurlexHtmlToCombined parses LegisWrite Commission-proposal layout", async () => {
+  const parsed = await parseEurlexHtmlToCombined(LEGISWRITE_COM_HTML, "ENG");
+
+  assert.match(parsed.title, /^Proposal for a REGULATION OF THE EUROPEAN PARLIAMENT/);
+  assert.equal(parsed.recitals.length, 2);
+  assert.equal(parsed.recitals[0].recital_number, "1");
+  assert.match(parsed.recitals[0].recital_text, /First recital text/);
+  assert.equal(parsed.articles.length, 2);
+  assert.equal(parsed.articles[0].article_number, "1");
+  assert.equal(parsed.articles[0].article_title, "Subject matter");
+  assert.equal(parsed.articles[0].division.chapter.number, "TITLE I");
+  assert.equal(parsed.articles[0].division.chapter.title, "GENERAL PROVISIONS");
+  assert.match(parsed.articles[0].article_html, /This Regulation lays down rules/);
+  // Explanatory-memorandum prose before the recitals must not leak into the body.
+  assert.ok(parsed.articles.every((a) => !/explanatory prose/i.test(a.article_html)));
+  assert.equal(parsed.annexes.length, 1);
+  assert.equal(parsed.annexes[0].annex_id, "I");
+  assert.match(parsed.annexes[0].annex_html, /Annex body content/);
+});
+
 test("parseEurlexHtmlToCombined keeps flat chapter and section headings out of article bodies", async () => {
   const parsed = await parseEurlexHtmlToCombined(FLAT_DIVISION_HTML, "ENG");
 

--- a/backend/shared/reference-utils.js
+++ b/backend/shared/reference-utils.js
@@ -69,13 +69,15 @@ function parseStructuredReference(input = {}) {
   };
 }
 
+// Descriptor may be 1 letter (e.g. R/L/D for adopted acts) or 2 letters
+// (e.g. PC/DC for preparatory documents like Commission proposals).
 function validateCelex(celex) {
-  return /^\d{5}[A-Z]\d{4}(?:\([0-9]+\))?$/.test(celex);
+  return /^\d{5}[A-Z]{1,2}\d{4}(?:\([0-9]+\))?$/.test(celex);
 }
 
 function extractCelexFromText(text = '') {
-  const match = String(text).match(/CELEX[:%]3A(\d{5}[A-Z]\d{4}(?:\([0-9]+\))?)/i)
-    || String(text).match(/CELEX:(\d{5}[A-Z]\d{4}(?:\([0-9]+\))?)/i);
+  const match = String(text).match(/CELEX[:%]3A(\d{5}[A-Z]{1,2}\d{4}(?:\([0-9]+\))?)/i)
+    || String(text).match(/CELEX:(\d{5}[A-Z]{1,2}\d{4}(?:\([0-9]+\))?)/i);
   return match ? match[1].toUpperCase() : null;
 }
 
@@ -129,7 +131,37 @@ function parseEurlexUrl(inputUrl) {
     };
   }
 
+  // Commission / preparatory documents, e.g. COM:2026:502:FIN, JOIN:2023:1:FIN.
+  const comMatch = uri.match(/^(COM|JOIN|SEC|SWD):(\d{4}):(\d{1,4}):(\w+)$/i);
+  if (comMatch) {
+    return {
+      type: 'com',
+      com: {
+        docType: comMatch[1].toUpperCase(),
+        year: comMatch[2],
+        number: String(parseInt(comMatch[3], 10)),
+        suffix: comMatch[4].toUpperCase(),
+      },
+      url,
+    };
+  }
+
   return { type: 'html', url };
+}
+
+// Builds the COMNAT-style document identifier Cellar uses for Commission /
+// preparatory documents, e.g. { COM, 2026, 502, FIN } -> "comnat:COM_2026_0502_FIN".
+function buildComnatId(com) {
+  if (!com?.docType || !com?.year || !com?.number || !com?.suffix) return null;
+  const number = String(parseInt(com.number, 10));
+  if (!/^\d+$/.test(number)) return null;
+  return `comnat:${com.docType}_${com.year}_${number.padStart(4, '0')}_${com.suffix}`;
+}
+
+function buildEurlexComFallbackUrl(com, lang, toSearchLang, EURLEX_BASE) {
+  const langCode = toSearchLang(lang).toUpperCase();
+  if (!com?.docType || !com?.year || !com?.number || !com?.suffix) return null;
+  return `${EURLEX_BASE}/legal-content/${langCode}/TXT/?uri=${com.docType}:${com.year}:${com.number}:${com.suffix}`;
 }
 
 function buildEurlexSearchFallbackUrl(reference, lang, toSearchLang, EURLEX_BASE) {
@@ -457,6 +489,46 @@ LIMIT 5`;
     return resolveOfficialJournalViaCellar(oj, lang);
   }
 
+  async function resolveCommissionDocument(com, lang = 'ENG') {
+    const comnatId = buildComnatId(com);
+    if (!comnatId) {
+      throw new ClientError('Commission document reference requires docType, year, number and suffix', 400, 'invalid_com_reference');
+    }
+
+    const cacheKey = JSON.stringify({ type: 'com-resolve', com, lang });
+    const cached = cacheGet(resolutionCache, cacheKey);
+    if (cached) return cached;
+
+    const fallback = {
+      type: 'open-source-url',
+      url: buildEurlexComFallbackUrl(com, lang, toSearchLang, EURLEX_BASE),
+    };
+
+    const query = `
+PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
+SELECT DISTINCT ?celex WHERE {
+  ?work cdm:work_id_document ?id .
+  ?work cdm:resource_legal_id_celex ?celex .
+  FILTER(STR(?id) = "${comnatId}")
+}
+LIMIT 5`;
+
+    const data = await runSparqlQuery(query);
+    const celexValues = (data.results?.bindings || [])
+      .map((binding) => binding.celex?.value)
+      .filter(Boolean);
+
+    const payload = {
+      resolved: celexValues.length > 0
+        ? { celex: celexValues[0].toUpperCase(), source: 'cellar-com' }
+        : null,
+      tried: [{ source: 'cellar-com', comnatId, celex: celexValues }],
+      fallback,
+    };
+    cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+    return payload;
+  }
+
   async function resolveEurlexUrl(inputUrl, lang = 'ENG') {
     const parsed = parseEurlexUrl(inputUrl);
     const cacheKey = JSON.stringify({ type: 'resolve-url', inputUrl, lang });
@@ -538,6 +610,25 @@ LIMIT 5`;
       return payload;
     }
 
+    if (parsed.type === 'com') {
+      const resolution = await resolveCommissionDocument(parsed.com, lang);
+      const payload = {
+        sourceUrl: parsed.url.toString(),
+        parsed: {
+          type: parsed.type,
+          com: parsed.com,
+        },
+        resolved: resolution.resolved,
+        tried: resolution.tried,
+        fallback: resolution.fallback || {
+          type: 'open-source-url',
+          url: parsed.url.toString(),
+        },
+      };
+      cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+      return payload;
+    }
+
     const payload = {
       sourceUrl: parsed.url.toString(),
       parsed: {
@@ -554,6 +645,7 @@ LIMIT 5`;
   }
 
   return {
+    resolveCommissionDocument,
     resolveReference,
     resolveEurlexUrl,
     resolveOfficialJournal,
@@ -564,6 +656,7 @@ LIMIT 5`;
 }
 
 module.exports = {
+  buildComnatId,
   buildEliCandidates,
   createReferenceResolver,
   extractCelexFromText,

--- a/backend/shared/reference-utils.test.js
+++ b/backend/shared/reference-utils.test.js
@@ -78,6 +78,21 @@ test('validateCelex accepts canonical CELEX format', () => {
   assert.equal(validateCelex('GDPR'), false);
 });
 
+test('validateCelex accepts two-letter descriptors for preparatory documents', () => {
+  assert.equal(validateCelex('52021PC0206'), true);
+  assert.equal(validateCelex('52026PC0502'), true);
+  assert.equal(validateCelex('52021DC0118'), true);
+});
+
+test('parseEurlexUrl recognizes Commission-document (COM) URLs', () => {
+  const parsed = parseEurlexUrl('https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=COM:2026:502:FIN');
+  assert.equal(parsed.type, 'com');
+  assert.equal(parsed.com.docType, 'COM');
+  assert.equal(parsed.com.year, '2026');
+  assert.equal(parsed.com.number, '502');
+  assert.equal(parsed.com.suffix, 'FIN');
+});
+
 function createResolver({ store, fetchImpl }) {
   const originalFetch = global.fetch;
   if (fetchImpl) {
@@ -266,6 +281,37 @@ test('resolveEurlexUrl keeps OJ fallback path when cache cannot resolve determin
     assert.equal(result.resolved, null);
     assert.equal(result.fallback?.type, 'open-source-url');
     assert.equal(fetchCalls.length, 4);
+  } finally {
+    restore();
+  }
+});
+
+test('resolveEurlexUrl resolves a Commission-document URL via the COMNAT identifier', async () => {
+  const store = new JsonLegalCacheStore(fixturePath);
+  store.load();
+
+  const fetchCalls = [];
+  const { resolver, restore } = createResolver({
+    store,
+    fetchImpl: async (url) => {
+      fetchCalls.push(String(url));
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return { results: { bindings: [{ celex: { value: '52026PC0502' } }] } };
+        },
+      };
+    },
+  });
+
+  try {
+    const result = await resolver.resolveEurlexUrl('https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=COM:2026:502:FIN', 'ENG');
+    assert.equal(result.parsed.type, 'com');
+    assert.equal(result.resolved?.celex, '52026PC0502');
+    assert.equal(result.resolved?.source, 'cellar-com');
+    assert.equal(fetchCalls.length, 1);
+    assert.match(decodeURIComponent(fetchCalls[0]), /comnat:COM_2026_0502_FIN/);
   } finally {
     restore();
   }

--- a/src/i18n/localeMeta.js
+++ b/src/i18n/localeMeta.js
@@ -51,6 +51,7 @@ export function isSupportedUiLocale(value) {
 
 export function getPathSegments(pathname) {
   return String(pathname || "/")
+    .replace(/[?#].*$/, "")
     .replace(/^\/+|\/+$/g, "")
     .split("/")
     .filter(Boolean);

--- a/src/utils/lawRouting.js
+++ b/src/utils/lawRouting.js
@@ -124,7 +124,15 @@ export function findBundledLawBySlug(slug) {
 
 export function getCanonicalLawRoute(law, kind = null, id = null, locale = "en") {
   const slug = getLawSlug(law);
-  if (!slug) return "/";
+  if (!slug) {
+    // Laws without an official-reference slug (e.g. Commission proposals, COM
+    // documents) are opened through the celex-based import route.
+    const celex = String(law?.celex || "").trim().toUpperCase();
+    if (!celex) return "/";
+    const query = `?celex=${encodeURIComponent(celex)}`;
+    if (kind && id != null) return `/import/${kind}/${encodeURIComponent(String(id))}${query}`;
+    return `/import${query}`;
+  }
   const base = normalizeUiLocale(locale) === "en" ? `/${slug}` : `/${normalizeUiLocale(locale)}/${slug}`;
   if (kind && id != null) return `${base}/${kind}/${encodeURIComponent(String(id))}`;
   return base;

--- a/src/utils/lawRouting.test.js
+++ b/src/utils/lawRouting.test.js
@@ -122,8 +122,18 @@ describe("getCanonicalLawRoute", () => {
     expect(route).toBe("/gdpr/article/5a");
   });
 
-  it("returns / for law without slug", () => {
+  it("returns / for law without slug or celex", () => {
     expect(getCanonicalLawRoute({})).toBe("/");
+  });
+
+  it("falls back to the import route for slugless laws with a celex (e.g. COM proposals)", () => {
+    const route = getCanonicalLawRoute({ celex: "52026PC0502" });
+    expect(route).toBe("/import?celex=52026PC0502");
+  });
+
+  it("keeps kind/id on the import fallback route", () => {
+    const route = getCanonicalLawRoute({ celex: "52026PC0502" }, "article", "5");
+    expect(route).toBe("/import/article/5?celex=52026PC0502");
   });
 
   it("includes locale prefix for non-English", () => {


### PR DESCRIPTION
## Summary

EUR-Lex links to Commission documents — e.g. `https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=COM:2026:502:FIN` — could not be opened. This adds end-to-end support for COM proposals (resolution, parsing, display, and opening from the recent-laws list).

### Backend
- **`parseEurlexUrl`** now recognises `COM`/`JOIN`/`SEC`/`SWD` document URIs and a new `resolveCommissionDocument` resolver maps them to a CELEX via the Cellar COMNAT identifier (`COM:2026:502:FIN` → `comnat:COM_2026_0502_FIN` → `52026PC0502`).
- **`validateCelex` / `extractCelexFromText`** now accept two-letter descriptors (`PC`, `DC`, …) used by preparatory documents, not just single letters (`R`/`L`/`D`). Without this the resolved CELEX was rejected by the API.
- **New LegisWrite HTML parser** (`parseLegisWriteToCombined`) handles the Commission's proposal markup (`Titrearticle` / `li ManualConsidrant` / `SectionTitle` / `Annexetitre`), since COM proposals are not published as Formex XML and fall through to the HTML path.

### Frontend
- **`getCanonicalLawRoute`** falls back to the `/import?celex=` route for slugless laws (COM proposals have no official-reference slug), so clicking one in the recent-laws list opens the viewer instead of navigating home.
- **`getPathSegments`** strips query/hash so `localizePath` treats `/import?celex=` as a reserved, locale-agnostic path across all UI locales.

## Verification
- Resolves the example `COM:2026:502:FIN` → `52026PC0502`; parser yields 48 articles / 91 recitals / 3 annexes with correct titles and divisions.
- Backend: 49/49 tests pass. Frontend: 196/196 tests pass. Lint clean.
- Added tests for two-letter CELEX validation, COM URL parsing, COMNAT resolution, the LegisWrite layout, and the import-route fallback.

## Known follow-up (out of scope)
A slugless COM proposal currently shows in the recent list as `CELEX 52026PC0502` rather than its title, because import doesn't persist a label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)