### PR TITLE
Make recital→article matching language-aware

### DIFF
--- a/src/components/PrintView.jsx
+++ b/src/components/PrintView.jsx
@@ -13,8 +13,8 @@ export function PrintView({ data, options, uiLocale = "en", labels }) {
   // Compute related recitals if needed.
   const relatedRecitalsMap = useMemo(() => {
     if (!includeRelatedRecitals || !articles || !recitals) return new Map();
-    return mapRecitalsToArticles(recitals, articles);
-  }, [includeRelatedRecitals, articles, recitals]);
+    return mapRecitalsToArticles(recitals, articles, data?.langCode);
+  }, [includeRelatedRecitals, articles, recitals, data]);
 
   if (!data) return null;
 

--- a/src/hooks/law-viewer/useRecitalMap.js
+++ b/src/hooks/law-viewer/useRecitalMap.js
@@ -44,7 +44,7 @@ export function useRecitalMap({ data, currentLaw, formexLang }) {
       }
 
       const timer = setTimeout(() => {
-        const map = mapRecitalsToArticles(data.recitals, data.articles);
+        const map = mapRecitalsToArticles(data.recitals, data.articles, data.langCode);
         setRecitalMap(withOrphanRecitals(map));
 
         if (!cacheKey) return;
@@ -60,7 +60,7 @@ export function useRecitalMap({ data, currentLaw, formexLang }) {
 
     setRecitalMap(withOrphanRecitals(new Map()));
     return undefined;
-  }, [currentLaw, data.articles, data.recitals, formexLang]);
+  }, [currentLaw, data.articles, data.recitals, data.langCode, formexLang]);
 
   return recitalMap;
 }

--- a/src/utils/nlp.js
+++ b/src/utils/nlp.js
@@ -1,5 +1,5 @@
 // NLP Algorithm Version - bump this when algorithm changes to invalidate cache
-export const NLP_VERSION = 13;
+export const NLP_VERSION = 14;
 
 const MONOTONICITY_BETA = 0.9;
 const MONOTONICITY_GAMMA = 2;
@@ -125,18 +125,19 @@ const stripTags = (html) => {
  * 
  * @param {Array} recitals - Array of { recital_number, recital_text, ... }
  * @param {Array} articles - Array of { article_number, article_title, article_html, ... }
+ * @param {string} [langCode] - Optional language code (e.g. "PL") for language-specific stop words
  * @returns {Map} - Map where key is article_number, value is array of matching recitals.
  *                  Unmapped recital numbers are exposed under the reserved null key.
  */
-export function mapRecitalsToArticles(recitals, articles) {
+export function mapRecitalsToArticles(recitals, articles, langCode) {
   // Configuration
   const TITLE_WEIGHT = 3; // How many times to repeat title tokens for weighting
 
   // 1. Prepare Article Documents (Corpus)
   // Weight article titles more heavily by repeating their tokens
   const articleDocs = articles.map(a => {
-    const titleTokens = tokenize(a.article_title || "");
-    const bodyTokens = tokenize(stripTags(a.article_html));
+    const titleTokens = tokenize(a.article_title || "", langCode);
+    const bodyTokens = tokenize(stripTags(a.article_html), langCode);
     // Repeat title tokens for increased weight
     const weightedTitleTokens = [];
     for (let i = 0; i < TITLE_WEIGHT; i++) {
@@ -168,7 +169,7 @@ export function mapRecitalsToArticles(recitals, articles) {
   // 4. Process Recitals
   recitals.forEach((r, recitalIndex) => {
     const recitalText = r.recital_text || stripTags(r.recital_html) || "";
-    const tokens = tokenize(recitalText);
+    const tokens = tokenize(recitalText, langCode);
     const recitalVec = computeTFIDFVector(tokens, idf);
 
     // Extract top keywords based on TF-IDF scores

--- a/src/utils/nlp.test.js
+++ b/src/utils/nlp.test.js
@@ -173,6 +173,28 @@ describe("mapRecitalsToArticles", () => {
       }
     }
   });
+
+  it("honours an optional langCode by using language-specific stop words", () => {
+    // "der" and "verordnung" are German stop words but not English ones, so
+    // without a langCode they still count as matching evidence between the
+    // recital and article 1, while passing "DE" filters them out entirely
+    // (leaving no tokens to match on) and the recital becomes an orphan.
+    const deArticles = [
+      { article_number: "1", article_title: "", article_html: "<p>der verordnung</p>" },
+      { article_number: "2", article_title: "", article_html: "<p>fillertwo fillertwo</p>" },
+    ];
+    const deRecitals = [
+      { recital_number: "1", recital_text: "der verordnung" },
+    ];
+
+    const defaultResult = mapRecitalsToArticles(deRecitals, deArticles);
+    expect(defaultResult.get("1").map((r) => r.recital_number)).toContain("1");
+    expect(defaultResult.get(null)).toEqual([]);
+
+    const deResult = mapRecitalsToArticles(deRecitals, deArticles, "DE");
+    expect(deResult.get("1")).toHaveLength(0);
+    expect(deResult.get(null)).toEqual(["1"]);
+  });
 });
 
 describe("buildSearchIndex + searchIndex", () => {


### PR DESCRIPTION
## Summary
- `mapRecitalsToArticles(recitals, articles)` in `src/utils/nlp.js` always tokenized article titles, article bodies, and recital text with **English** stop words (via the module's `tokenize()` helper), regardless of the law's actual language — degrading TF-IDF match quality for German, Polish, and other non-English laws. The sibling function `buildSearchIndex` in the same file already threads `langCode` into its `tokenize` calls; `mapRecitalsToArticles` did not.
- Added an optional third parameter `langCode` to `mapRecitalsToArticles(recitals, articles, langCode)` and passed it into every `tokenize(...)` call inside that function (weighted article title tokens, article body tokens, and recital text tokens). Omitting the parameter preserves today's English-only behavior, so this is backward compatible.
- Bumped `NLP_VERSION` (13 → 14) in `nlp.js` since the recital→article cache is keyed on it, invalidating stale per-law caches computed with the old, language-blind algorithm.
- Wired the law's content language through at both call sites:
  - `src/hooks/law-viewer/useRecitalMap.js`: `mapRecitalsToArticles(data.recitals, data.articles, data.langCode)` (its localStorage cache key already includes `formexLang`, so no cache-key change was needed — also added `data.langCode` to the effect's dependency array to satisfy `react-hooks/exhaustive-deps`).
  - `src/components/PrintView.jsx`: passes `data?.langCode` as the third arg inside the `relatedRecitalsMap` `useMemo`, and adds `data` to its dependency array so it recomputes correctly.
- Extended `src/utils/nlp.test.js` with a test asserting the `langCode` parameter is honored: German stop words ("der", "verordnung") are retained (and match) under the default English tokenizer, but filtered out entirely (leaving the recital an orphan) when `"DE"` is passed.

## Test plan
- [x] `npm run lint` passes with no errors or warnings
- [x] `npx vitest run src/utils/nlp.test.js` passes (22/22)
- [x] `npx vitest run` full suite passes (208/208)

🤖 Generated with [Claude Code](https://claude.com/claude-code)