### PR TITLE
Fix linked law overwriting source law's name in library

### DIFF
--- a/src/components/LawViewer.jsx
+++ b/src/components/LawViewer.jsx
@@ -180,6 +180,12 @@ export function LawViewer() {
 
   useEffect(() => {
     if (!source.effectiveCelex || !derived.hasLoadedContent) return;
+    // Only persist metadata once the loaded document actually corresponds to
+    // the current law.  When navigating to a linked law, `effectiveCelex`
+    // changes a render before the document refetches, so `primaryDocument.data`
+    // still holds the previous law's title — saving here would overwrite the
+    // new law's name with the old one.
+    if (primaryDocument.data.celex !== source.effectiveCelex) return;
     const rawReference = searchParams.get("raw");
     const officialReference = source.currentLaw?.officialReference || parseOfficialReference(rawReference || "");
     saveLawMeta({
@@ -195,6 +201,7 @@ export function LawViewer() {
   }, [
     derived.hasLoadedContent,
     preferences.formexLang,
+    primaryDocument.data.celex,
     primaryDocument.data.langCode,
     primaryDocument.data.title,
     searchParams,

--- a/src/hooks/law-viewer/useLawDocument.js
+++ b/src/hooks/law-viewer/useLawDocument.js
@@ -57,7 +57,11 @@ export function useLawDocument({ celex, lang, t, enabled = true }) {
       }
 
       if (requestRef.current !== requestId) return;
-      setData(nextData);
+      // Tag the loaded document with the celex it belongs to so consumers can
+      // tell whether `data` matches the currently requested law.  Without this,
+      // a stale document (from the previously viewed law) can be mistaken for
+      // the newly requested one during the render before the refetch lands.
+      setData({ ...nextData, celex });
 
       if (nextData.recitals?.length > 0) {
         setRecitalTitlesLoading(true);

--- a/src/utils/law-viewer/constants.js
+++ b/src/utils/law-viewer/constants.js
@@ -1,4 +1,5 @@
 export const EMPTY_LAW_DATA = {
+  celex: null,
   title: "",
   articles: [],
   recitals: [],


### PR DESCRIPTION
## What

Fixes a bug where opening a law linked from inside another law overwrote the linked law's name on the landing page with the *source* law's name. For example, clicking the GDPR reference inside the Digital Services Act caused GDPR (Regulation 2016/679) to appear in the library labeled "Digital Services Act".

## Why

The auto-save effect in `LawViewer.jsx` keys on `source.effectiveCelex`. When navigating to a linked law, `effectiveCelex` updates to the new CELEX one render *before* `useLawDocument` refetches and clears `primaryDocument.data`. For that one render the effect saw **new CELEX + previous document's title**, so it persisted the wrong law's name under the new law's CELEX.

## How

- `EMPTY_LAW_DATA` now carries a `celex` field.
- `useLawDocument` tags the loaded document with the CELEX it was fetched for (`setData({ ...nextData, celex })`).
- The auto-save effect bails unless `primaryDocument.data.celex === source.effectiveCelex`, ensuring metadata is only persisted once the loaded document actually matches the current law.

## Testing

- All 196 existing tests pass (`npx vitest run`).
- Lint clean on changed files (one pre-existing unrelated warning remains).

🤖 Generated with [Claude Code](https://claude.com/claude-code)