### PR TITLE
Fix HTML-fallback content being cached and labeled under the wrong language

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -107,19 +107,26 @@ function hasParsedLawContent(parsed) {
   );
 }
 
+// fetchEurlexHtmlLaw always fetches the English EUR-Lex HTML page regardless of the
+// requested language (see shared/eurlex-html-parser.js). Cache lookups/writes must key
+// on the language actually served, not the requested one, so we don't store identical
+// English HTML redundantly under every language code or mislabel it as translated.
+const HTML_FALLBACK_SERVED_LANG = 'ENG';
+
 /**
  * On-demand HTML law fetcher with disk caching.
  *
  * Caches raw HTML so parser improvements apply without re-fetching.
  * Parses on each request (JSDOM is fast; the network/Playwright fetch is the bottleneck).
  *
- * 1. Check disk cache for raw HTML
+ * 1. Check disk cache for raw HTML (keyed by the language actually served, always English)
  * 2. If miss, fetch from EUR-Lex (plain fetch first, Playwright on WAF challenge)
- * 3. Store raw HTML to disk cache
- * 4. Parse and return
+ * 3. Store raw HTML to disk cache (same served-language key)
+ * 4. Parse and return, including the requested `lang` and the honest `servedLang`
  */
 async function fetchAndParseHtmlLawCached(celex, lang) {
-  let rawHtml = await htmlCache.get(celex, lang);
+  let servedLang = HTML_FALLBACK_SERVED_LANG;
+  let rawHtml = await htmlCache.get(celex, servedLang);
   let fromCache = Boolean(rawHtml);
 
   async function fetchFreshHtml() {
@@ -131,6 +138,7 @@ async function fetchAndParseHtmlLawCached(celex, lang) {
       usePlaywrightOnChallenge: true,
       closeBrowserAfterFetch: true,
     });
+    servedLang = fetched.servedLang || HTML_FALLBACK_SERVED_LANG;
     return fetched.rawHtml;
   }
 
@@ -141,29 +149,30 @@ async function fetchAndParseHtmlLawCached(celex, lang) {
 
   let parsed;
   try {
-    parsed = await parseEurlexHtmlToCombined(rawHtml, lang);
+    parsed = await parseEurlexHtmlToCombined(rawHtml, servedLang);
   } catch (err) {
     if (fromCache && err?.code === 'law_not_found') {
-      htmlCache.remove(celex, lang);
+      htmlCache.remove(celex, servedLang);
       rawHtml = await fetchFreshHtml();
       fromCache = false;
-      parsed = await parseEurlexHtmlToCombined(rawHtml, lang);
+      parsed = await parseEurlexHtmlToCombined(rawHtml, servedLang);
     } else {
       throw err;
     }
   }
 
   if (!fromCache && hasParsedLawContent(parsed)) {
-    htmlCache.put(celex, lang, rawHtml).catch((err) => {
-      console.error(`[HtmlCache] Failed to cache ${celex}_${lang}:`, err.message);
+    htmlCache.put(celex, servedLang, rawHtml).catch((err) => {
+      console.error(`[HtmlCache] Failed to cache ${celex}_${servedLang}:`, err.message);
     });
   } else if (!fromCache) {
-    console.warn(`[HtmlCache] Skipping cache for ${celex}_${lang}: parsed HTML did not yield law content`);
+    console.warn(`[HtmlCache] Skipping cache for ${celex}_${servedLang}: parsed HTML did not yield law content`);
   }
 
   return {
     celex,
     lang,
+    servedLang,
     source: 'eurlex-html',
     format: 'combined-v1',
     ...parsed,

--- a/backend/shared/parsed-law-service.test.js
+++ b/backend/shared/parsed-law-service.test.js
@@ -27,3 +27,28 @@ test('resolveParsedLaw uses the HTML fallback path when skipFmxProbe is set and 
   await resolveParsedLaw('32016R0679', 'FRA', { skipFmxProbe: true });
   assert.equal(htmlCalls, 2);
 });
+
+test('resolveParsedLaw propagates servedLang from the HTML fallback without overriding the requested lang', async () => {
+  // Simulates the real fetchAndParseHtmlLawCached in server.js, which always serves
+  // English HTML (servedLang) even when a different language was requested (lang),
+  // so callers can tell the two apart instead of the content being silently mislabeled.
+  const resolveParsedLaw = createParsedLawResolver({
+    prepareLawPayload: async () => { throw new Error('prepareLawPayload should not be called'); },
+    fetchAndParseHtmlLaw: async (celex, lang) => ({
+      celex,
+      lang,
+      servedLang: 'ENG',
+      source: 'eurlex-html',
+      title: `Law ${celex}`,
+      articles: [],
+      recitals: [],
+      annexes: [],
+      definitions: [],
+      crossReferences: {},
+    }),
+  });
+
+  const result = await resolveParsedLaw('32016R0679', 'FRA', { skipFmxProbe: true });
+  assert.equal(result.lang, 'FRA', 'top-level lang should stay the requested language for routing/URL state');
+  assert.equal(result.servedLang, 'ENG', 'servedLang should surface the language actually served');
+});


### PR DESCRIPTION
## The bug

When a law has no Formex (FMX) data, the backend falls back to fetching EUR-Lex HTML. `fetchEurlexHtmlLaw` in `backend/shared/eurlex-html-parser.js` always fetches the **English** page (`servedLang = "ENG"`), regardless of the requested language — this is intentional and already correctly reported via `requestedLang`/`servedLang` fields on its return value (see `shared/eurlex-html-parser.test.js`).

The bug was one layer up: `fetchAndParseHtmlLawCached` in `backend/server.js` ignored that and:
- looked up/stored the raw HTML disk cache keyed on the **requested** `lang` (`htmlCache.get/put(celex, lang, ...)`), and
- parsed the (English) HTML while telling the parser it was in the requested language (`parseEurlexHtmlToCombined(rawHtml, lang)`).

Net effect: a French/German/etc. request for a law without FMX returned English content that was presented and cached as if it were in the requested language, and the same English HTML got redundantly stored on disk under every language code that was ever requested for that CELEX.

## The fix

Minimal, labeling/caching-only change in `backend/server.js`:
- `fetchAndParseHtmlLawCached` now keys every `htmlCache.get`/`put`/`remove` call on the language actually served (`servedLang`, sourced from `fetchEurlexHtmlLaw`'s return value, always `"ENG"` today) instead of the requested `lang`.
- The returned payload now includes an explicit `servedLang: 'ENG'` field alongside the existing `source: 'eurlex-html'`.
- The top-level `lang` field is **unchanged** — it still reflects the requested language, since `backend/shared/parsed-law-service.js` (`resolveParsedLaw`) uses it for routing/URL state. `servedLang` flows through automatically because `resolveParsedLaw` spreads the parsed object into its result.

No changes to `eurlex-html-parser.js` — the "always English" fetch behavior there was already correct and already tested; only the caching/labeling layer in `server.js` needed fixing.

## ⚠️ Flagging for maintainer review

This PR does **not** change the underlying behavior: when FMX is unavailable, the app still serves **English content for every requested language**. It only makes that fact explicit (`servedLang`) instead of silently mislabeling the content as the requested language. Whether/how to surface `servedLang` in the frontend UI (e.g. a "shown in English" notice) is a product decision left for a follow-up — out of scope here per the task.

## Verification

- `cd backend && npm test` — all 136 tests pass, including a new regression test in `shared/parsed-law-service.test.js` asserting that `servedLang` propagates through `resolveParsedLaw` while the requested `lang` is preserved.
- `npm run lint` (repo root) — clean, no errors/warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)