### PR TITLE
Single search-loading spinner with pulsing body hint

### DIFF
--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -765,7 +765,7 @@ export function SearchBox({
                 </div>
               ) : isBusy ? (
                 <div className="flex flex-col items-center justify-center py-16 text-gray-400">
-                  <Loader2 className="animate-spin text-blue-600 mb-4" size={32} />
+                  <Search size={48} className="opacity-20 mb-4 animate-pulse" />
                   <p className="text-sm text-center max-w-sm">{modeSummary}</p>
                 </div>
               ) : results.length > 0 ? (


### PR DESCRIPTION
## What changed

After #48 was squash-merged, the search panel ended up showing **two loading spinners at once**: the spinner in the search input field, plus a second `Loader2` spinner in the results body.

This PR removes the duplicate. The body's loading branch now uses the `Search` icon (consistent with the other empty states) with a subtle `animate-pulse`, so the empty results area still reads as *"in progress"* rather than *"no results"* — while the input-field spinner remains the single actual spinner.

## Why this approach

- One animated spinner avoids the visual competition of two spinning circles.
- `animate-pulse` on the body's `Search` icon keeps the large empty area clearly signalling activity (which was the point of the original loading-state fix), without a second spinner.
- Reuses the already-localized `modeSummary` text, so no locale-file changes are needed.

## Result

- While loading: one spinner (input) + a pulsing `Search` icon and "Searching…" text in the body.
- A genuine "No primary EU acts found" still only appears once the search completes with no matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)