### PR TITLE
Feed the AI law summary fuller input and adapt it to act type

### DIFF
--- a/backend/shared/law-summary-service.js
+++ b/backend/shared/law-summary-service.js
@@ -4,24 +4,38 @@ const crypto = require('crypto');
 
 const { chatComplete } = require('./openrouter-chat');
 const { ACT_CELEX_MAP } = require('./law-queries');
+const { inferTypeFromCelex } = require('../search/search-ranking');
 
 const CACHE_FILE = 'law-summary-cache-v1.json';
 const CACHE_VERSION = 1;
-const SCHEMA_VERSION = 1;
-const PROMPT_VERSION = 1;
-const MAX_ARTICLE_TEXT_CHARS = 1200;
+const SCHEMA_VERSION = 2;
+const PROMPT_VERSION = 2;
+const MAX_ARTICLE_TEXT_CHARS = 6000;
+const MAX_RECITAL_COUNT = 60;
 const MAX_RECITAL_TEXT_CHARS = 700;
 const MAX_RELATED_CANDIDATES = 12;
+const MAX_ARTICLE_TEXT_BUDGET_CHARS = 500000;
+
+const ACT_TYPE_GUIDANCE = {
+  regulation: 'This is a regulation: frame key points as directly-applicable obligations, rights, and prohibitions binding on the addressees themselves.',
+  directive: 'This is a directive: frame key points as duties on Member States, i.e. what must be transposed into national law and by when if a deadline is stated, not direct obligations on private parties.',
+  decision: 'This is a decision or establishing act: frame key points around the addressees, the body or authority it creates, and that body\'s powers and mandate.',
+  unknown: 'The act type could not be determined: frame key points generically as obligations, rights, powers, or prohibitions as best supported by the text.',
+};
 
 const inFlight = new Map();
 
