### PR TITLE
Write full sitemap to sitemap_copy.xml on build

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -48,9 +48,16 @@ function generateSitemap() {
 
   sitemap += '</urlset>';
 
-  const outputPath = path.join(__dirname, '../public/sitemap.xml');
-  fs.writeFileSync(outputPath, sitemap);
-  console.log(`Sitemap generated at ${outputPath}.`);
+  // Write to sitemap.xml and a duplicate sitemap_copy.xml. The copy exists
+  // because Google Search Console applies a long fetch back-off to a sitemap
+  // URL once it has failed, and our sitemap.xml entry got stuck in that state.
+  // The sitemap_copy.xml URL has a healthy fetch history in GSC, so we keep it
+  // populated with identical content as a working fallback.
+  for (const fileName of ['sitemap.xml', 'sitemap_copy.xml']) {
+    const outputPath = path.join(__dirname, '../public', fileName);
+    fs.writeFileSync(outputPath, sitemap);
+    console.log(`Sitemap generated at ${outputPath}.`);
+  }
 }
 
 generateSitemap();


### PR DESCRIPTION
## What

Update `scripts/generate-sitemap.js` to write the generated sitemap to **both** `public/sitemap.xml` and `public/sitemap_copy.xml` on every build (the generator already runs as part of `npm run build`).

## Why

Google Search Console has reported **"Couldn't fetch"** for `https://legalviz.eu/sitemap.xml` for months. Investigation showed the file itself is completely healthy:

- `200 OK`, `content-type: application/xml`, valid UTF-8 (no BOM)
- Well-formed XML (`xmllint` OK), 1,534 URLs, all on the apex domain
- `robots.txt` allows all and references the sitemap
- DNS, TLS, and gzip transfer all fine; served in ~150 ms

The root cause is on Google's side: GSC applies a long fetch back-off to a sitemap **URL** once it has failed (likely a transient failure or a 404 before the file first existed), and rarely retries it afterward. This matched the observation that `sitemap_copy.xml` — a fresh URL with no failure history — fetched successfully, while `sitemap.xml` stayed stuck.

The problem: `sitemap_copy.xml` only contained a stale single-URL stub (just the homepage), so the working URL never advertised the real pages.

## Fix

Populate `sitemap_copy.xml` with the same full content as `sitemap.xml` on build. The URL GSC already fetches successfully now carries all 1,534 URLs, restoring sitemap-based indexing without depending on the stuck `sitemap.xml` entry.

## Notes for reviewer

- This is a pragmatic workaround for a GSC-side stuck state, not a root-cause fix (the back-off lives in Google's systems and isn't reachable from the repo).
- `robots.txt` was intentionally left unchanged; its `Sitemap:` directive does not affect fetchability of a manually-submitted sitemap.
- After deploy, submit/keep `sitemap_copy.xml` in GSC; optionally remove + re-add `sitemap.xml` to try resetting its back-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)