### PR TITLE
Show loading state in search results while search is in flight

### DIFF
--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -763,6 +763,11 @@ export function SearchBox({
                   <Search size={48} className="opacity-10 mb-4" />
                   <p className="max-w-sm text-center text-sm">{lawSearchError}</p>
                 </div>
+              ) : isBusy ? (
+                <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+                  <Loader2 className="animate-spin text-blue-600 mb-4" size={32} />
+                  <p className="text-sm text-center max-w-sm">{modeSummary}</p>
+                </div>
               ) : results.length > 0 ? (
                 <div className="flex flex-col gap-2 p-2 w-full" ref={resultsRef}>
                   {results.map((item, idx) => (


### PR DESCRIPTION
## What changed

The global search panel body had only three states: error, has-results, and no-results. There was no loading state.

While a search was still running, `results` was empty, so the render fell straight through to the empty-state branch and showed **"No primary EU acts found for …"** — even though the input spinner indicated the search was still ongoing. This produced a confusing flash of a false "no results" message during every search.

This PR adds a loading branch in the results body (`TopBar.jsx`) that renders before the empty-state checks: when `isBusy` is true it shows a spinner plus the already-localized `modeSummary` text (e.g. "Searching primary EU acts…").

## Why this approach

`isBusy` already encapsulates the per-mode loading flags (`isLawSearchLoading` for law mode; the building/loading flags for the other modes), and `modeSummary` is already localized per mode. Reusing them means the fix required no changes to the 24 locale files.

## Result

- While loading: spinner in input **and** "Searching…" in the body.
- A genuine "No primary EU acts found" only appears once the search actually completes with no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)