### PR TITLE
Fix backend cache eviction gap, cache size ceiling, and dead subclass

### DIFF
--- a/backend/search/search-index.js
+++ b/backend/search/search-index.js
@@ -3,10 +3,8 @@ const {
   JsonLegalCacheStore,
 } = require("./legal-cache-store");
 
-class SearchIndex extends JsonLegalCacheStore {}
-
 module.exports = {
   DEFAULT_SEARCH_CACHE_PATH,
   JsonLegalCacheStore,
-  SearchIndex,
+  SearchIndex: JsonLegalCacheStore,
 };

--- a/backend/shared/fmx-service.js
+++ b/backend/shared/fmx-service.js
@@ -298,6 +298,19 @@ function createFmxService({
         file.size = buffer.length;
       }
 
+      // Safety net: the pre-download eviction pass above sizes itself from the
+      // `content-length` header, which some upstream responses omit (yielding
+      // size 0 and skipping eviction entirely). Now that files are written to
+      // disk with their real sizes, re-check the on-disk total and evict the
+      // oldest files if the cache still exceeds STORAGE_LIMIT_MB. Passing 0 as
+      // the required size means only files beyond the existing cap are
+      // evicted; sorted-by-mtime eviction order means the files just written
+      // above are newest and won't be evicted by this pass.
+      const { evicted: postWriteEvicted, freedMB: postWriteFreedMB } = evictOldestIfNeeded(0);
+      if (postWriteEvicted > 0) {
+        console.log(`[Cache] Post-download eviction removed ${postWriteEvicted} file(s), freed ${postWriteFreedMB} MB`);
+      }
+
       return { type, files: downloaded };
     })().finally(() => {
       inFlightDownloads.delete(lockKey);

--- a/backend/shared/parsed-law-service.js
+++ b/backend/shared/parsed-law-service.js
@@ -5,6 +5,11 @@ const { parseFmxXml } = require('./fmx-parser-node');
 
 const PARSED_LAW_CACHE_MS = 10 * 60 * 1000; // 10 minutes
 
+// Each entry holds a full parsed law (including rendered article/annex HTML),
+// so cap the in-memory cache well below the generic DEFAULT_CACHE_MAX_ENTRIES
+// (10,000) to keep the memory ceiling reasonable.
+const MAX_PARSED_CACHE_ENTRIES = 200;
+
 /**
  * Builds a resolver that turns a CELEX + language into the parsed "combined"
  * law structure ({ title, articles, recitals, annexes, definitions,
@@ -57,7 +62,7 @@ function createParsedLawResolver({ prepareLawPayload, fetchAndParseHtmlLaw, CELE
       ...parsed,
     };
 
-    cacheSet(parsedCache, cacheKey, result, PARSED_LAW_CACHE_MS);
+    cacheSet(parsedCache, cacheKey, result, PARSED_LAW_CACHE_MS, MAX_PARSED_CACHE_ENTRIES);
     return result;
   }
 


### PR DESCRIPTION
## Summary

Three small, targeted backend fixes:

1. **FMX cache eviction skipped when upstream omits `Content-Length`** (`backend/shared/fmx-service.js`, `downloadFmx`)
   The pre-download eviction pass sizes itself from a per-file HEAD request's `content-length` header. When that header is absent, `parseInt(...) || 0` makes the required size `0`, so `evictOldestIfNeeded` is skipped entirely and `STORAGE_LIMIT_MB` can be silently exceeded. Added a post-write safety-net pass (`evictOldestIfNeeded(0)`) that runs after files are written to disk, using their real byte sizes to evict the oldest cached files if the cap is still exceeded. The existing pre-download HEAD-based eviction is unchanged; since eviction sorts by mtime, the files just written are newest and are evicted last, so nothing from the current download is evicted prematurely.

2. **Parsed-law in-memory cache had a 10,000-entry ceiling** (`backend/shared/parsed-law-service.js`)
   `parsedCache` used `cacheSet` with no explicit `maxEntries`, falling back to `DEFAULT_CACHE_MAX_ENTRIES = 10_000` from `api-utils.js`. Each entry holds a full parsed law including rendered article/annex HTML, making that ceiling a large memory risk. Added a module-local `MAX_PARSED_CACHE_ENTRIES = 200` and passed it as the 5th argument to `cacheSet`.

3. **Dead no-op subclass** (`backend/search/search-index.js`)
   `class SearchIndex extends JsonLegalCacheStore {}` added nothing. Removed the empty subclass and instead export `SearchIndex: JsonLegalCacheStore` as an alias, preserving the public API (`new SearchIndex(...)` still works, confirmed via `backend/search/search-regression.test.js`).

## Impact
- Prevents unbounded FMX disk-cache growth when upstream responses lack `Content-Length`.
- Bounds the parsed-law in-memory cache's worst-case memory footprint.
- Removes dead code with no behavior change.

## Verification
- `cd backend && npm test` — all 135 tests pass, including `shared/parsed-law-service.test.js` and the full `search/*.test.js` suite (`search-regression.test.js` constructs `new SearchIndex(...)` and still passes).
- `npm run lint` (repo root) — clean, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)