### PR TITLE
Fix dark-mode flash and harden theme storage access

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,16 @@
     <meta name="twitter:description" content="Read EU laws like the GDPR, AI Act, DMA, DSA and Data Act with ease. Navigate articles, recitals, annexes and cross-references, side by side." />
     <meta name="twitter:image" content="https://legalviz.eu/preview.png" />
     <title>LegalViz.EU — Read EU law: GDPR, AI Act, DMA, DSA &amp; more</title>
+    <script>
+      try {
+        var storedTheme = localStorage.getItem("vite-ui-theme") || "system";
+        var resolvedTheme =
+          storedTheme === "system"
+            ? (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light")
+            : storedTheme;
+        document.documentElement.classList.add(resolvedTheme === "dark" ? "dark" : "light");
+      } catch (e) {}
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/components/ThemeProvider.jsx
+++ b/src/components/ThemeProvider.jsx
@@ -1,37 +1,56 @@
 import React, { createContext, useEffect, useState } from "react";
 
-const ThemeContext = createContext({
-    theme: "system",
-    setTheme: () => null,
-});
+const ThemeContext = createContext(null);
 
 export function ThemeProvider({ children, defaultTheme = "system", storageKey = "vite-ui-theme" }) {
     const [theme, setTheme] = useState(() => {
-        return localStorage.getItem(storageKey) || defaultTheme;
+        try {
+            return localStorage.getItem(storageKey) || defaultTheme;
+        } catch {
+            return defaultTheme;
+        }
     });
 
     useEffect(() => {
         const root = window.document.documentElement;
 
-        root.classList.remove("light", "dark");
+        const applyTheme = () => {
+            root.classList.remove("light", "dark");
 
-        if (theme === "system") {
-            const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
-                .matches
-                ? "dark"
-                : "light";
+            if (theme === "system") {
+                const systemTheme = window.matchMedia("(prefers-color-scheme: dark)")
+                    .matches
+                    ? "dark"
+                    : "light";
 
-            root.classList.add(systemTheme);
+                root.classList.add(systemTheme);
+                return;
+            }
+
+            root.classList.add(theme);
+        };
+
+        applyTheme();
+
+        if (theme !== "system") {
             return;
         }
 
-        root.classList.add(theme);
+        const media = window.matchMedia("(prefers-color-scheme: dark)");
+        media.addEventListener("change", applyTheme);
+        return () => {
+            media.removeEventListener("change", applyTheme);
+        };
     }, [theme]);
 
     const value = {
         theme,
         setTheme: (theme) => {
-            localStorage.setItem(storageKey, theme);
+            try {
+                localStorage.setItem(storageKey, theme);
+            } catch {
+                // ignore persistence failures
+            }
             setTheme(theme);
         },
     };

--- a/src/components/useTheme.js
+++ b/src/components/useTheme.js
@@ -4,7 +4,7 @@ import { ThemeContext } from "./ThemeProvider.jsx";
 export function useTheme() {
   const context = useContext(ThemeContext);
 
-  if (context === undefined) {
+  if (context === null) {
     throw new Error("useTheme must be used within a ThemeProvider");
   }
 


### PR DESCRIPTION
## Summary
- Add an inline pre-paint `<script>` in the `<head>` of `index.html` (before the module script) that reads `localStorage.getItem("vite-ui-theme")`, resolves `system` via `matchMedia("(prefers-color-scheme: dark)")`, and adds the matching `light`/`dark` class to `document.documentElement` — eliminating the dark-mode flash of unstyled content (FOUC) on cold load. It uses the exact same storage key and class names as `ThemeProvider`, and is wrapped in try/catch so it can never throw.
- Wrap the `localStorage.getItem`/`setItem` calls in `ThemeProvider.jsx` in try/catch (mirroring the existing pattern in `src/i18n/I18nProvider.jsx` and `src/components/LawViewer.jsx`), falling back to `defaultTheme` on read failure and silently ignoring write failures, so blocked storage (e.g. private browsing) no longer crashes the app during render.
- When `theme === "system"`, subscribe to `matchMedia("(prefers-color-scheme: dark)")` `change` events and re-apply the resolved class live, cleaning up the listener on unmount / theme change, so an OS-level theme switch is now reflected immediately instead of only after a reload.
- Fix the dead guard in `useTheme.js`: `ThemeContext`'s default value is now `null` (was a stub object), and `useTheme` checks `context === null` instead of the always-false `context === undefined`, so the "must be used within a ThemeProvider" error actually fires.

## Test plan
- [x] `npm run lint` passes
- [x] `npx vitest run` passes (207 tests, 17 files)
- [x] Manually re-read the inline script in `index.html` to confirm it's wrapped in try/catch and uses the same `vite-ui-theme` key / `light`/`dark` class names as `ThemeProvider.jsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)