### PR TITLE
AI summaries: English-only, with offline API cache

### DIFF
--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -416,15 +416,13 @@ function registerApiRoutes(app, deps) {
   app.get('/api/laws/:celex/summary', rateLimitMiddleware, async (req, res) => {
     try {
       const { celex } = req.params;
-      const rawLang = req.query.lang || 'ENG';
 
       if (!validateCelex(celex)) {
         return res.status(400).json({ error: 'Invalid CELEX format' });
       }
-      const lang = validateLang(rawLang);
-      if (!lang) {
-        return res.status(400).json({ error: `Invalid language code: ${rawLang}` });
-      }
+      // Summaries are generated in English only for now; the lang query
+      // parameter is ignored so other languages cannot trigger generation.
+      const lang = 'ENG';
 
       const parsed = await resolveParsedLaw(celex, lang, { skipFmxProbe: req.query.skipFmxProbe === '1' });
       const result = await ensureLawSummary({
@@ -582,7 +580,7 @@ function registerApiRoutes(app, deps) {
         'GET /api/laws/by-reference?actType=directive&year=2018&number=1972&lang=ENG': 'Resolve an official reference and fetch the matching FMX',
         'GET /api/laws/:celex/case-law': 'List CJEU judgments that interpret this law',
         'GET /api/laws/:celex/recital-titles?lang=ENG': 'Get cached AI-generated short titles for recitals',
-        'GET /api/laws/:celex/summary?lang=ENG': 'Get cached static summary of what this law does',
+        'GET /api/laws/:celex/summary': 'Get cached static summary of what this law does (English only)',
         'GET /api/laws/:celex/articles/:n/case-law-digest?lang=ENG': 'Get cached static digest of CJEU case law interpreting one article',
         'GET /api/search?q=keyword&limit=10': 'Search cached primary-law metadata',
         'GET /api/resolve-reference?actType=directive&year=2018&number=1972&lang=ENG': 'Resolve an FMX-derived legal reference to CELEX via cache-first lookup with Cellar fallback',

--- a/src/components/LawSummary.jsx
+++ b/src/components/LawSummary.jsx
@@ -35,7 +35,8 @@ function CitedText({ block, onArticleClick }) {
 export function LawSummary({ celex, lang = "EN", onArticleClick, className = "mb-6 border-y border-blue-100 py-3 dark:border-blue-950/70" }) {
   const { t } = useI18n();
   const [open, setOpen] = useState(true);
-  const { summary, metadata, loading, loaded, error, retry } = useLawSummary(celex, { lang });
+  const { summary, metadata, loading, loaded, error, retry } = useLawSummary(celex);
+  const showEnglishOnlyNote = (lang || "EN").toUpperCase() !== "EN";
 
   if (!celex) return null;
 
@@ -50,6 +51,11 @@ export function LawSummary({ celex, lang = "EN", onArticleClick, className = "mb
         <span className="flex min-w-0 items-center gap-2">
           <Sparkles size={16} className="shrink-0 text-blue-700 dark:text-blue-300" />
           <span className="font-semibold text-gray-900 dark:text-gray-100">AI Overview</span>
+          {showEnglishOnlyNote ? (
+            <span className="shrink-0 rounded border border-gray-200 px-1.5 py-0.5 text-[11px] font-medium text-gray-500 dark:border-gray-700 dark:text-gray-400">
+              English only
+            </span>
+          ) : null}
         </span>
         <span className="shrink-0 text-gray-500 dark:text-gray-400">
           {open ? <ChevronUp size={16} /> : <ChevronDown size={16} />}

--- a/src/hooks/law-viewer/useLawSummary.js
+++ b/src/hooks/law-viewer/useLawSummary.js
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { fetchLawSummary } from "../../utils/formexApi.js";
 
-export function useLawSummary(celex, { lang = "EN", enabled = true } = {}) {
+export function useLawSummary(celex, { enabled = true } = {}) {
   const [summary, setSummary] = useState(null);
   const [metadata, setMetadata] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -14,14 +14,14 @@ export function useLawSummary(celex, { lang = "EN", enabled = true } = {}) {
     setLoaded(false);
     setLoading(false);
     setError(null);
-  }, [celex, lang]);
+  }, [celex]);
 
   useEffect(() => {
     if (!celex || !enabled || loaded) return;
     let cancelled = false;
 
     setLoading(true);
-    fetchLawSummary(celex, lang)
+    fetchLawSummary(celex)
       .then((payload) => {
         if (cancelled) return;
         setSummary(payload.summary || null);
@@ -46,7 +46,7 @@ export function useLawSummary(celex, { lang = "EN", enabled = true } = {}) {
     return () => {
       cancelled = true;
     };
-  }, [celex, lang, enabled, loaded]);
+  }, [celex, enabled, loaded]);
 
   const retry = useCallback(() => {
     setError(null);

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -20,6 +20,18 @@ export const API_BASE = (() => {
   return "https://api.legalviz.eu";
 })();
 
+/**
+ * fetch() wrapper for backend calls. Tags every request with the "web" channel
+ * so server-side analytics can tell frontend traffic apart from direct REST API
+ * and MCP callers. Use this for all API_BASE requests.
+ */
+export function apiFetch(url, options = {}) {
+  return fetch(url, {
+    ...options,
+    headers: { ...(options.headers || {}), "x-legalviz-client": "web" },
+  });
+}
+
 // Cache version — bump to invalidate all cached entries
 const CACHE_VERSION = 2;
 const RECITAL_TITLE_CACHE_VERSION = 2;
@@ -115,6 +127,77 @@ function createCombinedLawEnvelope(payload) {
     format: "combined-v1",
     payload,
   };
+}
+
+const API_JSON_CACHE_VERSION = 1;
+// After this age, cache-first entries are revalidated against the network
+// (still served from cache if the network is unavailable).
+const API_JSON_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+
+function isApiJsonEnvelope(value) {
+  return !!value
+    && typeof value === "object"
+    && value.format === "api-json-v1"
+    && value.version === API_JSON_CACHE_VERSION
+    && typeof value.payload === "object"
+    && value.payload != null;
+}
+
+function createApiJsonEnvelope(payload) {
+  return {
+    format: "api-json-v1",
+    version: API_JSON_CACHE_VERSION,
+    cachedAt: Date.now(),
+    payload,
+  };
+}
+
+function shouldFallBackToCache(error) {
+  // Offline / network failures surface as TypeError from fetch; server-side
+  // trouble (5xx, rate limiting) is also worth papering over with a cached
+  // copy. Deliberate 4xx answers (e.g. 404) are not.
+  if (!(error instanceof FormexApiError)) return true;
+  return error.status >= 500 || error.status === 429;
+}
+
+/**
+ * Fetch a JSON API response with IndexedDB caching so previously opened
+ * laws stay readable offline.
+ *
+ * `cacheFirst: true` serves a cached copy immediately (revalidating only
+ * once it is older than `maxAgeMs`); otherwise the network is tried first
+ * and the cache is used as an offline fallback.
+ */
+async function fetchJsonWithCache({
+  cacheKey,
+  url,
+  errorLabel,
+  cacheFirst = false,
+  maxAgeMs = API_JSON_CACHE_MAX_AGE_MS,
+}) {
+  const cached = await cacheGet(cacheKey);
+  const envelope = isApiJsonEnvelope(cached) ? cached : null;
+
+  if (cacheFirst && envelope && Date.now() - envelope.cachedAt < maxAgeMs) {
+    console.log(`[FormexAPI] Cache hit: ${cacheKey}`);
+    return { ...envelope.payload, cached: true, localCached: true };
+  }
+
+  try {
+    const res = await apiFetch(url);
+    if (!res.ok) {
+      await readApiError(res, `${errorLabel} (${res.status})`);
+    }
+    const payload = await res.json();
+    await cacheSet(cacheKey, createApiJsonEnvelope(payload));
+    return payload;
+  } catch (error) {
+    if (envelope && shouldFallBackToCache(error)) {
+      console.log(`[FormexAPI] Serving stale cache after fetch failure: ${cacheKey}`);
+      return { ...envelope.payload, cached: true, localCached: true };
+    }
+    throw error;
+  }
 }
 
 function isRecitalTitleEnvelope(value) {
@@ -487,7 +570,7 @@ export async function fetchFormex(celex, lang = "EN") {
     // 2. Fetch from API
     console.log(`[FormexAPI] Fetching: ${celex} (${apiLang})`);
     const url = `${API_BASE}/api/laws/${encodeURIComponent(celex)}?lang=${apiLang}`;
-    const res = await fetch(url);
+    const res = await apiFetch(url);
 
     if (!res.ok) {
       try {
@@ -550,7 +633,7 @@ export async function getCachedLawPayload(celex, lang = "EN") {
 export async function resolveOfficialReference(reference, lang = "EN") {
   const query = buildReferenceQuery(reference, lang);
   const url = `${API_BASE}/api/resolve-reference?${query}`;
-  const res = await fetch(url);
+  const res = await apiFetch(url);
 
   if (!res.ok) {
     await readApiError(res, `Reference resolution failed (${res.status})`);
@@ -566,7 +649,7 @@ export async function resolveEurlexUrl(sourceUrl, lang = "EN") {
     lang: apiLang,
   });
   const url = `${API_BASE}/api/resolve-url?${params.toString()}`;
-  const res = await fetch(url);
+  const res = await apiFetch(url);
 
   if (!res.ok) {
     await readApiError(res, `EUR-Lex URL resolution failed (${res.status})`);
@@ -576,36 +659,27 @@ export async function resolveEurlexUrl(sourceUrl, lang = "EN") {
 }
 
 export async function fetchAmendments(celex) {
-  const url = `${API_BASE}/api/laws/${encodeURIComponent(celex)}/amendments`;
-  const res = await fetch(url);
-
-  if (!res.ok) {
-    await readApiError(res, `Amendment history fetch failed (${res.status})`);
-  }
-
-  return res.json();
+  return getInFlightRequest(`amendments:${celex}`, () => fetchJsonWithCache({
+    cacheKey: `${celex}_amendments`,
+    url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/amendments`,
+    errorLabel: "Amendment history fetch failed",
+  }));
 }
 
 export async function fetchLawMetadata(celex) {
-  const url = `${API_BASE}/api/laws/${encodeURIComponent(celex)}/metadata`;
-  const res = await fetch(url);
-
-  if (!res.ok) {
-    await readApiError(res, `Metadata fetch failed (${res.status})`);
-  }
-
-  return res.json();
+  return getInFlightRequest(`metadata:${celex}`, () => fetchJsonWithCache({
+    cacheKey: `${celex}_metadata`,
+    url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/metadata`,
+    errorLabel: "Metadata fetch failed",
+  }));
 }
 
 export async function fetchCaseLaw(celex) {
-  const url = `${API_BASE}/api/laws/${encodeURIComponent(celex)}/case-law`;
-  const res = await fetch(url);
-
-  if (!res.ok) {
-    await readApiError(res, `Case law fetch failed (${res.status})`);
-  }
-
-  return res.json();
+  return getInFlightRequest(`case-law:${celex}`, () => fetchJsonWithCache({
+    cacheKey: `${celex}_case_law`,
+    url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/case-law`,
+    errorLabel: "Case law fetch failed",
+  }));
 }
 
 export async function fetchRecitalTitles(celex, lang = "EN") {
@@ -623,7 +697,7 @@ export async function fetchRecitalTitles(celex, lang = "EN") {
     }
 
     const url = `${API_BASE}/api/laws/${encodeURIComponent(celex)}/recital-titles?lang=${apiLang}`;
-    const res = await fetch(url);
+    const res = await apiFetch(url);
 
     if (!res.ok) {
       await readApiError(res, `Recital title fetch failed (${res.status})`);
@@ -635,45 +709,35 @@ export async function fetchRecitalTitles(celex, lang = "EN") {
   });
 }
 
-export async function fetchLawSummary(celex, lang = "EN") {
-  const apiLang = toApiLang(lang);
-  const key = `${celex}_${apiLang}`;
-  return getInFlightRequest(`law-summary:${key}`, async () => {
-    const url = `${API_BASE}/api/laws/${encodeURIComponent(celex)}/summary?lang=${apiLang}`;
-    const res = await fetch(url);
-
-    if (!res.ok) {
-      await readApiError(res, `Law summary fetch failed (${res.status})`);
-    }
-
-    return res.json();
-  });
+// Law summaries are generated in English only for now, regardless of the
+// reading language.
+export async function fetchLawSummary(celex) {
+  const key = `${celex}_ENG_summary`;
+  return getInFlightRequest(`law-summary:${key}`, () => fetchJsonWithCache({
+    cacheKey: key,
+    url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/summary?lang=ENG`,
+    errorLabel: "Law summary fetch failed",
+    cacheFirst: true,
+  }));
 }
 
 export async function fetchArticleCaseLawDigest(celex, articleNumber, lang = "EN") {
   const apiLang = toApiLang(lang);
-  const key = `${celex}_${articleNumber}_${apiLang}`;
-  return getInFlightRequest(`article-case-law-digest:${key}`, async () => {
-    const url = `${API_BASE}/api/laws/${encodeURIComponent(celex)}/articles/${encodeURIComponent(articleNumber)}/case-law-digest?lang=${apiLang}`;
-    const res = await fetch(url);
-
-    if (!res.ok) {
-      await readApiError(res, `Article case-law digest fetch failed (${res.status})`);
-    }
-
-    return res.json();
-  });
+  const key = `${celex}_${apiLang}_digest_${articleNumber}`;
+  return getInFlightRequest(`article-case-law-digest:${key}`, () => fetchJsonWithCache({
+    cacheKey: key,
+    url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/articles/${encodeURIComponent(articleNumber)}/case-law-digest?lang=${apiLang}`,
+    errorLabel: "Article case-law digest fetch failed",
+    cacheFirst: true,
+  }));
 }
 
 export async function fetchImplementingActs(celex) {
-  const url = `${API_BASE}/api/laws/${encodeURIComponent(celex)}/implementing`;
-  const res = await fetch(url);
-
-  if (!res.ok) {
-    await readApiError(res, `Implementing acts fetch failed (${res.status})`);
-  }
-
-  return res.json();
+  return getInFlightRequest(`implementing:${celex}`, () => fetchJsonWithCache({
+    cacheKey: `${celex}_implementing`,
+    url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/implementing`,
+    errorLabel: "Implementing acts fetch failed",
+  }));
 }
 
 export async function searchLaws(query, { limit = 10, noRewrite = false, signal } = {}) {
@@ -687,7 +751,7 @@ export async function searchLaws(query, { limit = 10, noRewrite = false, signal 
   }
 
   const url = `${API_BASE}/api/search?${params.toString()}`;
-  const res = await fetch(url, { signal });
+  const res = await apiFetch(url, { signal });
 
   if (!res.ok) {
     await readApiError(res, `Law search failed (${res.status})`);
@@ -699,7 +763,7 @@ export async function searchLaws(query, { limit = 10, noRewrite = false, signal 
 export async function fetchFormexByReference(reference, lang = "EN") {
   const query = buildReferenceQuery(reference, lang);
   const url = `${API_BASE}/api/laws/by-reference?${query}`;
-  const res = await fetch(url);
+  const res = await apiFetch(url);
 
   if (!res.ok) {
     await readApiError(res, `Formex reference fetch failed (${res.status})`);
@@ -723,7 +787,7 @@ export async function fetchParsedLaw(celex, lang = "EN") {
       params.set("skipFmxProbe", "1");
     }
     const url = `${API_BASE}/api/laws/${encodeURIComponent(celex)}/parsed?${params.toString()}`;
-    const res = await fetch(url);
+    const res = await apiFetch(url);
 
     if (!res.ok) {
       await readApiError(res, `Parsed law fetch failed (${res.status})`);


### PR DESCRIPTION
## What & why

**English-only AI summaries** — `/api/laws/:celex/summary` now always generates/serves in English; the `lang` query param is ignored. Previously reading a law in any of the ~24 supported languages could each trigger their own AI generation and cache entry; capping it to English keeps generation to one artifact per law. The UI shows an "English only" badge when reading in another language so it's not silently mismatched.

**Offline API cache** — new `fetchJsonWithCache` helper (IndexedDB-backed) for the JSON API endpoints: amendments, metadata, case-law, summary, article case-law digest, implementing acts.
- `summary` and `article-case-law-digest` are served **cache-first** (revalidated after 7 days) — these are the expensive AI-generated, rarely-changing pieces.
- The rest are **network-first**, falling back to a cached copy only on offline / 5xx / 429 — a genuine 404 is never masked.

Net effect: previously opened laws stay readable offline, and the app is more resilient to backend rate-limiting or transient errors.

## Testing
- 207 frontend tests pass, 97 backend tests pass, eslint clean.