### PR TITLE
Write generated sitemaps into dist/ so they actually deploy

### DIFF
--- a/scripts/generate-sitemap.js
+++ b/scripts/generate-sitemap.js
@@ -53,10 +53,18 @@ function generateSitemap() {
   // URL once it has failed, and our sitemap.xml entry got stuck in that state.
   // The sitemap_copy.xml URL has a healthy fetch history in GSC, so we keep it
   // populated with identical content as a working fallback.
+  //
+  // Write into both public/ (repo source of truth) and dist/ (the build output
+  // that gets deployed). This script runs after `vite build`, which has already
+  // copied public/ into dist/, so writing only to public/ would never reach the
+  // deployed site.
+  const outputDirs = [path.join(__dirname, '../public'), distDir];
   for (const fileName of ['sitemap.xml', 'sitemap_copy.xml']) {
-    const outputPath = path.join(__dirname, '../public', fileName);
-    fs.writeFileSync(outputPath, sitemap);
-    console.log(`Sitemap generated at ${outputPath}.`);
+    for (const dir of outputDirs) {
+      const outputPath = path.join(dir, fileName);
+      fs.writeFileSync(outputPath, sitemap);
+      console.log(`Sitemap generated at ${outputPath}.`);
+    }
   }
 }
 


### PR DESCRIPTION
## What

Make `scripts/generate-sitemap.js` write the generated `sitemap.xml` and `sitemap_copy.xml` into **`dist/`** (the deployed build artifact), in addition to `public/`.

## Why

Follow-up to #49. After that merged, the live `sitemap_copy.xml` was *still* a 1-URL stub. Root cause: the deploy workflow ([pages.yml](.github/workflows/pages.yml)) uploads `./dist`, and the build runs:

```
vite build && copy-404 && generate-prerendered-law-pages && generate-sitemap
```

`vite build` copies `public/` → `dist/` **first**. `generate-sitemap.js` runs **last** and was writing only to `public/` — after vite had already populated `dist/`. So the generated sitemaps never reached the deployed artifact, and CI doesn't commit them back. The live `sitemap.xml` looked correct only because a full copy happened to be committed in `public/`; `sitemap_copy.xml` stayed the committed stub.

## Fix

Write both sitemap files into `dist/` (reusing the same `distDir` the script already reads routes from, which exists at this point because `vite build` created it) as well as `public/` to keep the repo source of truth in sync. The full content now actually deploys.

## Notes for reviewer

- No change to how routes are collected; only the output destinations.
- After deploy, `https://legalviz.eu/sitemap_copy.xml` should serve the full URL set instead of just the homepage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)