-const SYSTEM_PROMPT = `You write concise, grounded summaries of EU legal acts for a legal research reader.
+function buildSystemPrompt(actType) {
+  const guidance = ACT_TYPE_GUIDANCE[actType] || ACT_TYPE_GUIDANCE.unknown;
+  return `You write concise, grounded summaries of EU legal acts for a legal research reader.
+
+${guidance}
 
 Return ONLY a JSON object with this exact shape:
 {
   "purpose": { "text": "1-2 sentences", "citations": ["1", "2"] },
   "scope": { "text": "who or what the law applies to", "citations": ["2", "3"] },
-  "keyObligations": [
+  "keyPoints": [
     { "text": "one concrete obligation, right, power, or prohibition", "citations": ["5"] }
   ],
   "structure": "short narrative of how the chapters/sections are organised",
@@ -32,10 +46,11 @@ Return ONLY a JSON object with this exact shape:
 
 Rules:
 - Use only the provided law input and related-instrument candidates.
-- Every scope and key-obligation item must cite existing article numbers from the provided article list.
-- Prefer 3-6 key obligations.
+- Every scope and key-point item must cite existing article numbers from the provided article list.
+- Prefer 3-6 key points.
 - Keep the whole output under about 400 words.
 - Do not invent article numbers, CELEX identifiers, instruments, obligations, or legal effects.`;
+}
 
 function stripTags(value) {
   return String(value || '')
@@ -52,7 +67,19 @@ function stripTags(value) {
 function clip(value, maxChars) {
   const text = stripTags(value);
   if (text.length <= maxChars) return text;
-  return `${text.slice(0, maxChars).trim()}...`;
+  const window = text.slice(0, maxChars);
+  const boundaryPattern = /[.;]\s|\n/g;
+  let lastBoundaryEnd = -1;
+  let match;
+  while ((match = boundaryPattern.exec(window))) {
+    lastBoundaryEnd = match.index + match[0].length;
+  }
+  if (lastBoundaryEnd > 0) {
+    return `${window.slice(0, lastBoundaryEnd).trim()}…`;
+  }
+  const lastSpace = window.lastIndexOf(' ');
+  const cut = lastSpace > 0 ? window.slice(0, lastSpace) : window;
+  return `${cut.trim()}…`;
 }
 
 function cacheKey(celex, lang) {
@@ -148,14 +175,22 @@ function buildSkeleton(articles) {
 }
 
 function buildLawSummaryInput(parsedLaw, { actCelexMap = ACT_CELEX_MAP } = {}) {
+  let articleTextBudgetUsed = 0;
   const articles = (parsedLaw.articles || [])
-    .map((article) => ({
-      number: String(article.article_number || '').trim(),
-      title: article.article_title || null,
-      chapter: article.division?.chapter?.title || null,
-      section: article.division?.section?.title || null,
-      text: clip(article.article_text || article.article_html || '', MAX_ARTICLE_TEXT_CHARS),
-    }))
+    .map((article) => {
+      let text = '';
+      if (articleTextBudgetUsed < MAX_ARTICLE_TEXT_BUDGET_CHARS) {
+        text = clip(article.article_text || article.article_html || '', MAX_ARTICLE_TEXT_CHARS);
+        articleTextBudgetUsed += text.length;
+      }
+      return {
+        number: String(article.article_number || '').trim(),
+        title: article.article_title || null,
+        chapter: article.division?.chapter?.title || null,
+        section: article.division?.section?.title || null,
+        text,
+      };
+    })
     .filter((article) => article.number && article.text);
 
   return {
@@ -164,6 +199,7 @@ function buildLawSummaryInput(parsedLaw, { actCelexMap = ACT_CELEX_MAP } = {}) {
     title: parsedLaw.title || parsedLaw.doc_title || parsedLaw.name || null,
     eli: parsedLaw.eli || null,
     source: parsedLaw.source || null,
+    actType: inferTypeFromCelex(parsedLaw.celex),
     skeleton: buildSkeleton(parsedLaw.articles || []),
     definitions: (parsedLaw.definitions || [])
       .map((definition) => ({
@@ -171,7 +207,7 @@ function buildLawSummaryInput(parsedLaw, { actCelexMap = ACT_CELEX_MAP } = {}) {
         sourceArticle: definition.sourceArticle || definition.source_article || null,
       }))
       .filter((definition) => definition.term),
-    recitals: (parsedLaw.recitals || []).slice(0, 8).map((recital) => ({
+    recitals: (parsedLaw.recitals || []).slice(0, MAX_RECITAL_COUNT).map((recital) => ({
       number: String(recital.recital_number || '').trim(),
       text: clip(recital.recital_text || recital.recital_html || '', MAX_RECITAL_TEXT_CHARS),
     })).filter((recital) => recital.number && recital.text),
@@ -242,10 +278,13 @@ function normalizeRelatedInstruments(value, candidates) {
 
 function parseLawSummaryJson(text, input) {
   const parsed = extractJsonObject(text);
-  const validArticles = new Set((input.articles || []).map((article) => String(article.number)));
+  const validArticles = new Set([
+    ...(input.articles || []).map((article) => String(article.number)),
+    ...(input.skeleton || []).map((article) => String(article.number)),
+  ]);
   const purpose = normalizeCitedBlock(parsed.purpose, validArticles);
   const scope = normalizeCitedBlock(parsed.scope, validArticles, { requireCitation: true });
-  const keyObligations = (Array.isArray(parsed.keyObligations) ? parsed.keyObligations : [])
+  const keyPoints = (Array.isArray(parsed.keyPoints) ? parsed.keyPoints : [])
     .map((item) => normalizeCitedBlock(item, validArticles, { requireCitation: true }))
     .filter(Boolean)
     .slice(0, 8);
@@ -254,13 +293,13 @@ function parseLawSummaryJson(text, input) {
 
   if (!purpose?.text) throw new Error('Summary is missing purpose');
   if (!scope?.text) throw new Error('Summary is missing cited scope');
-  if (keyObligations.length === 0) throw new Error('Summary is missing cited key obligations');
+  if (keyPoints.length === 0) throw new Error('Summary is missing cited key points');
   if (!structure) throw new Error('Summary is missing structure');
 
   return {
     purpose,
     scope,
-    keyObligations,
+    keyPoints,
     structure,
     relatedInstruments,
   };
@@ -274,6 +313,7 @@ function buildUserPrompt(input) {
       title: input.title,
       eli: input.eli,
       source: input.source,
+      actType: input.actType,
     },
     articleIndex: input.skeleton,
     definitions: input.definitions,
@@ -292,11 +332,11 @@ async function generateLawSummary(input, {
     model,
     apiKey,
     temperature: 0.1,
-    maxTokens: 2400,
+    maxTokens: 3000,
     responseFormat: 'json_object',
     reasoning: { max_tokens: 256, exclude: true },
     messages: [
-      { role: 'system', content: SYSTEM_PROMPT },
+      { role: 'system', content: buildSystemPrompt(input.actType) },
       { role: 'user', content: buildUserPrompt(input) },
     ],
   });

--- a/backend/shared/law-summary-service.test.js
+++ b/backend/shared/law-summary-service.test.js
@@ -43,9 +43,9 @@ test('parseLawSummaryJson keeps only valid article citations and related instrum
   const summary = parseLawSummaryJson(JSON.stringify({
     purpose: { text: 'It protects personal data.', citations: ['1', '999'] },
     scope: { text: 'It applies to personal data processing.', citations: ['1'] },
-    keyObligations: [
+    keyPoints: [
       { text: 'Data must be processed lawfully.', citations: ['5'] },
-      { text: 'Invalid obligation is dropped.', citations: ['999'] },
+      { text: 'Invalid point is dropped.', citations: ['999'] },
     ],
     structure: 'It starts with general provisions and then sets principles.',
     relatedInstruments: [
@@ -55,7 +55,7 @@ test('parseLawSummaryJson keeps only valid article citations and related instrum
   }), input);
 
   assert.deepEqual(summary.purpose.citations, ['1']);
-  assert.deepEqual(summary.keyObligations.map((item) => item.citations), [['5']]);
+  assert.deepEqual(summary.keyPoints.map((item) => item.citations), [['5']]);
   assert.equal(summary.relatedInstruments.length, 1);
   assert.equal(summary.relatedInstruments[0].celex, '31995L0046');
 });
@@ -71,7 +71,7 @@ test('ensureLawSummary caches validated summaries', async () => {
       text: JSON.stringify({
         purpose: { text: 'It protects personal data.', citations: ['1'] },
         scope: { text: 'It applies to personal data processing.', citations: ['1'] },
-        keyObligations: [{ text: 'Data must be processed lawfully.', citations: ['5'] }],
+        keyPoints: [{ text: 'Data must be processed lawfully.', citations: ['5'] }],
         structure: 'It starts with general provisions and then sets principles.',
         relatedInstruments: [{ label: 'Directive 95/46/EC', celex: '31995L0046', relationship: 'Predecessor framework.' }],
       }),
@@ -100,4 +100,65 @@ test('ensureLawSummary caches validated summaries', async () => {
   assert.equal(first.cached, false);
   assert.equal(second.cached, true);
   assert.equal(calls, 1);
+});
+
+function repeatedSentences(targetChars) {
+  let text = '';
+  let n = 1;
+  while (text.length < targetChars) {
+    text += `Sentence number ${n} provides that data shall be processed lawfully and fairly. `;
+    n += 1;
+  }
+  return text;
+}
+
+test('article text is clipped at a sentence boundary, not mid-word', () => {
+  const parsedLaw = sampleParsedLaw();
+  parsedLaw.articles[0].article_html = `<p>${repeatedSentences(8000)}</p>`;
+
+  const input = buildLawSummaryInput(parsedLaw);
+  const clipped = input.articles.find((article) => article.number === '1').text;
+
+  assert.ok(clipped.length <= 6001, `expected clipped text near the 6000-char cap, got ${clipped.length}`);
+  assert.ok(clipped.endsWith('.…'), `expected a full sentence before the ellipsis, got: ...${clipped.slice(-40)}`);
+});
+
+test('overall article budget drops bodies but keeps every article number citable', () => {
+  const parsedLaw = sampleParsedLaw();
+  const totalArticles = 90;
+  parsedLaw.articles = Array.from({ length: totalArticles }, (_, i) => ({
+    article_number: String(i + 1),
+    article_title: `Article ${i + 1}`,
+    article_html: `<p>${repeatedSentences(6500)}</p>`,
+    division: { chapter: { title: 'General provisions' } },
+  }));
+
+  const input = buildLawSummaryInput(parsedLaw);
+
+  assert.equal(input.skeleton.length, totalArticles, 'skeleton must retain every article number');
+  assert.ok(input.articles.length < totalArticles, 'article bodies should be dropped once the budget is exceeded');
+
+  const keptNumbers = new Set(input.articles.map((article) => article.number));
+  const droppedArticle = input.skeleton.find((article) => !keptNumbers.has(article.number));
+  assert.ok(droppedArticle, 'expected at least one article whose body was trimmed away');
+
+  const summary = parseLawSummaryJson(JSON.stringify({
+    purpose: { text: 'It protects personal data.', citations: [droppedArticle.number] },
+    scope: { text: 'It applies broadly.', citations: [droppedArticle.number] },
+    keyPoints: [{ text: 'A rule still cites a body-trimmed article.', citations: [droppedArticle.number] }],
+    structure: 'It is organised into many articles.',
+    relatedInstruments: [],
+  }), input);
+
+  assert.deepEqual(summary.scope.citations, [droppedArticle.number]);
+  assert.deepEqual(summary.keyPoints[0].citations, [droppedArticle.number]);
+});
+
+test('actType is derived from the CELEX descriptor letter', () => {
+  const base = sampleParsedLaw();
+
+  assert.equal(buildLawSummaryInput({ ...base, celex: '32016R0679' }).actType, 'regulation');
+  assert.equal(buildLawSummaryInput({ ...base, celex: '32019L0790' }).actType, 'directive');
+  assert.equal(buildLawSummaryInput({ ...base, celex: '32021D2054' }).actType, 'decision');
+  assert.equal(buildLawSummaryInput({ ...base, celex: null }).actType, 'unknown');
 });

--- a/scripts/generate-prerendered-law-pages.js
+++ b/scripts/generate-prerendered-law-pages.js
@@ -138,7 +138,7 @@ function buildLawSummarySection(law, summaryPayload) {
 
   const purposeHtml = citedText(law, summary.purpose);
   const scopeHtml = citedText(law, summary.scope);
-  const keyObligationsHtml = (summary.keyObligations || [])
+  const keyPointsHtml = (summary.keyPoints || [])
     .map((item) => `<li>${citedText(law, item)}</li>`)
     .join("");
   const relatedInstrumentsHtml = (summary.relatedInstruments || [])
@@ -154,7 +154,7 @@ function buildLawSummarySection(law, summaryPayload) {
       <h2>Overview</h2>
       ${purposeHtml ? `<p>${purposeHtml}</p>` : ""}
       ${scopeHtml ? `<p>${scopeHtml}</p>` : ""}
-      ${keyObligationsHtml ? `<h3>Key points</h3><ul>${keyObligationsHtml}</ul>` : ""}
+      ${keyPointsHtml ? `<h3>Key points</h3><ul>${keyPointsHtml}</ul>` : ""}
       ${summary.structure ? `<h3>Structure</h3><p>${escapeHtml(summary.structure)}</p>` : ""}
       ${relatedInstrumentsHtml ? `<h3>Related instruments</h3><ul>${relatedInstrumentsHtml}</ul>` : ""}
     </section>

--- a/src/components/LawSummary.jsx
+++ b/src/components/LawSummary.jsx
@@ -87,11 +87,11 @@ export function LawSummary({ celex, lang = "EN", onArticleClick, className = "mb
                 <p><CitedText block={summary.scope} onArticleClick={onArticleClick} /></p>
               </div>
 
-              {summary.keyObligations?.length ? (
+              {summary.keyPoints?.length ? (
                 <div>
                   <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">Key Points</div>
                   <ul className="space-y-1.5">
-                    {summary.keyObligations.map((item, index) => (
+                    {summary.keyPoints.map((item, index) => (
                       <li key={`${item.text}-${index}`} className="flex gap-2">
                         <span className="mt-2 h-1.5 w-1.5 shrink-0 rounded-full bg-blue-500 dark:bg-blue-400" />
                         <span><CitedText block={item} onArticleClick={onArticleClick} /></span>


### PR DESCRIPTION
## Summary
- Article/recital truncation was starving the summary generator (`gemini-2.5-pro`, ~1M-token context) of context: articles were hard-clipped to 1200 chars mid-word, and only the first 8 recitals were included. Raise the per-article budget to 6000 chars with sentence-aware trimming, and include up to 60 recitals, so Purpose/Scope draw on the legislative recitals as intended.
- Add a single safety cap on total article-body text for pathologically large acts; citations to budget-trimmed articles still validate against the article skeleton.
- The output schema was GDPR-shaped (`keyObligations`), reading awkwardly for directives (Member-State transposition duties) and decisions (addressees/powers). Derive `actType` from the CELEX descriptor via the existing `inferTypeFromCelex` helper, inject a type-specific prompt line, and rename `keyObligations` → `keyPoints` to match what the UI already labels the section.
- Bump `SCHEMA_VERSION`/`PROMPT_VERSION` so cached summaries regenerate under the new shape.

## Test plan
- [x] `node --test backend/shared/law-summary-service.test.js` — 5/5 passing (new cases: sentence-boundary clipping, budget-cap degradation keeping citations valid, `actType` derivation for R/L/D/unknown)
- [x] `npm --prefix backend test` — full backend suite green
- [ ] Regenerate and eyeball a few representative acts in the running app (GDPR, AI Act, a directive, a decision) — needs a live model call, not run in this session

🤖 Generated with [Claude Code](https://claude.com/claude-code)