### PR TITLE
fix: resolve react-hooks/exhaustive-deps warning in LawViewer

### DIFF
--- a/src/components/LawViewer.jsx
+++ b/src/components/LawViewer.jsx
@@ -170,14 +170,11 @@ export function LawViewer() {
     t,
   });
 
+  const { secondaryLang, setSecondaryLanguage } = preferences;
   useEffect(() => {
-    if (!derived.isLegacyHtmlFallback || !preferences.secondaryLang) return;
-    preferences.setSecondaryLanguage(null);
-  }, [
-    derived.isLegacyHtmlFallback,
-    preferences.secondaryLang,
-    preferences.setSecondaryLanguage,
-  ]);
+    if (!derived.isLegacyHtmlFallback || !secondaryLang) return;
+    setSecondaryLanguage(null);
+  }, [derived.isLegacyHtmlFallback, secondaryLang, setSecondaryLanguage]);
 
   useEffect(() => {
     if (!source.effectiveCelex || !derived.hasLoadedContent) return;


### PR DESCRIPTION
## Summary

`npm run lint` reported one warning:

```
src/components/LawViewer.jsx
  176:6  warning  React Hook useEffect has a missing dependency: 'preferences'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
```

This is the effect that clears the secondary (side-by-side) language when the viewer falls back to the legacy EUR-Lex HTML source (which only ever has an English version, so a secondary-language comparison no longer makes sense):

```jsx
useEffect(() => {
  if (!derived.isLegacyHtmlFallback || !preferences.secondaryLang) return;
  preferences.setSecondaryLanguage(null);
}, [
  derived.isLegacyHtmlFallback,
  preferences.secondaryLang,
  preferences.setSecondaryLanguage,
]);
```

Even though the two specific `preferences.*` members used in the effect body were already listed, `eslint-plugin-react-hooks` v5 (`recommended-latest`) still asked for `preferences` itself. That's because `useLawViewerPreferences` (`src/hooks/law-viewer/useLawViewerPreferences.js`) returns a plain object literal — a fresh, referentially-unstable object every render, not memoized.

**Why I didn't just take eslint's autofix.** The suggested fix was to add `preferences` (the whole object) to the array. I verified that clears the warning, but it's the wrong fix: since `preferences` is a new object identity on every render, adding it to the deps array is equivalent to having no dependency array at all — the effect would re-run on every re-render of `LawViewer` (not just when `secondaryLang`/`isLegacyHtmlFallback` actually change), including re-renders triggered by completely unrelated state.

**The fix I applied instead** — destructure the two stable values out of `preferences` before the effect, and depend on those:

```jsx
const { secondaryLang, setSecondaryLanguage } = preferences;
useEffect(() => {
  if (!derived.isLegacyHtmlFallback || !secondaryLang) return;
  setSecondaryLanguage(null);
}, [derived.isLegacyHtmlFallback, secondaryLang, setSecondaryLanguage]);
```

`secondaryLang` is a primitive string/null and `setSecondaryLanguage` is `useCallback`-memoized inside `useLawViewerPreferences`, so both are referentially stable across renders unless their own underlying deps change — identical to what the effect depended on before my change, just referenced via local bindings instead of through the unstable `preferences` object. This satisfies eslint (it no longer needs the whole object because the values are no longer read via member access on an unmemoized object) while preserving the exact same re-run semantics as before the fix: the effect still only fires when `derived.isLegacyHtmlFallback`, `secondaryLang`, or `setSecondaryLanguage`'s identity actually changes.

## Test plan

- [x] `npm run lint` → 0 warnings, 0 errors
- [x] `npm run test:web` → 207 tests passed (17 files)
- [x] Reasoned through re-run semantics: no behavior change (see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)