### PR TITLE
Fix: search modal can't be closed by clicking the backdrop

### DIFF
--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -687,8 +687,14 @@ export function SearchBox({
 
       {/* Spotlight Modal Overlay (Rendered in Portal to cover whole screen) */}
       {isOpen && createPortal(
-        <div className="fixed inset-0 z-[100] flex items-start justify-center bg-black/20 transition-all md:p-4 md:pt-[15vh]">
+        <div
+          className="fixed inset-0 z-[100] flex items-start justify-center bg-black/20 transition-all md:p-4 md:pt-[15vh]"
+          onClick={() => setIsOpen(false)}
+        >
           <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={t("search.trigger")}
             className="w-full max-w-2xl flex flex-col h-full md:h-auto md:max-h-[70vh] bg-white shadow-2xl ring-1 ring-black/5 animate-in fade-in zoom-in-95 duration-100 overflow-hidden fixed inset-0 md:static md:inset-auto md:rounded-2xl dark:bg-gray-900 dark:ring-white/10"
             onClick={(e) => e.stopPropagation()}
           >
@@ -956,9 +962,6 @@ export function SearchBox({
               <span>{t("search.escToClose")}</span>
             </div>
           </div>
-
-          {/* Click backdrop to close */}
-          <div className="absolute inset-0 -z-10" />
         </div>,
         document.body
       )}


### PR DESCRIPTION
## Bug

In `src/components/TopBar.jsx`, the spotlight search modal's outer overlay `<div className="fixed inset-0 z-[100] ...">` had no `onClick` handler, while the inner content panel called `e.stopPropagation()` — dead code, since there was no parent handler for it to stop propagation to. A trailing `{/* Click backdrop to close */}` comment plus `<div className="absolute inset-0 -z-10" />` was also dead code with no click handler wired up.

As a result, the modal could only be dismissed via Escape, the "Close" button, or by selecting a result — clicking the backdrop did nothing, which is inconsistent with the app's other two modals (`AddLawDialog.jsx`, `CaseLawModal.jsx`), both of which correctly implement click-outside-to-close.

## Fix

- Added `onClick={() => setIsOpen(false)}` to the outer overlay div, so clicking the backdrop closes the modal. The inner panel's `onClick={(e) => e.stopPropagation()}` is kept so clicks inside the panel don't bubble up and close it.
- Removed the now-redundant dead comment and `<div className="absolute inset-0 -z-10" />`.
- Added dialog a11y semantics to the inner panel (`role="dialog"`, `aria-modal="true"`, `aria-label={t("search.trigger")}`) to match the pattern used in `AddLawDialog.jsx` and `CaseLawModal.jsx`. Reused the existing `search.trigger` i18n key rather than adding a new one.

Escape and Ctrl+K handlers, and the mobile full-screen layout, are unchanged.

## Test plan
- [x] `npm run lint` passes
- [x] `npx vitest run` passes (207 tests, 17 files)
- [x] Manually reasoned through backdrop click bubbling vs. panel `stopPropagation` and mobile layout (panel is `fixed inset-0` on mobile, matching prior behavior where only Escape/back-button/Close closes it there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)