### PR TITLE
Wire up remaining hardcoded case-law UI strings to i18n

### DIFF
--- a/src/components/ArticleCaseLawDigest.jsx
+++ b/src/components/ArticleCaseLawDigest.jsx
@@ -103,13 +103,13 @@ export function ArticleCaseLawDigest({ celex, articleNumber, currentLang = "EN",
       {loading && !loaded ? (
         <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
           <Loader2 size={14} className="animate-spin" />
-          Generating case-law digest
+          {t("caseLawDigest.generating")}
         </div>
       ) : null}
 
       {error ? (
         <div className="flex flex-wrap items-center justify-between gap-3 border-l-2 border-amber-300 pl-3 text-sm text-amber-800 dark:border-amber-700 dark:text-amber-200">
-          <span>Case-law digest is not available yet.</span>
+          <span>{t("caseLawDigest.unavailable")}</span>
           <Button type="button" variant="outline" size="sm" onClick={retry}>
             <RefreshCw size={14} />
             {t("common.retry")}
@@ -144,8 +144,8 @@ export function ArticleCaseLawDigest({ celex, articleNumber, currentLang = "EN",
 
           {metadata?.generatedAt ? (
             <div className="pl-6 text-[11px] text-gray-400 dark:text-gray-500">
-              Static digest generated {new Date(metadata.generatedAt).toLocaleDateString("en-GB")}
-              {metadata.cached ? " from cache" : ""}
+              {t("caseLawDigest.generatedOn", { date: new Date(metadata.generatedAt).toLocaleDateString("en-GB") })}
+              {metadata.cached ? ` ${t("caseLawDigest.fromCache")}` : ""}
             </div>
           ) : null}
         </div>

--- a/src/components/CaseLawDigest.jsx
+++ b/src/components/CaseLawDigest.jsx
@@ -78,10 +78,10 @@ export function CaseLawDigest({ celex, currentLang = "EN" }) {
       >
         <span className="inline-flex min-w-0 items-center gap-2 font-medium text-teal-900 dark:text-teal-100">
           <Sparkles size={14} className="shrink-0 text-teal-700 dark:text-teal-300" />
-          <span>Generate case-law digest</span>
+          <span>{t("caseLawDigest.generate")}</span>
         </span>
         <span className="shrink-0 rounded bg-teal-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-800 dark:bg-teal-900/50 dark:text-teal-200">
-          AI
+          {t("common.ai")}
         </span>
       </button>
     );
@@ -96,13 +96,13 @@ export function CaseLawDigest({ celex, currentLang = "EN" }) {
       {loading && !loaded ? (
         <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
           <Loader2 size={14} className="animate-spin" />
-          Generating case-law digest
+          {t("caseLawDigest.generating")}
         </div>
       ) : null}
 
       {error ? (
         <div className="flex flex-wrap items-center justify-between gap-3 border-l-2 border-amber-300 pl-3 text-sm text-amber-800 dark:border-amber-700 dark:text-amber-200">
-          <span>Case-law digest is not available yet.</span>
+          <span>{t("caseLawDigest.unavailable")}</span>
           <Button type="button" variant="outline" size="sm" onClick={retry}>
             <RefreshCw size={14} />
             {t("common.retry")}
@@ -137,8 +137,8 @@ export function CaseLawDigest({ celex, currentLang = "EN" }) {
 
           {metadata?.generatedAt ? (
             <div className="pl-6 text-[11px] text-gray-400 dark:text-gray-500">
-              Static digest generated {new Date(metadata.generatedAt).toLocaleDateString("en-GB")}
-              {metadata.cached ? " from cache" : ""}
+              {t("caseLawDigest.generatedOn", { date: new Date(metadata.generatedAt).toLocaleDateString("en-GB") })}
+              {metadata.cached ? ` ${t("caseLawDigest.fromCache")}` : ""}
             </div>
           ) : null}
         </div>

--- a/src/components/CaseLawModal.jsx
+++ b/src/components/CaseLawModal.jsx
@@ -22,6 +22,7 @@ function formatDate(isoDate) {
 const MAX_VISIBLE_ARTICLES = 5;
 
 function CaseCard({ c, currentLang }) {
+  const { t } = useI18n();
   const [expanded, setExpanded] = useState(false);
   const [showAllArticles, setShowAllArticles] = useState(false);
   const eurlexUrl = `https://eur-lex.europa.eu/legal-content/${currentLang || "EN"}/TXT/?uri=CELEX:${c.celex}`;
@@ -75,7 +76,7 @@ function CaseCard({ c, currentLang }) {
                 onClick={() => setShowAllArticles(true)}
                 className="inline-block rounded-full bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600 transition-colors"
               >
-                +{hiddenArticleCount} more
+                {t("caseLawCard.moreArticles", { count: hiddenArticleCount })}
               </button>
             )}
           </div>
@@ -90,13 +91,13 @@ function CaseCard({ c, currentLang }) {
                 onClick={() => setExpanded(true)}
                 className="w-full text-left"
               >
-                <span className="text-[10px] font-medium text-gray-500 dark:text-gray-400">Decision:</span>
+                <span className="text-[10px] font-medium text-gray-500 dark:text-gray-400">{t("caseLawCard.decisionLabel")}</span>
                 <p className="mt-0.5 text-[11px] text-gray-500 dark:text-gray-400 leading-relaxed line-clamp-2">
                   {c.declarations.map((d) => `${d.number}. ${d.text}`).join(" ")}
                 </p>
                 <span className="mt-0.5 inline-flex items-center gap-0.5 text-[10px] font-medium text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300">
                   <ChevronDown size={10} />
-                  Expand decision
+                  {t("caseLawCard.expandDecision")}
                 </span>
               </button>
             ) : (
@@ -115,7 +116,7 @@ function CaseCard({ c, currentLang }) {
                   className="mt-0.5 inline-flex items-center gap-0.5 text-[10px] font-medium text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300"
                 >
                   <ChevronUp size={10} />
-                  Collapse
+                  {t("caseLawCard.collapse")}
                 </button>
               </div>
             )}
@@ -135,7 +136,7 @@ function CaseCard({ c, currentLang }) {
             rel="noopener noreferrer"
             className="ml-auto shrink-0 inline-flex items-center gap-1 rounded-md bg-teal-50 px-2.5 py-1 text-[11px] font-medium text-teal-700 hover:bg-teal-100 transition-colors dark:bg-teal-900/30 dark:text-teal-300 dark:hover:bg-teal-900/50"
           >
-            Read full judgment
+            {t("caseLawCard.readFullJudgment")}
             <ExternalLink size={10} />
           </a>
         </div>
@@ -265,7 +266,7 @@ export function CaseLawModal({ isOpen, onClose, cases, currentLang, celex }) {
               onClick={() => setVisibleCount((v) => v + PAGE_SIZE)}
               className="mt-3 w-full rounded-lg border border-gray-200 bg-gray-50 py-2 text-xs font-medium text-gray-600 hover:bg-gray-100 transition-colors dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700"
             >
-              Show {Math.min(PAGE_SIZE, remaining)} more ({remaining} remaining)
+              {t("caseLawModal.showMore", { count: Math.min(PAGE_SIZE, remaining), remaining })}
             </button>
           )}
         </div>

--- a/src/components/MetadataPanel.jsx
+++ b/src/components/MetadataPanel.jsx
@@ -45,7 +45,7 @@ export function CaseLawButton({ celex, currentLang = "EN" }) {
           <span className="flex items-center gap-2">
             <Scale size={16} />
             {t("metadata.caseLaw")} ({cases.length})
-            <span className="rounded bg-teal-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-800 dark:bg-teal-800 dark:text-teal-200">beta</span>
+            <span className="rounded bg-teal-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-800 dark:bg-teal-800 dark:text-teal-200">{t("common.beta")}</span>
           </span>
         </button>
         <CaseLawModal
@@ -63,7 +63,7 @@ export function CaseLawButton({ celex, currentLang = "EN" }) {
     return (
       <div className="flex w-full items-center gap-2 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5 text-sm text-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-500">
         <Scale size={16} />
-        {t("metadata.caseLaw")} — none found
+        {t("metadata.caseLaw")} {t("common.noneFoundSuffix")}
       </div>
     );
   }
@@ -79,7 +79,7 @@ export function CaseLawButton({ celex, currentLang = "EN" }) {
       <span className="flex items-center gap-2">
         {loading ? <Loader2 size={16} className="animate-spin" /> : <Scale size={16} />}
         {t("metadata.caseLaw")}
-        <span className="rounded bg-teal-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-800 dark:bg-teal-800 dark:text-teal-200">beta</span>
+        <span className="rounded bg-teal-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-800 dark:bg-teal-800 dark:text-teal-200">{t("common.beta")}</span>
       </span>
     </button>
   );
@@ -113,6 +113,7 @@ const TYPE_BADGE = {
  */
 // Renders with the same shell as Accordion so there's no layout shift on load
 function LoadButton({ label, count, loading, loaded, onClick }) {
+  const { t } = useI18n();
   return (
     <div className="rounded-xl border border-gray-200 bg-white dark:bg-gray-800 dark:border-gray-700">
       <button
@@ -125,7 +126,7 @@ function LoadButton({ label, count, loading, loaded, onClick }) {
           {loading && <Loader2 size={12} className="animate-spin text-gray-400" />}
           {label}
           {loaded && count === 0 && (
-            <span className="text-xs font-normal text-gray-400 dark:text-gray-500">— none found</span>
+            <span className="text-xs font-normal text-gray-400 dark:text-gray-500">{t("common.noneFoundSuffix")}</span>
           )}
         </span>
         {!loaded && !loading && <ChevronDown size={16} />}

--- a/src/components/RelatedCaseLaw.jsx
+++ b/src/components/RelatedCaseLaw.jsx
@@ -15,6 +15,7 @@ function formatDate(isoDate) {
 }
 
 function CaseCard({ c, currentLang }) {
+  const { t } = useI18n();
   const [expanded, setExpanded] = useState(false);
   const eurlexUrl = `https://eur-lex.europa.eu/legal-content/${currentLang || "EN"}/TXT/?uri=CELEX:${c.celex}`;
   const dateLabel = formatDate(c.date);
@@ -47,7 +48,7 @@ function CaseCard({ c, currentLang }) {
               </p>
               <span className="mt-0.5 inline-flex items-center gap-0.5 text-[10px] font-medium text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300">
                 <ChevronDown size={10} />
-                Expand decision
+                {t("caseLawCard.expandDecision")}
               </span>
             </button>
           ) : (
@@ -66,7 +67,7 @@ function CaseCard({ c, currentLang }) {
                 className="mt-1 inline-flex items-center gap-0.5 text-[10px] font-medium text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300"
               >
                 <ChevronUp size={10} />
-                Collapse
+                {t("caseLawCard.collapse")}
               </button>
             </div>
           )}
@@ -82,7 +83,7 @@ function CaseCard({ c, currentLang }) {
           rel="noopener noreferrer"
           className="ml-auto shrink-0 inline-flex items-center gap-1 rounded-md bg-teal-50 px-2.5 py-1 text-[11px] font-medium text-teal-700 hover:bg-teal-100 transition-colors dark:bg-teal-900/30 dark:text-teal-300 dark:hover:bg-teal-900/50"
         >
-          Read full judgment
+          {t("caseLawCard.readFullJudgment")}
           <ExternalLink size={10} />
         </a>
       </div>
@@ -117,11 +118,11 @@ export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN" }) {
           <span className="flex min-w-0 items-center gap-2">
             <Scale size={16} className="shrink-0 text-teal-700 dark:text-teal-300" />
             <span className="font-semibold text-gray-900 dark:text-gray-100">{title}</span>
-            <span className="rounded bg-teal-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-800 dark:bg-teal-800 dark:text-teal-200">beta</span>
+            <span className="rounded bg-teal-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-800 dark:bg-teal-800 dark:text-teal-200">{t("common.beta")}</span>
           </span>
           <span className="flex shrink-0 items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
             <Loader2 size={14} className="animate-spin" />
-            Loading
+            {t("relatedCaseLaw.loading")}
           </span>
         </div>
       </div>
@@ -141,8 +142,11 @@ export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN" }) {
         <div className="flex flex-wrap items-center gap-2 border-y border-gray-200 py-3 text-sm dark:border-gray-800">
           <Scale size={16} className="shrink-0 text-gray-400 dark:text-gray-500" />
           <span className="text-gray-500 dark:text-gray-400">
-            No case law maps to this article yet. {total} CJEU {total === 1 ? "judgment interprets" : "judgments interpret"} this law overall — open{" "}
-            <span className="font-medium text-gray-700 dark:text-gray-300">Case law</span> in the sidebar for the full list and an AI digest.
+            {t("relatedCaseLaw.noMatchPrefix", {
+              count: total,
+              judgmentWord: total === 1 ? t("relatedCaseLaw.judgmentInterprets") : t("relatedCaseLaw.judgmentsInterpret"),
+            })}{" "}
+            <span className="font-medium text-gray-700 dark:text-gray-300">{t("relatedCaseLaw.sidebarLabel")}</span> {t("relatedCaseLaw.noMatchSuffix")}
           </span>
         </div>
       </div>
@@ -158,7 +162,7 @@ export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN" }) {
           <span className="rounded-full bg-teal-100 px-2.5 py-0.5 text-sm font-medium text-teal-800 dark:bg-teal-900/40 dark:text-teal-200">
             {matching.length}
           </span>
-          <span className="rounded bg-teal-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-800 dark:bg-teal-800 dark:text-teal-200">beta</span>
+          <span className="rounded bg-teal-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-800 dark:bg-teal-800 dark:text-teal-200">{t("common.beta")}</span>
         </span>
       </div>
 
@@ -177,10 +181,10 @@ export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN" }) {
         >
           <span className="inline-flex min-w-0 items-center gap-2 font-medium text-gray-700 dark:text-gray-300">
             <Sparkles size={14} className="shrink-0 text-teal-700 dark:text-teal-300" />
-            <span>Generate case-law digest</span>
+            <span>{t("caseLawDigest.generate")}</span>
           </span>
           <span className="shrink-0 rounded bg-teal-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-800 dark:bg-teal-900/50 dark:text-teal-200">
-            AI
+            {t("common.ai")}
           </span>
         </button>
       )}
@@ -191,7 +195,7 @@ export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN" }) {
         aria-expanded={isListOpen}
         onClick={() => setIsListOpen((current) => !current)}
       >
-        <span className="font-medium text-gray-700 dark:text-gray-300">Show all {matching.length} judgments</span>
+        <span className="font-medium text-gray-700 dark:text-gray-300">{t("relatedCaseLaw.showAllJudgments", { count: matching.length })}</span>
         <span className="shrink-0 text-gray-500 dark:text-gray-400">
           {isListOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
         </span>

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -21,7 +21,10 @@
     "articles": "Членове",
     "recitals": "Съображения",
     "annexes": "Приложения",
-    "noSelection": "Няма избор"
+    "noSelection": "Няма избор",
+    "beta": "бета",
+    "ai": "ИИ",
+    "noneFoundSuffix": "— не са намерени"
   },
   "seo": {
     "defaultDescription": "Интерактивна визуализация на законодателството на ЕС. Навигирайте лесно между членове, съображения и приложения.",
@@ -183,6 +186,33 @@
     "description": "Тези съображения изглеждат свързани с този член въз основа на текстов анализ с проста AI техника (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF similarity</a> (Nanda et al.)). Подредени са по релевантност.",
     "match": "{score}% съвпадение",
     "read": "Прочети →"
+  },
+  "relatedCaseLaw": {
+    "title": "Свързана съдебна практика",
+    "loading": "Зареждане",
+    "showAllJudgments": "Покажи всички {count} решения",
+    "noMatchPrefix": "Все още няма съдебна практика, свързана с този член. {count} {judgmentWord} този закон като цяло — отвори",
+    "judgmentInterprets": "решение на СЕС тълкува",
+    "judgmentsInterpret": "решения на СЕС тълкуват",
+    "sidebarLabel": "Съдебна практика",
+    "noMatchSuffix": "в страничната лента за пълния списък и обобщение с ИИ."
+  },
+  "caseLawDigest": {
+    "generate": "Генерирай обобщение на съдебната практика",
+    "generating": "Генериране на обобщение на съдебната практика",
+    "unavailable": "Обобщението на съдебната практика все още не е налично.",
+    "generatedOn": "Статично обобщение, генерирано на {date}",
+    "fromCache": "от кеша"
+  },
+  "caseLawCard": {
+    "expandDecision": "Разгъни решението",
+    "collapse": "Свий",
+    "readFullJudgment": "Прочети цялото решение",
+    "decisionLabel": "Решение:",
+    "moreArticles": "+{count} още"
+  },
+  "caseLawModal": {
+    "showMore": "Покажи още {count} (остават {remaining})"
   },
   "crossReferences": {
     "title": "Препратки",

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -21,7 +21,10 @@
     "articles": "Články",
     "recitals": "Body odůvodnění",
     "annexes": "Přílohy",
-    "noSelection": "Nic není vybráno"
+    "noSelection": "Nic není vybráno",
+    "beta": "beta",
+    "ai": "AI",
+    "noneFoundSuffix": "— žádné nenalezeny"
   },
   "seo": {
     "defaultDescription": "Interaktivní vizualizace práva EU. Snadno procházejte články, body odůvodnění a přílohy.",
@@ -183,6 +186,33 @@
     "description": "Tyto body odůvodnění se zdají být s tímto článkem spojeny na základě textové analýzy pomocí jednoduché AI (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF similarity</a> (Nanda et al.)). Jsou seřazeny podle relevance.",
     "match": "Shoda {score} %",
     "read": "Číst →"
+  },
+  "relatedCaseLaw": {
+    "title": "Související judikatura",
+    "loading": "Načítání",
+    "showAllJudgments": "Zobrazit všech {count} rozsudků",
+    "noMatchPrefix": "K tomuto článku zatím není přiřazena žádná judikatura. {count} {judgmentWord} tento právní předpis jako celek — otevřete",
+    "judgmentInterprets": "rozsudek SDEU vykládá",
+    "judgmentsInterpret": "rozsudky SDEU vykládají",
+    "sidebarLabel": "Judikatura",
+    "noMatchSuffix": "na bočním panelu, kde najdete úplný seznam a shrnutí vytvořené AI."
+  },
+  "caseLawDigest": {
+    "generate": "Vygenerovat shrnutí judikatury",
+    "generating": "Generování shrnutí judikatury",
+    "unavailable": "Shrnutí judikatury zatím není k dispozici.",
+    "generatedOn": "Statické shrnutí vygenerováno {date}",
+    "fromCache": "z mezipaměti"
+  },
+  "caseLawCard": {
+    "expandDecision": "Rozbalit rozhodnutí",
+    "collapse": "Sbalit",
+    "readFullJudgment": "Přečíst celý rozsudek",
+    "decisionLabel": "Rozhodnutí:",
+    "moreArticles": "+{count} další"
+  },
+  "caseLawModal": {
+    "showMore": "Zobrazit dalších {count} (zbývá {remaining})"
   },
   "crossReferences": {
     "title": "Křížové odkazy",

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -21,7 +21,10 @@
     "articles": "Artikler",
     "recitals": "Betragtninger",
     "annexes": "Bilag",
-    "noSelection": "Intet valgt"
+    "noSelection": "Intet valgt",
+    "beta": "beta",
+    "ai": "AI",
+    "noneFoundSuffix": "— ingen fundet"
   },
   "seo": {
     "defaultDescription": "Interaktiv visualisering af EU-lovgivning. Naviger artikler, præambler og bilag med lethed.",
@@ -183,6 +186,33 @@
     "description": "Disse præambler ser ud til at være relateret til denne artikel baseret på tekstanalyse ved hjælp af simpel AI (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF lighed</a> (Nanda et al.)). Sorteret efter relevans score.",
     "match": "{score}% overensstemmelse",
     "read": "Læs →"
+  },
+  "relatedCaseLaw": {
+    "title": "Relateret retspraksis",
+    "loading": "Indlæser",
+    "showAllJudgments": "Vis alle {count} domme",
+    "noMatchPrefix": "Der er endnu ikke knyttet nogen retspraksis til denne artikel. {count} {judgmentWord} denne lov som helhed — åbn",
+    "judgmentInterprets": "dom fra EU-Domstolen fortolker",
+    "judgmentsInterpret": "domme fra EU-Domstolen fortolker",
+    "sidebarLabel": "Retspraksis",
+    "noMatchSuffix": "i sidepanelet for at se den fulde liste og et AI-resumé."
+  },
+  "caseLawDigest": {
+    "generate": "Generér resumé af retspraksis",
+    "generating": "Genererer resumé af retspraksis",
+    "unavailable": "Resumé af retspraksis er endnu ikke tilgængeligt.",
+    "generatedOn": "Statisk resumé genereret {date}",
+    "fromCache": "fra cache"
+  },
+  "caseLawCard": {
+    "expandDecision": "Udvid afgørelse",
+    "collapse": "Sammenfold",
+    "readFullJudgment": "Læs hele dommen",
+    "decisionLabel": "Afgørelse:",
+    "moreArticles": "+{count} mere"
+  },
+  "caseLawModal": {
+    "showMore": "Vis {count} mere ({remaining} tilbage)"
   },
   "crossReferences": {
     "title": "Krydshenvisninger",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -21,7 +21,10 @@
     "articles": "Artikel",
     "recitals": "Erwägungsgründe",
     "annexes": "Anhänge",
-    "noSelection": "Keine Auswahl"
+    "noSelection": "Keine Auswahl",
+    "beta": "Beta",
+    "ai": "KI",
+    "noneFoundSuffix": "— keine gefunden"
   },
   "seo": {
     "defaultDescription": "Interaktive Visualisierung von EU-Gesetzen. Navigieren Sie mühelos durch Artikel, Präambeln und Anhänge.",
@@ -183,6 +186,33 @@
     "description": "Diese Präambeln scheinen mit diesem Artikel verbunden zu sein, basierend auf Textanalyse unter Verwendung einfacher KI (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF-Ähnlichkeit</a> (Nanda et al.)). Sortiert nach Relevanzbewertung.",
     "match": "{score}% Übereinstimmung",
     "read": "Lesen →"
+  },
+  "relatedCaseLaw": {
+    "title": "Zugehörige Rechtsprechung",
+    "loading": "Wird geladen",
+    "showAllJudgments": "Alle {count} Urteile anzeigen",
+    "noMatchPrefix": "Diesem Artikel ist noch keine Rechtsprechung zugeordnet. {count} {judgmentWord} dieses Gesetz insgesamt — öffnen Sie",
+    "judgmentInterprets": "EuGH-Urteil legt aus",
+    "judgmentsInterpret": "EuGH-Urteile legen aus",
+    "sidebarLabel": "Rechtsprechung",
+    "noMatchSuffix": "in der Seitenleiste für die vollständige Liste und eine KI-Zusammenfassung."
+  },
+  "caseLawDigest": {
+    "generate": "Rechtsprechungsübersicht erstellen",
+    "generating": "Rechtsprechungsübersicht wird erstellt",
+    "unavailable": "Die Rechtsprechungsübersicht ist noch nicht verfügbar.",
+    "generatedOn": "Statische Übersicht erstellt am {date}",
+    "fromCache": "aus dem Cache"
+  },
+  "caseLawCard": {
+    "expandDecision": "Entscheidung ausklappen",
+    "collapse": "Einklappen",
+    "readFullJudgment": "Vollständiges Urteil lesen",
+    "decisionLabel": "Entscheidung:",
+    "moreArticles": "+{count} weitere"
+  },
+  "caseLawModal": {
+    "showMore": "{count} weitere anzeigen ({remaining} verbleibend)"
   },
   "crossReferences": {
     "title": "Kreuzverweise",

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -21,7 +21,10 @@
     "articles": "Άρθρα",
     "recitals": "Αιτιολογικές σκέψεις",
     "annexes": "Παραρτήματα",
-    "noSelection": "Καμία επιλογή"
+    "noSelection": "Καμία επιλογή",
+    "beta": "beta",
+    "ai": "ΤΝ",
+    "noneFoundSuffix": "— δεν βρέθηκαν"
   },
   "seo": {
     "defaultDescription": "Διαδραστική απεικόνιση νομοθεσίας της ΕΕ. Περιηγηθείτε σε άρθρα, ψηφίσματα και παραρτήματα με ευκολία.",
@@ -183,6 +186,33 @@
     "description": "Αυτά τα ψηφίσματα φαίνεται να σχετίζονται με αυτό το άρθρο με βάση την ανάλυση κειμένου χρησιμοποιώντας απλή AI (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">ομοιότητα TF-IDF</a> (Nanda et al.)). Ταξινομημένα κατά βαθμό συνάφειας.",
     "match": "{score}% αντιστοιχία",
     "read": "Ανάγνωση →"
+  },
+  "relatedCaseLaw": {
+    "title": "Σχετική νομολογία",
+    "loading": "Φόρτωση",
+    "showAllJudgments": "Εμφάνιση όλων των {count} αποφάσεων",
+    "noMatchPrefix": "Δεν έχει συσχετιστεί ακόμη νομολογία με αυτό το άρθρο. {count} {judgmentWord} συνολικά αυτόν τον νόμο — ανοίξτε",
+    "judgmentInterprets": "απόφαση του ΔΕΕ ερμηνεύει",
+    "judgmentsInterpret": "αποφάσεις του ΔΕΕ ερμηνεύουν",
+    "sidebarLabel": "Νομολογία",
+    "noMatchSuffix": "στην πλαϊνή στήλη για την πλήρη λίστα και μια σύνοψη με ΤΝ."
+  },
+  "caseLawDigest": {
+    "generate": "Δημιουργία σύνοψης νομολογίας",
+    "generating": "Δημιουργία σύνοψης νομολογίας σε εξέλιξη",
+    "unavailable": "Η σύνοψη νομολογίας δεν είναι ακόμη διαθέσιμη.",
+    "generatedOn": "Στατική σύνοψη δημιουργήθηκε στις {date}",
+    "fromCache": "από την κρυφή μνήμη"
+  },
+  "caseLawCard": {
+    "expandDecision": "Ανάπτυξη απόφασης",
+    "collapse": "Σύμπτυξη",
+    "readFullJudgment": "Ανάγνωση πλήρους απόφασης",
+    "decisionLabel": "Απόφαση:",
+    "moreArticles": "+{count} ακόμη"
+  },
+  "caseLawModal": {
+    "showMore": "Εμφάνιση {count} ακόμη (απομένουν {remaining})"
   },
   "crossReferences": {
     "title": "Διασταυρούμενες Αναφορές",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -21,7 +21,10 @@
     "articles": "Articles",
     "recitals": "Recitals",
     "annexes": "Annexes",
-    "noSelection": "No selection"
+    "noSelection": "No selection",
+    "beta": "beta",
+    "ai": "AI",
+    "noneFoundSuffix": "— none found"
   },
   "seo": {
     "defaultDescription": "Read EU laws like the GDPR, AI Act, DMA, DSA and Data Act with ease. Navigate articles, recitals, annexes and cross-references, side by side.",
@@ -187,7 +190,31 @@
     "read": "Read →"
   },
   "relatedCaseLaw": {
-    "title": "Related case law"
+    "title": "Related case law",
+    "loading": "Loading",
+    "showAllJudgments": "Show all {count} judgments",
+    "noMatchPrefix": "No case law maps to this article yet. {count} CJEU {judgmentWord} this law overall — open",
+    "judgmentInterprets": "judgment interprets",
+    "judgmentsInterpret": "judgments interpret",
+    "sidebarLabel": "Case law",
+    "noMatchSuffix": "in the sidebar for the full list and an AI digest."
+  },
+  "caseLawDigest": {
+    "generate": "Generate case-law digest",
+    "generating": "Generating case-law digest",
+    "unavailable": "Case-law digest is not available yet.",
+    "generatedOn": "Static digest generated {date}",
+    "fromCache": "from cache"
+  },
+  "caseLawCard": {
+    "expandDecision": "Expand decision",
+    "collapse": "Collapse",
+    "readFullJudgment": "Read full judgment",
+    "decisionLabel": "Decision:",
+    "moreArticles": "+{count} more"
+  },
+  "caseLawModal": {
+    "showMore": "Show {count} more ({remaining} remaining)"
   },
   "crossReferences": {
     "title": "Cross-References",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -21,7 +21,10 @@
     "articles": "Artículos",
     "recitals": "Considerandos",
     "annexes": "Anexos",
-    "noSelection": "Sin selección"
+    "noSelection": "Sin selección",
+    "beta": "beta",
+    "ai": "IA",
+    "noneFoundSuffix": "— no se encontraron"
   },
   "seo": {
     "defaultDescription": "Visualización interactiva de leyes de la UE. Navegue por artículos, considerandos y anexos con facilidad.",
@@ -183,6 +186,33 @@
     "description": "Estos considerandos parecen estar relacionados con este artículo según análisis de texto usando IA simple (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">similitud TF-IDF</a> (Nanda et al.)). Ordenado por puntuación de relevancia.",
     "match": "{score}% de coincidencia",
     "read": "Leer →"
+  },
+  "relatedCaseLaw": {
+    "title": "Jurisprudencia relacionada",
+    "loading": "Cargando",
+    "showAllJudgments": "Mostrar las {count} sentencias",
+    "noMatchPrefix": "Todavía no hay jurisprudencia asociada a este artículo. {count} {judgmentWord} esta ley en su conjunto — abra",
+    "judgmentInterprets": "sentencia del TJUE interpreta",
+    "judgmentsInterpret": "sentencias del TJUE interpretan",
+    "sidebarLabel": "Jurisprudencia",
+    "noMatchSuffix": "en la barra lateral para ver la lista completa y un resumen generado por IA."
+  },
+  "caseLawDigest": {
+    "generate": "Generar resumen de jurisprudencia",
+    "generating": "Generando resumen de jurisprudencia",
+    "unavailable": "El resumen de jurisprudencia aún no está disponible.",
+    "generatedOn": "Resumen estático generado el {date}",
+    "fromCache": "desde la caché"
+  },
+  "caseLawCard": {
+    "expandDecision": "Ampliar decisión",
+    "collapse": "Contraer",
+    "readFullJudgment": "Leer sentencia completa",
+    "decisionLabel": "Decisión:",
+    "moreArticles": "+{count} más"
+  },
+  "caseLawModal": {
+    "showMore": "Mostrar {count} más ({remaining} restantes)"
   },
   "crossReferences": {
     "title": "Referencias cruzadas",

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -21,7 +21,10 @@
     "articles": "Artiklid",
     "recitals": "Põhjendused",
     "annexes": "Lisad",
-    "noSelection": "Valik puudub"
+    "noSelection": "Valik puudub",
+    "beta": "beeta",
+    "ai": "TI",
+    "noneFoundSuffix": "— ei leitud ühtegi"
   },
   "seo": {
     "defaultDescription": "EU seaduste interaktiivne visualiseerimine. Liikuge artiklite, preambuli ja lisade vahel hõlpsalt.",
@@ -183,6 +186,33 @@
     "description": "Need preambuuli osad paistuvad selle artikliga seotud olevat teksti analüüsi abil, kasutades lihtsat tehisintellekti (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF sarnasus</a> (Nanda jt.)). Sorteeritud asjaolulisuse astme järgi.",
     "match": "{score}% vaste",
     "read": "Loe →"
+  },
+  "relatedCaseLaw": {
+    "title": "Seotud kohtupraktika",
+    "loading": "Laadimine",
+    "showAllJudgments": "Näita kõiki {count} kohtuotsust",
+    "noMatchPrefix": "Selle artikliga ei ole veel kohtupraktikat seostatud. {count} {judgmentWord} seda õigusakti tervikuna — ava",
+    "judgmentInterprets": "Euroopa Kohtu otsus tõlgendab",
+    "judgmentsInterpret": "Euroopa Kohtu otsused tõlgendavad",
+    "sidebarLabel": "Kohtupraktika",
+    "noMatchSuffix": "külgribal, et näha täielikku loetelu ja TI koostatud kokkuvõtet."
+  },
+  "caseLawDigest": {
+    "generate": "Loo kohtupraktika kokkuvõte",
+    "generating": "Kohtupraktika kokkuvõtte loomine",
+    "unavailable": "Kohtupraktika kokkuvõte ei ole veel saadaval.",
+    "generatedOn": "Staatiline kokkuvõte loodud {date}",
+    "fromCache": "vahemälust"
+  },
+  "caseLawCard": {
+    "expandDecision": "Ava otsus",
+    "collapse": "Sulge",
+    "readFullJudgment": "Loe kogu kohtuotsust",
+    "decisionLabel": "Otsus:",
+    "moreArticles": "+{count} veel"
+  },
+  "caseLawModal": {
+    "showMore": "Näita {count} veel (jäänud {remaining})"
   },
   "crossReferences": {
     "title": "Ristviited",

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -21,7 +21,10 @@
     "articles": "Artiklat",
     "recitals": "Johdanto-osan kappaleet",
     "annexes": "Liitteet",
-    "noSelection": "Ei valintaa"
+    "noSelection": "Ei valintaa",
+    "beta": "beta",
+    "ai": "tekoäly",
+    "noneFoundSuffix": "— ei löytynyt yhtään"
   },
   "seo": {
     "defaultDescription": "EU-lakien interaktiivinen visualisointi. Siirry artikkeleihin, johdantoihin ja liitteisiin helposti.",
@@ -183,6 +186,33 @@
     "description": "Nämä johdannot näyttävät liittyvän tähän artiklaan tekstin analyysiin perustuvalla yksinkertaisella tekoälyllä (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF samankaltaisuus</a> (Nanda et al.)). Lajiteltu merkityksen perusteella.",
     "match": "{score}% osuma",
     "read": "Lue →"
+  },
+  "relatedCaseLaw": {
+    "title": "Aiheeseen liittyvä oikeuskäytäntö",
+    "loading": "Ladataan",
+    "showAllJudgments": "Näytä kaikki {count} tuomiota",
+    "noMatchPrefix": "Tähän artiklaan ei ole vielä liitetty oikeuskäytäntöä. {count} {judgmentWord} tätä säädöstä kokonaisuutena — avaa",
+    "judgmentInterprets": "EU-tuomioistuimen tuomio tulkitsee",
+    "judgmentsInterpret": "EU-tuomioistuimen tuomiot tulkitsevat",
+    "sidebarLabel": "Oikeuskäytäntö",
+    "noMatchSuffix": "sivupalkista nähdäksesi koko luettelon ja tekoälyn laatiman yhteenvedon."
+  },
+  "caseLawDigest": {
+    "generate": "Luo oikeuskäytäntöyhteenveto",
+    "generating": "Luodaan oikeuskäytäntöyhteenvetoa",
+    "unavailable": "Oikeuskäytäntöyhteenveto ei ole vielä saatavilla.",
+    "generatedOn": "Staattinen yhteenveto luotu {date}",
+    "fromCache": "välimuistista"
+  },
+  "caseLawCard": {
+    "expandDecision": "Laajenna ratkaisu",
+    "collapse": "Supista",
+    "readFullJudgment": "Lue koko tuomio",
+    "decisionLabel": "Ratkaisu:",
+    "moreArticles": "+{count} lisää"
+  },
+  "caseLawModal": {
+    "showMore": "Näytä {count} lisää ({remaining} jäljellä)"
   },
   "crossReferences": {
     "title": "Ristiviitteet",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -21,7 +21,10 @@
     "articles": "Articles",
     "recitals": "Considérants",
     "annexes": "Annexes",
-    "noSelection": "Aucune sélection"
+    "noSelection": "Aucune sélection",
+    "beta": "bêta",
+    "ai": "IA",
+    "noneFoundSuffix": "— aucun trouvé"
   },
   "seo": {
     "defaultDescription": "Visualisation interactive des lois de l'UE. Naviguez dans les articles, considérants et annexes avec facilité.",
@@ -183,6 +186,33 @@
     "description": "Ces considérants semblent être liés à cet article en fonction de l'analyse textuelle utilisant une IA simple (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">similarité TF-IDF</a> (Nanda et al.)). Trié par score de pertinence.",
     "match": "{score}% de correspondance",
     "read": "Lire →"
+  },
+  "relatedCaseLaw": {
+    "title": "Jurisprudence associée",
+    "loading": "Chargement",
+    "showAllJudgments": "Afficher les {count} arrêts",
+    "noMatchPrefix": "Aucune jurisprudence n'est encore associée à cet article. {count} {judgmentWord} cette loi dans son ensemble — ouvrez",
+    "judgmentInterprets": "arrêt de la CJUE interprète",
+    "judgmentsInterpret": "arrêts de la CJUE interprètent",
+    "sidebarLabel": "Jurisprudence",
+    "noMatchSuffix": "dans la barre latérale pour la liste complète et une synthèse par IA."
+  },
+  "caseLawDigest": {
+    "generate": "Générer une synthèse de la jurisprudence",
+    "generating": "Génération de la synthèse de la jurisprudence",
+    "unavailable": "La synthèse de la jurisprudence n'est pas encore disponible.",
+    "generatedOn": "Synthèse statique générée le {date}",
+    "fromCache": "depuis le cache"
+  },
+  "caseLawCard": {
+    "expandDecision": "Développer la décision",
+    "collapse": "Réduire",
+    "readFullJudgment": "Lire l'arrêt complet",
+    "decisionLabel": "Décision :",
+    "moreArticles": "+{count} de plus"
+  },
+  "caseLawModal": {
+    "showMore": "Afficher {count} de plus ({remaining} restants)"
   },
   "crossReferences": {
     "title": "Références croisées",

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -21,7 +21,10 @@
     "articles": "Airteagail",
     "recitals": "Aithrisí",
     "annexes": "Iarscríbhinní",
-    "noSelection": "Gan roghnú"
+    "noSelection": "Gan roghnú",
+    "beta": "beite",
+    "ai": "AI",
+    "noneFoundSuffix": "— níor aimsíodh aon cheann"
   },
   "seo": {
     "defaultDescription": "Samhaltú idirghníomhach ar dhlithe EU. Nasáil altanna, réamhráití agus iatachán le fása.",
@@ -183,6 +186,33 @@
     "description": "Dealraítear go bhfuil na réamhráití seo a bheith gaolmhar don alt seo bunaithe ar anailís téacsa ag úsáid AI simplí (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF cosúlachta</a> (Nanda et al.)). Sórtáilte de réir scór ábharthachta.",
     "match": "{score}% meaitseáil",
     "read": "Léigh →"
+  },
+  "relatedCaseLaw": {
+    "title": "Cásdlí Gaolmhar",
+    "loading": "Ag lódáil",
+    "showAllJudgments": "Taispeáin gach ceann de na {count} breithiúnas",
+    "noMatchPrefix": "Níl aon chásdlí ceangailte leis an alt seo fós. Tá {count} {judgmentWord} an dlí seo trí chéile — oscail",
+    "judgmentInterprets": "breithiúnas ó CBBE ag léiriú",
+    "judgmentsInterpret": "breithiúnais ó CBBE ag léiriú",
+    "sidebarLabel": "Cásdlí",
+    "noMatchSuffix": "sa bharra taoibh don liosta iomlán agus achoimre AI."
+  },
+  "caseLawDigest": {
+    "generate": "Gin achoimre cásdlí",
+    "generating": "Ag giniúint achoimre cásdlí",
+    "unavailable": "Níl achoimre cásdlí ar fáil fós.",
+    "generatedOn": "Achoimre statach ginte {date}",
+    "fromCache": "ón taisce"
+  },
+  "caseLawCard": {
+    "expandDecision": "Leathnaigh an cinneadh",
+    "collapse": "Laghdaigh",
+    "readFullJudgment": "Léigh an breithiúnas iomlán",
+    "decisionLabel": "Cinneadh:",
+    "moreArticles": "+{count} eile"
+  },
+  "caseLawModal": {
+    "showMore": "Taispeáin {count} eile ({remaining} fágtha)"
   },
   "crossReferences": {
     "title": "Tagairtí Chrostacha",

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -21,7 +21,10 @@
     "articles": "Članci",
     "recitals": "Uvodne izjave",
     "annexes": "Prilozi",
-    "noSelection": "Nema odabira"
+    "noSelection": "Nema odabira",
+    "beta": "beta",
+    "ai": "UI",
+    "noneFoundSuffix": "— nije pronađeno"
   },
   "seo": {
     "defaultDescription": "Interaktivna vizualizacija EU zakona. Navigirajte člancima, preamblama i prilozima s lakoćom.",
@@ -183,6 +186,33 @@
     "description": "Čini se da su ove preamble povezane s ovim člankom na osnovi analize teksta koristeći jednostavnu AI (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF sličnost</a> (Nanda et al.)). Sortirano po rezultatu relevantnosti.",
     "match": "{score}% podudaranje",
     "read": "Čitaj →"
+  },
+  "relatedCaseLaw": {
+    "title": "Povezana sudska praksa",
+    "loading": "Učitavanje",
+    "showAllJudgments": "Prikaži svih {count} presuda",
+    "noMatchPrefix": "Ovom članku još nije pridružena sudska praksa. {count} {judgmentWord} ovaj propis u cjelini — otvorite",
+    "judgmentInterprets": "presuda Suda EU-a tumači",
+    "judgmentsInterpret": "presude Suda EU-a tumače",
+    "sidebarLabel": "Sudska praksa",
+    "noMatchSuffix": "na bočnoj traci za cijeli popis i sažetak izrađen UI-jem."
+  },
+  "caseLawDigest": {
+    "generate": "Generiraj sažetak sudske prakse",
+    "generating": "Generiranje sažetka sudske prakse",
+    "unavailable": "Sažetak sudske prakse još nije dostupan.",
+    "generatedOn": "Statički sažetak generiran {date}",
+    "fromCache": "iz predmemorije"
+  },
+  "caseLawCard": {
+    "expandDecision": "Proširi odluku",
+    "collapse": "Sažmi",
+    "readFullJudgment": "Pročitaj cijelu presudu",
+    "decisionLabel": "Odluka:",
+    "moreArticles": "+{count} više"
+  },
+  "caseLawModal": {
+    "showMore": "Prikaži još {count} (preostalo {remaining})"
   },
   "crossReferences": {
     "title": "Kereszt-referencije",

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -21,7 +21,10 @@
     "articles": "Cikkek",
     "recitals": "Preambulumbekezdések",
     "annexes": "Mellékletek",
-    "noSelection": "Nincs kijelölés"
+    "noSelection": "Nincs kijelölés",
+    "beta": "béta",
+    "ai": "MI",
+    "noneFoundSuffix": "— nem található"
   },
   "seo": {
     "defaultDescription": "Az EU jogszabályok interaktív megjelenítése. Könnyedén navigálhat a cikkek, preambulumok és mellékletek között.",
@@ -183,6 +186,33 @@
     "description": "Ezek az preambulumok kapcsolódnak ehhez a cikkhez a szöveganalízis alapján egyszerű AI-val (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF hasonlóság</a> (Nanda et al.)). Relevanciascore szerint rendezve.",
     "match": "{score}% egyezés",
     "read": "Olvasás →"
+  },
+  "relatedCaseLaw": {
+    "title": "Kapcsolódó ítélkezési gyakorlat",
+    "loading": "Betöltés",
+    "showAllJudgments": "Mind a(z) {count} ítélet megjelenítése",
+    "noMatchPrefix": "Ehhez a cikkhez még nem tartozik ítélkezési gyakorlat. {count} {judgmentWord} ezt a jogszabályt összességében — nyissa meg",
+    "judgmentInterprets": "EUB-ítélet értelmezi",
+    "judgmentsInterpret": "EUB-ítéletek értelmezik",
+    "sidebarLabel": "Ítélkezési gyakorlat",
+    "noMatchSuffix": "az oldalsávban a teljes listáért és egy MI által készített összefoglalóért."
+  },
+  "caseLawDigest": {
+    "generate": "Ítélkezési gyakorlat összefoglalójának létrehozása",
+    "generating": "Ítélkezési gyakorlat összefoglalójának létrehozása folyamatban",
+    "unavailable": "Az ítélkezési gyakorlat összefoglalója még nem érhető el.",
+    "generatedOn": "Statikus összefoglaló létrehozva: {date}",
+    "fromCache": "gyorsítótárból"
+  },
+  "caseLawCard": {
+    "expandDecision": "Döntés kibontása",
+    "collapse": "Összecsukás",
+    "readFullJudgment": "Teljes ítélet elolvasása",
+    "decisionLabel": "Döntés:",
+    "moreArticles": "+{count} további"
+  },
+  "caseLawModal": {
+    "showMore": "{count} további megjelenítése ({remaining} hátravan)"
   },
   "crossReferences": {
     "title": "Kereszthivatkozások",

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -21,7 +21,10 @@
     "articles": "Articoli",
     "recitals": "Considerando",
     "annexes": "Allegati",
-    "noSelection": "Nessuna selezione"
+    "noSelection": "Nessuna selezione",
+    "beta": "beta",
+    "ai": "IA",
+    "noneFoundSuffix": "— nessuno trovato"
   },
   "seo": {
     "defaultDescription": "Visualizzazione interattiva della normativa UE. Navigare negli articoli, considerando e allegati con facilità.",
@@ -183,6 +186,33 @@
     "description": "Questi considerando sembrano essere correlati a questo articolo in base all'analisi del testo utilizzando un'IA semplice (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">somiglianza TF-IDF</a> (Nanda et al.)). Ordinato per punteggio di pertinenza.",
     "match": "{score}% di corrispondenza",
     "read": "Leggi →"
+  },
+  "relatedCaseLaw": {
+    "title": "Giurisprudenza correlata",
+    "loading": "Caricamento",
+    "showAllJudgments": "Mostra tutte le {count} sentenze",
+    "noMatchPrefix": "Nessuna giurisprudenza è ancora associata a questo articolo. {count} {judgmentWord} questa legge nel complesso — apri",
+    "judgmentInterprets": "sentenza della CGUE interpreta",
+    "judgmentsInterpret": "sentenze della CGUE interpretano",
+    "sidebarLabel": "Giurisprudenza",
+    "noMatchSuffix": "nella barra laterale per l'elenco completo e una sintesi generata dall'IA."
+  },
+  "caseLawDigest": {
+    "generate": "Genera sintesi della giurisprudenza",
+    "generating": "Generazione della sintesi della giurisprudenza",
+    "unavailable": "La sintesi della giurisprudenza non è ancora disponibile.",
+    "generatedOn": "Sintesi statica generata il {date}",
+    "fromCache": "dalla cache"
+  },
+  "caseLawCard": {
+    "expandDecision": "Espandi decisione",
+    "collapse": "Comprimi",
+    "readFullJudgment": "Leggi la sentenza completa",
+    "decisionLabel": "Decisione:",
+    "moreArticles": "+{count} altri"
+  },
+  "caseLawModal": {
+    "showMore": "Mostra altri {count} ({remaining} rimanenti)"
   },
   "crossReferences": {
     "title": "Riferimenti incrociati",

--- a/src/i18n/locales/lt.json
+++ b/src/i18n/locales/lt.json
@@ -21,7 +21,10 @@
     "articles": "Straipsniai",
     "recitals": "Konstatuojamosios dalys",
     "annexes": "Priedai",
-    "noSelection": "Nieko nepasirinkta"
+    "noSelection": "Nieko nepasirinkta",
+    "beta": "beta",
+    "ai": "DI",
+    "noneFoundSuffix": "— nerasta"
   },
   "seo": {
     "defaultDescription": "Interaktyvi ES teisės aktų vizualizacija. Lengvai naršykite straipsnius, preambulės dalis ir priedus.",
@@ -183,6 +186,33 @@
     "description": "Šios preambulės dalys, atrodo, susijusios su šiuo straipsniu pagal teksto analizę naudojant paprastą AI (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF panašumas</a> (Nanda ir kt.)). Rūšiuota pagal aktualumo balą.",
     "match": "{score}% atitiktis",
     "read": "Skaityti →"
+  },
+  "relatedCaseLaw": {
+    "title": "Susijusi teismų praktika",
+    "loading": "Įkeliama",
+    "showAllJudgments": "Rodyti visus {count} sprendimus",
+    "noMatchPrefix": "Su šiuo straipsniu dar nesusieta jokia teismų praktika. {count} {judgmentWord} šį teisės aktą apskritai — atidarykite",
+    "judgmentInterprets": "ESTT sprendimas aiškina",
+    "judgmentsInterpret": "ESTT sprendimai aiškina",
+    "sidebarLabel": "Teismų praktika",
+    "noMatchSuffix": "šoninėje juostoje, kad pamatytumėte visą sąrašą ir DI parengtą santrauką."
+  },
+  "caseLawDigest": {
+    "generate": "Generuoti teismų praktikos santrauką",
+    "generating": "Generuojama teismų praktikos santrauka",
+    "unavailable": "Teismų praktikos santrauka dar nepasiekiama.",
+    "generatedOn": "Statinė santrauka sugeneruota {date}",
+    "fromCache": "iš talpyklos"
+  },
+  "caseLawCard": {
+    "expandDecision": "Išskleisti sprendimą",
+    "collapse": "Suskleisti",
+    "readFullJudgment": "Skaityti visą sprendimą",
+    "decisionLabel": "Sprendimas:",
+    "moreArticles": "+{count} daugiau"
+  },
+  "caseLawModal": {
+    "showMore": "Rodyti dar {count} (liko {remaining})"
   },
   "crossReferences": {
     "title": "Tarpusavio nuorodos",

--- a/src/i18n/locales/lv.json
+++ b/src/i18n/locales/lv.json
@@ -21,7 +21,10 @@
     "articles": "Panti",
     "recitals": "Apsvērumi",
     "annexes": "Pielikumi",
-    "noSelection": "Nav izvēles"
+    "noSelection": "Nav izvēles",
+    "beta": "beta",
+    "ai": "MI",
+    "noneFoundSuffix": "— nekas nav atrasts"
   },
   "seo": {
     "defaultDescription": "ES likumu interaktīva vizualizācija. Pārlūkojiet artikulus, preambulu un pielikumus viegli.",
@@ -183,6 +186,33 @@
     "description": "Šīs preambulas daļas šķiet saistītas ar šo rakstu, pamatojoties uz teksta analīzi, izmantojot vienkāršu AI (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF līdzība</a> (Nanda et al.)). Sakārtots pēc atbilstības reitinga.",
     "match": "{score}% atbilstība",
     "read": "Lasīt →"
+  },
+  "relatedCaseLaw": {
+    "title": "Saistītā judikatūra",
+    "loading": "Ielādē",
+    "showAllJudgments": "Rādīt visus {count} spriedumus",
+    "noMatchPrefix": "Šim pantam vēl nav piesaistīta judikatūra. {count} {judgmentWord} šo tiesību aktu kopumā — atveriet",
+    "judgmentInterprets": "EST spriedums interpretē",
+    "judgmentsInterpret": "EST spriedumi interpretē",
+    "sidebarLabel": "Judikatūra",
+    "noMatchSuffix": "sānjoslā, lai skatītu pilnu sarakstu un MI veidotu kopsavilkumu."
+  },
+  "caseLawDigest": {
+    "generate": "Ģenerēt judikatūras kopsavilkumu",
+    "generating": "Notiek judikatūras kopsavilkuma ģenerēšana",
+    "unavailable": "Judikatūras kopsavilkums vēl nav pieejams.",
+    "generatedOn": "Statisks kopsavilkums ģenerēts {date}",
+    "fromCache": "no kešatmiņas"
+  },
+  "caseLawCard": {
+    "expandDecision": "Izvērst lēmumu",
+    "collapse": "Sakļaut",
+    "readFullJudgment": "Lasīt pilnu spriedumu",
+    "decisionLabel": "Lēmums:",
+    "moreArticles": "+{count} vairāk"
+  },
+  "caseLawModal": {
+    "showMore": "Rādīt vēl {count} (atlikuši {remaining})"
   },
   "crossReferences": {
     "title": "Savstarpējās atsauces",

--- a/src/i18n/locales/mt.json
+++ b/src/i18n/locales/mt.json
@@ -21,7 +21,10 @@
     "articles": "Artikoli",
     "recitals": "Premessi",
     "annexes": "Annessi",
-    "noSelection": "Ebda għażla"
+    "noSelection": "Ebda għażla",
+    "beta": "beta",
+    "ai": "AI",
+    "noneFoundSuffix": "— l-ebda wieħed misjub"
   },
   "seo": {
     "defaultDescription": "Visualizzazzjoni interattiva tal-liġi tal-UE. Innaviga artikli, preamboli u anessi bl-ċans.",
@@ -183,6 +186,33 @@
     "description": "Jidher li dawk il-preamboli huma relatati għal dan l-artiklu ibbażat fuq analiżi tat-test bl-użu ta' AI sempliċi (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">similarità TF-IDF</a> (Nanda et al.)). Issort skond il-punteġġ tar-rilevanza.",
     "match": "{score}% taqbila",
     "read": "Aqra →"
+  },
+  "relatedCaseLaw": {
+    "title": "Ġurisprudenza Relatata",
+    "loading": "Qed jgħabbi",
+    "showAllJudgments": "Uri d-{count} sentenzi kollha",
+    "noMatchPrefix": "Għadha ma ġiet assoċjata l-ebda ġurisprudenza ma' dan l-artikolu. {count} {judgmentWord} din il-liġi b'mod ġenerali — iftaħ",
+    "judgmentInterprets": "sentenza tal-QĠUE tinterpreta",
+    "judgmentsInterpret": "sentenzi tal-QĠUE jinterpretaw",
+    "sidebarLabel": "Ġurisprudenza",
+    "noMatchSuffix": "fil-barra laterali għal-lista sħiħa u sommarju magħmul bl-AI."
+  },
+  "caseLawDigest": {
+    "generate": "Iġġenera sommarju tal-ġurisprudenza",
+    "generating": "Qed jiġi ġġenerat is-sommarju tal-ġurisprudenza",
+    "unavailable": "Is-sommarju tal-ġurisprudenza għadu mhux disponibbli.",
+    "generatedOn": "Sommarju statiku ġġenerat fi {date}",
+    "fromCache": "mill-cache"
+  },
+  "caseLawCard": {
+    "expandDecision": "Espandi d-deċiżjoni",
+    "collapse": "Għalaq",
+    "readFullJudgment": "Aqra s-sentenza sħiħa",
+    "decisionLabel": "Deċiżjoni:",
+    "moreArticles": "+{count} oħra"
+  },
+  "caseLawModal": {
+    "showMore": "Uri {count} oħra ({remaining} li fadal)"
   },
   "crossReferences": {
     "title": "Riferimenti Inkruċiati",

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -21,7 +21,10 @@
     "articles": "Artikelen",
     "recitals": "Overwegingen",
     "annexes": "Bijlagen",
-    "noSelection": "Geen selectie"
+    "noSelection": "Geen selectie",
+    "beta": "bèta",
+    "ai": "AI",
+    "noneFoundSuffix": "— geen gevonden"
   },
   "seo": {
     "defaultDescription": "Interactieve visualisatie van EU-wetgeving. Navigeer gemakkelijk door artikelen, preambules en bijlagen.",
@@ -183,6 +186,33 @@
     "description": "Deze preambules lijken gerelateerd te zijn aan dit artikel op basis van tekstanalyse met behulp van eenvoudige AI (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF gelijkenis</a> (Nanda et al.)). Gesorteerd op relevantiescore.",
     "match": "{score}% overeenkomst",
     "read": "Lees →"
+  },
+  "relatedCaseLaw": {
+    "title": "Gerelateerde rechtspraak",
+    "loading": "Bezig met laden",
+    "showAllJudgments": "Toon alle {count} arresten",
+    "noMatchPrefix": "Aan dit artikel is nog geen rechtspraak gekoppeld. {count} {judgmentWord} deze wet als geheel — open",
+    "judgmentInterprets": "arrest van het HvJ-EU interpreteert",
+    "judgmentsInterpret": "arresten van het HvJ-EU interpreteren",
+    "sidebarLabel": "Rechtspraak",
+    "noMatchSuffix": "in de zijbalk voor de volledige lijst en een door AI gegenereerde samenvatting."
+  },
+  "caseLawDigest": {
+    "generate": "Samenvatting van rechtspraak genereren",
+    "generating": "Samenvatting van rechtspraak wordt gegenereerd",
+    "unavailable": "Samenvatting van rechtspraak is nog niet beschikbaar.",
+    "generatedOn": "Statische samenvatting gegenereerd op {date}",
+    "fromCache": "uit de cache"
+  },
+  "caseLawCard": {
+    "expandDecision": "Beslissing uitklappen",
+    "collapse": "Inklappen",
+    "readFullJudgment": "Volledig arrest lezen",
+    "decisionLabel": "Beslissing:",
+    "moreArticles": "+{count} meer"
+  },
+  "caseLawModal": {
+    "showMore": "Toon {count} meer ({remaining} resterend)"
   },
   "crossReferences": {
     "title": "Kruisverwijzingen",

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -21,7 +21,10 @@
     "articles": "Artykuły",
     "recitals": "Motywy",
     "annexes": "Załączniki",
-    "noSelection": "Brak wyboru"
+    "noSelection": "Brak wyboru",
+    "beta": "beta",
+    "ai": "AI",
+    "noneFoundSuffix": "— nie znaleziono"
   },
   "seo": {
     "defaultDescription": "Interaktywna wizualizacja prawa UE. Nawiguj po artykułach, motywach i załącznikach z łatwością.",
@@ -183,6 +186,33 @@
     "description": "Te motywy wydają się być powiązane z tym artykułem na podstawie analizy tekstu przy użyciu prostej AI (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">podobieństwo TF-IDF</a> (Nanda et al.)). Posortowane według wyniku istotności.",
     "match": "{score}% dopasowanie",
     "read": "Czytaj →"
+  },
+  "relatedCaseLaw": {
+    "title": "Powiązane orzecznictwo",
+    "loading": "Ładowanie",
+    "showAllJudgments": "Pokaż wszystkie {count} wyroków",
+    "noMatchPrefix": "Do tego artykułu nie przypisano jeszcze żadnego orzecznictwa. {count} {judgmentWord} ten akt prawny jako całość — otwórz",
+    "judgmentInterprets": "wyrok TSUE interpretuje",
+    "judgmentsInterpret": "wyroki TSUE interpretują",
+    "sidebarLabel": "Orzecznictwo",
+    "noMatchSuffix": "w panelu bocznym, aby zobaczyć pełną listę i podsumowanie wygenerowane przez AI."
+  },
+  "caseLawDigest": {
+    "generate": "Wygeneruj podsumowanie orzecznictwa",
+    "generating": "Generowanie podsumowania orzecznictwa",
+    "unavailable": "Podsumowanie orzecznictwa nie jest jeszcze dostępne.",
+    "generatedOn": "Statyczne podsumowanie wygenerowane {date}",
+    "fromCache": "z pamięci podręcznej"
+  },
+  "caseLawCard": {
+    "expandDecision": "Rozwiń decyzję",
+    "collapse": "Zwiń",
+    "readFullJudgment": "Przeczytaj pełny wyrok",
+    "decisionLabel": "Decyzja:",
+    "moreArticles": "+{count} więcej"
+  },
+  "caseLawModal": {
+    "showMore": "Pokaż jeszcze {count} (pozostało {remaining})"
   },
   "crossReferences": {
     "title": "Odsyłacze Wzajemne",

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -21,7 +21,10 @@
     "articles": "Artigos",
     "recitals": "Considerandos",
     "annexes": "Anexos",
-    "noSelection": "Sem seleção"
+    "noSelection": "Sem seleção",
+    "beta": "beta",
+    "ai": "IA",
+    "noneFoundSuffix": "— nenhum encontrado"
   },
   "seo": {
     "defaultDescription": "Visualização interativa da legislação da UE. Navegue nos artigos, considerandos e anexos com facilidade.",
@@ -183,6 +186,33 @@
     "description": "Estes considerandos parecem estar relacionados a este artigo com base em análise de texto usando IA simples (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">similaridade TF-IDF</a> (Nanda et al.)). Classificado por pontuação de relevância.",
     "match": "{score}% de correspondência",
     "read": "Ler →"
+  },
+  "relatedCaseLaw": {
+    "title": "Jurisprudência relacionada",
+    "loading": "A carregar",
+    "showAllJudgments": "Mostrar todos os {count} acórdãos",
+    "noMatchPrefix": "Ainda não existe jurisprudência associada a este artigo. {count} {judgmentWord} esta lei no geral — abra",
+    "judgmentInterprets": "acórdão do TJUE interpreta",
+    "judgmentsInterpret": "acórdãos do TJUE interpretam",
+    "sidebarLabel": "Jurisprudência",
+    "noMatchSuffix": "na barra lateral para a lista completa e um resumo gerado por IA."
+  },
+  "caseLawDigest": {
+    "generate": "Gerar resumo da jurisprudência",
+    "generating": "A gerar resumo da jurisprudência",
+    "unavailable": "O resumo da jurisprudência ainda não está disponível.",
+    "generatedOn": "Resumo estático gerado em {date}",
+    "fromCache": "da cache"
+  },
+  "caseLawCard": {
+    "expandDecision": "Expandir decisão",
+    "collapse": "Recolher",
+    "readFullJudgment": "Ler acórdão completo",
+    "decisionLabel": "Decisão:",
+    "moreArticles": "+{count} mais"
+  },
+  "caseLawModal": {
+    "showMore": "Mostrar mais {count} (faltam {remaining})"
   },
   "crossReferences": {
     "title": "Referências cruzadas",

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -21,7 +21,10 @@
     "articles": "Articole",
     "recitals": "Considerente",
     "annexes": "Anexe",
-    "noSelection": "Nicio selecție"
+    "noSelection": "Nicio selecție",
+    "beta": "beta",
+    "ai": "IA",
+    "noneFoundSuffix": "— niciunul găsit"
   },
   "seo": {
     "defaultDescription": "Vizualizare interactivă a legislației UE. Navigați prin articole, preambuluri și anexe cu ușurință.",
@@ -183,6 +186,33 @@
     "description": "Aceste preambuluri par să fie conectate la acest articol pe baza analizei textului folosind IA simplă (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">similaritate TF-IDF</a> (Nanda et al.)). Sortate după scor de relevanță.",
     "match": "{score}% potrivire",
     "read": "Citire →"
+  },
+  "relatedCaseLaw": {
+    "title": "Jurisprudență conexă",
+    "loading": "Se încarcă",
+    "showAllJudgments": "Afișează toate cele {count} hotărâri",
+    "noMatchPrefix": "Niciun act de jurisprudență nu este încă asociat acestui articol. {count} {judgmentWord} această lege în ansamblu — deschideți",
+    "judgmentInterprets": "hotărâre a CJUE interpretează",
+    "judgmentsInterpret": "hotărâri ale CJUE interpretează",
+    "sidebarLabel": "Jurisprudență",
+    "noMatchSuffix": "din bara laterală pentru lista completă și un rezumat generat de IA."
+  },
+  "caseLawDigest": {
+    "generate": "Generează rezumatul jurisprudenței",
+    "generating": "Se generează rezumatul jurisprudenței",
+    "unavailable": "Rezumatul jurisprudenței nu este încă disponibil.",
+    "generatedOn": "Rezumat static generat la {date}",
+    "fromCache": "din cache"
+  },
+  "caseLawCard": {
+    "expandDecision": "Extinde decizia",
+    "collapse": "Restrânge",
+    "readFullJudgment": "Citește hotărârea completă",
+    "decisionLabel": "Decizie:",
+    "moreArticles": "+{count} în plus"
+  },
+  "caseLawModal": {
+    "showMore": "Afișează încă {count} (au mai rămas {remaining})"
   },
   "crossReferences": {
     "title": "Referințe încrucișate",

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -21,7 +21,10 @@
     "articles": "Články",
     "recitals": "Odôvodnenia",
     "annexes": "Prílohy",
-    "noSelection": "Žiadny výber"
+    "noSelection": "Žiadny výber",
+    "beta": "beta",
+    "ai": "AI",
+    "noneFoundSuffix": "— žiadne nenájdené"
   },
   "seo": {
     "defaultDescription": "Interaktívna vizualizácia zákonov EÚ. Navigujte článkami, preamblami a prílohami s ľahkosťou.",
@@ -183,6 +186,33 @@
     "description": "Zdá sa, že tieto preambuly súvisia s týmto článkom na základe analýzy textu pomocou jednoduchej AI (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF podobnosť</a> (Nanda et al.)). Zoradené podľa skóre relevantnosti.",
     "match": "{score}% zhoda",
     "read": "Čítaj →"
+  },
+  "relatedCaseLaw": {
+    "title": "Súvisiaca judikatúra",
+    "loading": "Načítava sa",
+    "showAllJudgments": "Zobraziť všetkých {count} rozsudkov",
+    "noMatchPrefix": "K tomuto článku zatiaľ nie je priradená žiadna judikatúra. {count} {judgmentWord} tento právny predpis ako celok — otvorte",
+    "judgmentInterprets": "rozsudok Súdneho dvora EÚ vykladá",
+    "judgmentsInterpret": "rozsudky Súdneho dvora EÚ vykladajú",
+    "sidebarLabel": "Judikatúra",
+    "noMatchSuffix": "na bočnom paneli, kde nájdete úplný zoznam a zhrnutie vytvorené AI."
+  },
+  "caseLawDigest": {
+    "generate": "Vygenerovať zhrnutie judikatúry",
+    "generating": "Generovanie zhrnutia judikatúry",
+    "unavailable": "Zhrnutie judikatúry zatiaľ nie je k dispozícii.",
+    "generatedOn": "Statické zhrnutie vygenerované {date}",
+    "fromCache": "z vyrovnávacej pamäte"
+  },
+  "caseLawCard": {
+    "expandDecision": "Rozbaliť rozhodnutie",
+    "collapse": "Zbaliť",
+    "readFullJudgment": "Prečítať celý rozsudok",
+    "decisionLabel": "Rozhodnutie:",
+    "moreArticles": "+{count} ďalších"
+  },
+  "caseLawModal": {
+    "showMore": "Zobraziť ďalších {count} (zostáva {remaining})"
   },
   "crossReferences": {
     "title": "Skrížené Odkazy",

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -21,7 +21,10 @@
     "articles": "Členi",
     "recitals": "Uvodne izjave",
     "annexes": "Priloge",
-    "noSelection": "Ni izbire"
+    "noSelection": "Ni izbire",
+    "beta": "beta",
+    "ai": "UI",
+    "noneFoundSuffix": "— ni najdenih"
   },
   "seo": {
     "defaultDescription": "Interaktivna vizualizacija zakonodaje EU. Navigirajte po členih, preamblah in prilogah z lahkoto.",
@@ -183,6 +186,33 @@
     "description": "Zdi se, da so te preambule povezane s tem členom na podlagi analize besedila z uporabo preproste AI (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF podobnost</a> (Nanda et al.)). Razvrščeno po rezultatu relevantnosti.",
     "match": "{score}% ujemanje",
     "read": "Preberi →"
+  },
+  "relatedCaseLaw": {
+    "title": "Povezana sodna praksa",
+    "loading": "Nalaganje",
+    "showAllJudgments": "Prikaži vseh {count} sodb",
+    "noMatchPrefix": "Temu členu še ni pripisana nobena sodna praksa. {count} {judgmentWord} ta zakon kot celoto — odprite",
+    "judgmentInterprets": "sodba Sodišča EU razlaga",
+    "judgmentsInterpret": "sodbe Sodišča EU razlagajo",
+    "sidebarLabel": "Sodna praksa",
+    "noMatchSuffix": "v stranski vrstici za celoten seznam in povzetek, ki ga ustvari UI."
+  },
+  "caseLawDigest": {
+    "generate": "Ustvari povzetek sodne prakse",
+    "generating": "Ustvarjanje povzetka sodne prakse",
+    "unavailable": "Povzetek sodne prakse še ni na voljo.",
+    "generatedOn": "Statični povzetek ustvarjen {date}",
+    "fromCache": "iz predpomnilnika"
+  },
+  "caseLawCard": {
+    "expandDecision": "Razširi odločbo",
+    "collapse": "Strni",
+    "readFullJudgment": "Preberi celotno sodbo",
+    "decisionLabel": "Odločba:",
+    "moreArticles": "+{count} več"
+  },
+  "caseLawModal": {
+    "showMore": "Prikaži še {count} (preostane {remaining})"
   },
   "crossReferences": {
     "title": "Medsebojni Sklici",

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -21,7 +21,10 @@
     "articles": "Artiklar",
     "recitals": "Skäl",
     "annexes": "Bilagor",
-    "noSelection": "Inget valt"
+    "noSelection": "Inget valt",
+    "beta": "beta",
+    "ai": "AI",
+    "noneFoundSuffix": "— inga hittades"
   },
   "seo": {
     "defaultDescription": "Interaktiv visualisering av EU-lagar. Navigera enkelt genom artiklar, preambel och bilagor.",
@@ -183,6 +186,33 @@
     "description": "Denna preambel verkar vara relaterad till denna artikel baserad på textanalys med enkel AI (<a href=\"https://ebooks.iospress.nl/volumearticle/56169\" target=\"_blank\" rel=\"noopener noreferrer\">TF-IDF likhet</a> (Nanda et al.)). Sorterad efter relevanspoäng.",
     "match": "{score}% träff",
     "read": "Läs →"
+  },
+  "relatedCaseLaw": {
+    "title": "Relaterad rättspraxis",
+    "loading": "Läser in",
+    "showAllJudgments": "Visa alla {count} domar",
+    "noMatchPrefix": "Ingen rättspraxis är ännu kopplad till denna artikel. {count} {judgmentWord} denna lag som helhet — öppna",
+    "judgmentInterprets": "EU-domstolens dom tolkar",
+    "judgmentsInterpret": "EU-domstolens domar tolkar",
+    "sidebarLabel": "Rättspraxis",
+    "noMatchSuffix": "i sidopanelen för hela listan och en AI-genererad sammanfattning."
+  },
+  "caseLawDigest": {
+    "generate": "Skapa sammanfattning av rättspraxis",
+    "generating": "Skapar sammanfattning av rättspraxis",
+    "unavailable": "Sammanfattning av rättspraxis är inte tillgänglig än.",
+    "generatedOn": "Statisk sammanfattning skapad {date}",
+    "fromCache": "från cache"
+  },
+  "caseLawCard": {
+    "expandDecision": "Expandera avgörande",
+    "collapse": "Fäll ihop",
+    "readFullJudgment": "Läs hela domen",
+    "decisionLabel": "Avgörande:",
+    "moreArticles": "+{count} till"
+  },
+  "caseLawModal": {
+    "showMore": "Visa {count} till ({remaining} kvar)"
   },
   "crossReferences": {
     "title": "Korsreferenser",


### PR DESCRIPTION
## Why

[PR #60](https://github.com/maastrichtlawtech/legalviz.eu/pull/60)'s automated review flagged that `CaseLawDigest.jsx` and the `RelatedCaseLaw.jsx` sparse-article note were hardcoded English despite the components already using `t()` elsewhere. A sweep of the rest of the case-law UI turned up the same pattern in several other places that predate that PR.

## What

Extracted all remaining hardcoded English strings in the CJEU case-law feature into `t()` calls, and added the corresponding keys to every one of the 24 supported locale files:

- `src/components/CaseLawDigest.jsx` — generate button, loading/error text, "Static digest generated … from cache"
- `src/components/ArticleCaseLawDigest.jsx` — same strings (pre-existing duplication of the above)
- `src/components/RelatedCaseLaw.jsx` — "beta" badge, "Loading", the sparse-article note, generate button, "Show all N judgments", and the shared case card ("Expand decision" / "Collapse" / "Read full judgment")
- `src/components/CaseLawModal.jsx` — same shared case-card strings, "+N more" article pill, "Decision:" label, "Show N more (…)"
- `src/components/MetadataPanel.jsx` — "beta" badge and "— none found" (the latter was also generalized into a shared `common.noneFoundSuffix` key already reused by the Amendment History / Implementing Acts load buttons, which had the same issue)

New i18n keys (`common.beta`, `common.ai`, `common.noneFoundSuffix`, `relatedCaseLaw.*`, `caseLawDigest.*`, `caseLawCard.*`, `caseLawModal.*`) were translated into all 23 non-English locales, reusing each locale's existing CJEU terminology (e.g. `metadata.caseLaw`) for consistency. `relatedCaseLaw` previously only had a `title` key in `en.json` and was missing entirely from every other locale — it's now fully populated everywhere.

## Testing

- `npm run test:web` — 207 passed
- `cd backend && npm test` — 131 passed
- `npx eslint src/` — clean
- Verified in browser preview: new keys resolve correctly (e.g. "CJEU Case Law — none found" renders via the new `common.noneFoundSuffix` key), no console errors, no missing-key artifacts.
- Full end-to-end click-through of the case-law modal/digest UI wasn't possible locally (needs live network access to EUR-Lex SPARQL data), but all string extractions are behavior-preserving (same interpolation, same conditional logic) and covered by lint + unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)