### PR TITLE
chore: add ESLint coverage for backend/**

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,6 +17,7 @@ jobs:
         with: { node-version: '24' }
       - run: npm ci
       - run: npm ci --prefix backend
+      - run: npm run lint
       - run: npm test
       - run: npm run build
       - uses: actions/upload-pages-artifact@v4

--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -68,9 +68,7 @@ function registerApiRoutes(app, deps) {
   const {
     analytics,
     CELEX_NAMES,
-    EURLEX_BASE,
     FMX_DIR,
-    RATE_LIMIT_MAX,
     RESOLUTION_CACHE_MS,
     cacheGet,
     cacheSet,

--- a/backend/shared/law-queries.js
+++ b/backend/shared/law-queries.js
@@ -8,7 +8,7 @@
 const fs = require('fs');
 const path = require('path');
 const { JSDOM } = require('jsdom');
-const { getSharedPlaywrightPage, loadPlaywrightModule, closeSharedPlaywrightBrowser } = require('./eurlex-html-parser');
+const { getSharedPlaywrightPage, loadPlaywrightModule } = require('./eurlex-html-parser');
 
 const EURLEX_COOKIE_MAX_AGE_MS = parseInt(process.env.EURLEX_COOKIE_MAX_AGE_MS) || 12 * 60 * 60 * 1000; // 12h
 const PARTIAL_RETRY_COOLDOWN_MS = 6 * 60 * 60 * 1000; // 6h

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,27 @@ import reactHooks from 'eslint-plugin-react-hooks'
 import reactRefresh from 'eslint-plugin-react-refresh'
 import { defineConfig, globalIgnores } from 'eslint/config'
 
+// Correctness-focused ruleset for backend/**: catch bugs (undefined identifiers,
+// dead code, unused vars) without imposing stylistic rules (quotes, semicolons,
+// indentation). `no-undef` stays an error unconditionally — it's the rule that
+// would have caught the ReferenceError this config was added to prevent.
+const backendRules = {
+  'no-undef': 'error',
+  'no-unused-vars': [
+    'warn',
+    {
+      args: 'none',
+      caughtErrors: 'none',
+      // Allow `const { omitMe, ...rest } = obj` (a common way to drop a key).
+      ignoreRestSiblings: true,
+    },
+  ],
+  // Empty `catch {}` blocks are a deliberate "ignore this failure" idiom used
+  // throughout the backend (e.g. best-effort cleanup); don't flag those, but
+  // still flag other empty blocks (likely dead/forgotten code).
+  'no-empty': ['error', { allowEmptyCatch: true }],
+}
+
 export default defineConfig([
   globalIgnores([
     'dist/**',
@@ -12,6 +33,8 @@ export default defineConfig([
     'extension/**',
     '**/*.html',
     '**/*_files/**',
+    'backend/search/data/**',
+    'backend/node_modules/**',
   ]),
   {
     files: ['src/**/*.{js,jsx}'],
@@ -41,5 +64,43 @@ export default defineConfig([
       sourceType: 'module',
       globals: globals.node,
     },
+  },
+  {
+    // Backend (Express API + `eurlex` CLI) is CommonJS unless it's a .mjs file (see below).
+    files: ['backend/**/*.js'],
+    ignores: ['backend/shared/formex-parser/fmxParser.test.js'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'commonjs',
+      globals: globals.node,
+    },
+    rules: backendRules,
+  },
+  {
+    // This one backend test file is run by vitest (see vite.config.js `test.include`),
+    // not `node --test`, and uses ESM import syntax like the frontend tests.
+    files: ['backend/shared/formex-parser/fmxParser.test.js'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: { ...globals.node, ...globals.browser },
+    },
+    rules: backendRules,
+  },
+  {
+    // backend/shared/formex-parser/*.mjs is ESM and also used directly by the frontend.
+    // It runs in the browser DOM there, and against DOM globals shimmed onto `global`
+    // by backend/shared/fmx-parser-node.js (via jsdom) when run under Node — so it
+    // needs both Node and browser globals (DOMParser, Node, NodeFilter, etc.).
+    files: ['backend/**/*.mjs'],
+    extends: [js.configs.recommended],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+      globals: { ...globals.node, ...globals.browser },
+    },
+    rules: backendRules,
   },
 ])


### PR DESCRIPTION
## Motivation

`eslint.config.js` only covered `src/**` and `scripts/**` — `backend/**` (Express API, `eurlex` CLI, shared FMX/HTML parsers) had no static analysis. That gap recently let two bare undefined identifiers (a real `ReferenceError` at runtime) ship green, which `no-undef` would have caught instantly.

## Ruleset

Correctness-focused, not stylistic — no quotes/semicolons/indentation rules, so the diff stays small:
- `no-undef`: **error**, unconditionally (this is the rule the motivating bug needed)
- `no-unused-vars`: **warn** (`args: 'none'`, `caughtErrors: 'none'`, `ignoreRestSiblings: true` — the backend leans on unused-arg placeholders, swallowed-error catches, and `const { drop, ...rest } = obj` idioms; none of that is a bug class worth erroring on)
- `no-empty`: **error**, with `allowEmptyCatch: true` (empty `catch {}` is a deliberate best-effort-cleanup idiom used throughout `backend/shared/eurlex-html-parser.js`; other empty blocks still flag)
- everything else from `eslint:recommended` (`no-unreachable`, `no-dupe-keys`, `no-const-assign`, `no-redeclare`, etc.)

## .js vs .mjs scoping

- `backend/**/*.js` → CommonJS, Node globals (matches the backend's default module system; no `type: module` in `backend/package.json`)
- `backend/**/*.mjs` (the shared Formex parser, `backend/shared/formex-parser/`) → ESM, **Node + browser globals**. This module runs directly in the browser (imported from `src/`) and, under Node, against `DOMParser`/`Node`/`NodeFilter` shimmed onto `global` via jsdom by `backend/shared/fmx-parser-node.js` — so both global sets are legitimate, not `no-undef` bugs.
- `backend/shared/formex-parser/fmxParser.test.js` gets its own override: it's the one backend file that uses ESM `import` syntax and is run by vitest (`vite.config.js` `test.include`), not `node --test` like the rest of `backend/**/*.test.js`.

Excluded `backend/search/data/**` (generated cache JSON) and `backend/node_modules/**` from linting.

## Wiring

`npm run lint` already runs `eslint .` from the repo root, so it now covers `backend/**` automatically — no new script needed. Also added a `npm run lint` step to `.github/workflows/pages.yml`, which previously ran `npm test` and `npm run build` but never linted at all.

## Violations found & triaged

Initial run: 16 problems (12 errors, 4 warnings). After scoping globals correctly for the DOM-dependent `.mjs` parser (10 of the 12 errors were `Node`/`DOMParser`/`NodeFilter` — legitimate shimmed globals, not bugs) and fixing the parsing error on the vitest-run test file, 5 remained:

- **Genuine dead code, fixed:**
  - `backend/routes/api-routes.js`: `registerApiRoutes` destructured `EURLEX_BASE` and `RATE_LIMIT_MAX` from `deps` but never used them in that function (both are used directly in `server.js` instead) — dropped from the destructure.
  - `backend/shared/law-queries.js`: dropped an unused `closeSharedPlaywrightBrowser` import.
- **Intentional idioms, handled via rule config rather than code changes** (see ruleset above): an empty `catch {}` and a `const { rawHtml, ...withoutRawHtml } = fetched` destructure.

No further undefined-identifier bugs surfaced beyond the legitimately-shimmed DOM globals.

## Verification

- `npm run lint` → 0 errors, 0 warnings
- `cd backend && npm install && npm test` → 120/120 passing
- `npm run test:web` → 207/207 passing (frontend lint/tests unaffected — no `src/**` changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)