### PR TITLE
Harden backend API routes: constant-time analytics token check + fail-fast AI endpoints

### DIFF
--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -1,3 +1,4 @@
+const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 
@@ -101,8 +102,12 @@ function registerApiRoutes(app, deps) {
   app.get('/api/_stats', rateLimitMiddleware, (req, res) => {
     const token = process.env.ANALYTICS_TOKEN;
     if (!token) return res.status(404).json({ error: 'Not found' });
-    const provided = req.headers['x-analytics-token'] || req.query.token;
-    if (provided !== token) return res.status(401).json({ error: 'Unauthorized' });
+    const provided = String(req.headers['x-analytics-token'] || '');
+    const tokenBuf = Buffer.from(token);
+    const providedBuf = Buffer.from(provided);
+    if (providedBuf.length !== tokenBuf.length || !crypto.timingSafeEqual(providedBuf, tokenBuf)) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
     res.json(analytics.getStats());
   });
 
@@ -390,12 +395,17 @@ function registerApiRoutes(app, deps) {
       // parameter is ignored so other languages cannot trigger generation.
       const lang = 'ENG';
 
+      const apiKey = getStaticSummaryApiKey();
+      if (!apiKey) {
+        return res.status(503).json({ error: 'OpenRouter API key is not configured', code: 'openrouter_unconfigured' });
+      }
+
       const skipFmxProbe = req.query.skipFmxProbe === '1';
       const result = await ensureLawSummary({
         celex,
         lang,
         cacheDir: FMX_DIR,
-        apiKey: getStaticSummaryApiKey(),
+        apiKey,
         model: DEFAULT_STATIC_SUMMARY_MODEL,
         // Resolve the raw FMX source without parsing it, so the summary
         // service can validate its cache against the raw bytes and skip the
@@ -466,6 +476,11 @@ function registerApiRoutes(app, deps) {
         return res.status(400).json({ error: `Invalid language code: ${rawLang}` });
       }
 
+      const apiKey = getStaticSummaryApiKey();
+      if (!apiKey) {
+        return res.status(503).json({ error: 'OpenRouter API key is not configured', code: 'openrouter_unconfigured' });
+      }
+
       const parsed = await resolveParsedLaw(celex, lang, { skipFmxProbe: req.query.skipFmxProbe === '1' });
       const caseLawPayload = await fetchCaseLaw(celex, runSparqlQuery, { cacheDir: FMX_DIR });
       const result = await ensureArticleDigest({
@@ -475,7 +490,7 @@ function registerApiRoutes(app, deps) {
         parsedLaw: parsed,
         caseLawPayload,
         cacheDir: FMX_DIR,
-        apiKey: getStaticSummaryApiKey(),
+        apiKey,
         model: DEFAULT_ARTICLE_DIGEST_MODEL,
       });
 
@@ -514,6 +529,11 @@ function registerApiRoutes(app, deps) {
         return res.status(400).json({ error: `Invalid language code: ${rawLang}` });
       }
 
+      const apiKey = getStaticSummaryApiKey();
+      if (!apiKey) {
+        return res.status(503).json({ error: 'OpenRouter API key is not configured', code: 'openrouter_unconfigured' });
+      }
+
       const parsed = await resolveParsedLaw(celex, lang, { skipFmxProbe: req.query.skipFmxProbe === '1' });
       const caseLawPayload = await fetchCaseLaw(celex, runSparqlQuery, { cacheDir: FMX_DIR });
       const result = await ensureCaseLawDigest({
@@ -522,7 +542,7 @@ function registerApiRoutes(app, deps) {
         parsedLaw: parsed,
         caseLawPayload,
         cacheDir: FMX_DIR,
-        apiKey: getStaticSummaryApiKey(),
+        apiKey,
         model: DEFAULT_CASE_LAW_DIGEST_MODEL,
       });
 

--- a/backend/routes/api-routes.test.js
+++ b/backend/routes/api-routes.test.js
@@ -361,20 +361,17 @@ test("AI-backed static routes require their own OpenRouter key or the shared fal
   });
 
   await withOpenRouterEnv({ RECITAL_TITLE_OPENROUTER_API_KEY: "title-key" }, async () => {
+    // The recital-titles-only key does not grant access to the summary
+    // endpoint, which requires its own key or the shared OPENROUTER_API_KEY
+    // fallback. The summary handler now checks this before doing any
+    // expensive work (resolving/parsing the law), so this should fail fast
+    // with openrouter_unconfigured rather than reaching resolveParsedLaw.
+    let resolveParsedLawCalled = false;
     const { app } = registerTestRoutes({
-      fetchAndParseHtmlLaw: async (celex, lang) => ({
-        celex,
-        lang,
-        source: "eurlex-html",
-        format: "combined-v1",
-        title: "Regulation (EU) 2016/679",
-        langCode: "EN",
-        articles: [{ article_number: "1", article_title: "Subject matter", article_html: "<p>This Regulation lays down rules.</p>", division: { chapter: { title: "General provisions" } } }],
-        recitals: [{ recital_number: "1", recital_text: "Protection of natural persons.", recital_html: "<p>Protection of natural persons.</p>" }],
-        annexes: [],
-        definitions: [],
-        crossReferences: {},
-      }),
+      resolveParsedLaw: async () => {
+        resolveParsedLawCalled = true;
+        throw new Error("resolveParsedLaw should not be called without an API key");
+      },
     });
     const handler = app.routes.get("/api/laws/:celex/summary");
     const res = createResponseRecorder();
@@ -385,8 +382,9 @@ test("AI-backed static routes require their own OpenRouter key or the shared fal
     }, res);
 
     assert.equal(res.statusCode, 503);
-    assert.equal(res.payload.code, "missing_api_key");
-    assert.match(res.payload.message, /OPENROUTER_API_KEY/);
+    assert.equal(res.payload.code, "openrouter_unconfigured");
+    assert.match(res.payload.error, /OpenRouter API key/);
+    assert.equal(resolveParsedLawCalled, false);
   });
 });
 
@@ -401,8 +399,14 @@ test("AI-backed static routes require their own OpenRouter key or the shared fal
 // identifier that was never in scope in api-routes.js (it's only wired into
 // server.js's resolveParsedLaw), so the guard was always false and HTML-only
 // laws got a re-thrown 404 instead of falling back to HTML parsing.
+// A dummy API key is supplied in these two tests so the route's early
+// "no API key configured" fast-fail guard (see below) does not short-circuit
+// before getSource/getParsedLaw run. global.fetch is stubbed to fail
+// synchronously (no real network call) once the pipeline reaches the actual
+// chat call, so a successful fetch invocation is itself proof that
+// getSource()/getParsedLaw() completed without error.
 test("GET /api/laws/:celex/summary drives the real getSource/getParsedLaw closures for an FMX law", async () => {
-  await withOpenRouterEnv({}, async () => {
+  await withOpenRouterEnv({ LAW_SUMMARY_OPENROUTER_API_KEY: "test-key" }, async () => {
     const gdprXml = fs.readFileSync(gdprFmxPath, "utf8");
     const { app } = registerTestRoutes({
       prepareLawPayload: async () => ({ servePath: gdprFmxPath }),
@@ -410,24 +414,34 @@ test("GET /api/laws/:celex/summary drives the real getSource/getParsedLaw closur
     const handler = app.routes.get("/api/laws/:celex/summary");
     const res = createResponseRecorder();
 
-    await handler({
-      params: { celex: "32016R0679" },
-      query: { lang: "ENG" },
-    }, res);
+    let fetchCalled = false;
+    const originalFetch = global.fetch;
+    global.fetch = async () => {
+      fetchCalled = true;
+      throw new Error("network disabled in test");
+    };
 
-    // No OpenRouter key is configured, so the request should fail with the
-    // handled 503/missing_api_key error from the chat call -- proving
-    // getSource() read the fixture and getParsedLaw() successfully parsed it
-    // with parseFmxXml (a ReferenceError there would surface as an unhandled
-    // 500 with no `code`, and gdprXml would never have been read at all).
+    try {
+      await handler({
+        params: { celex: "32016R0679" },
+        query: { lang: "ENG" },
+      }, res);
+    } finally {
+      global.fetch = originalFetch;
+    }
+
+    // Reaching the (stubbed) chat call proves getSource() read the fixture
+    // and getParsedLaw() successfully parsed it with parseFmxXml (a
+    // ReferenceError there would surface before fetch is ever called, and
+    // gdprXml would never have been read at all).
     assert.ok(gdprXml.length > 0);
-    assert.equal(res.statusCode, 503);
-    assert.equal(res.payload.code, "missing_api_key");
+    assert.ok(fetchCalled, "Expected the summary pipeline to reach the chat call");
+    assert.equal(res.statusCode, 500);
   });
 });
 
 test("GET /api/laws/:celex/summary falls back to HTML parsing when FMX is unavailable for a law", async () => {
-  await withOpenRouterEnv({}, async () => {
+  await withOpenRouterEnv({ LAW_SUMMARY_OPENROUTER_API_KEY: "test-key" }, async () => {
     const { app } = registerTestRoutes({
       prepareLawPayload: async () => {
         throw new ClientError("FMX not found", 404, "fmx_not_found");
@@ -449,18 +463,106 @@ test("GET /api/laws/:celex/summary falls back to HTML parsing when FMX is unavai
     const handler = app.routes.get("/api/laws/:celex/summary");
     const res = createResponseRecorder();
 
-    await handler({
-      params: { celex: "32016R0679" },
-      query: { lang: "ENG" },
-    }, res);
+    let fetchCalled = false;
+    const originalFetch = global.fetch;
+    global.fetch = async () => {
+      fetchCalled = true;
+      throw new Error("network disabled in test");
+    };
+
+    try {
+      await handler({
+        params: { celex: "32016R0679" },
+        query: { lang: "ENG" },
+      }, res);
+    } finally {
+      global.fetch = originalFetch;
+    }
 
     // With the guard bug, getSource() re-throws the 404 from
     // prepareLawPayload instead of swallowing it, so the handler would
     // respond 404 here instead of falling through to the HTML parse and
-    // reaching the (also handled) missing-API-key error.
-    assert.equal(res.statusCode, 503);
-    assert.equal(res.payload.code, "missing_api_key");
+    // reaching the (stubbed) chat call.
+    assert.ok(fetchCalled, "Expected the summary pipeline to fall through to HTML parsing and reach the chat call");
+    assert.equal(res.statusCode, 500);
   });
+});
+
+test("Case-law-digest routes fail fast without an OpenRouter key, before resolving/parsing the law", async () => {
+  await withOpenRouterEnv({}, async () => {
+    let resolveParsedLawCalled = false;
+    const { app } = registerTestRoutes({
+      resolveParsedLaw: async () => {
+        resolveParsedLawCalled = true;
+        throw new Error("resolveParsedLaw should not be called without an API key");
+      },
+    });
+
+    const articleHandler = app.routes.get("/api/laws/:celex/articles/:n/case-law-digest");
+    const articleRes = createResponseRecorder();
+    await articleHandler({
+      params: { celex: "32016R0679", n: "5" },
+      query: { lang: "ENG" },
+    }, articleRes);
+
+    assert.equal(articleRes.statusCode, 503);
+    assert.equal(articleRes.payload.code, "openrouter_unconfigured");
+    assert.equal(resolveParsedLawCalled, false);
+
+    const digestHandler = app.routes.get("/api/laws/:celex/case-law-digest");
+    const digestRes = createResponseRecorder();
+    await digestHandler({
+      params: { celex: "32016R0679" },
+      query: { lang: "ENG" },
+    }, digestRes);
+
+    assert.equal(digestRes.statusCode, 503);
+    assert.equal(digestRes.payload.code, "openrouter_unconfigured");
+    assert.equal(resolveParsedLawCalled, false);
+  });
+});
+
+test("GET /api/_stats requires the header token and rejects the query-param form", async () => {
+  const previousToken = process.env.ANALYTICS_TOKEN;
+  try {
+    delete process.env.ANALYTICS_TOKEN;
+    const { app: appWithoutToken } = registerTestRoutes();
+    const noTokenHandler = appWithoutToken.routes.get("/api/_stats");
+    const noTokenRes = createResponseRecorder();
+    await noTokenHandler({ headers: {}, query: {} }, noTokenRes);
+    assert.equal(noTokenRes.statusCode, 404);
+
+    process.env.ANALYTICS_TOKEN = "secret-token";
+    const { app } = registerTestRoutes({
+      analytics: { getStats: () => ({ ok: true }) },
+    });
+    const handler = app.routes.get("/api/_stats");
+
+    const missingHeaderRes = createResponseRecorder();
+    await handler({ headers: {}, query: {} }, missingHeaderRes);
+    assert.equal(missingHeaderRes.statusCode, 401);
+
+    // The query-param fallback must no longer grant access, even though the
+    // token value is correct, since it leaks into access/proxy logs.
+    const queryParamRes = createResponseRecorder();
+    await handler({ headers: {}, query: { token: "secret-token" } }, queryParamRes);
+    assert.equal(queryParamRes.statusCode, 401);
+
+    const wrongHeaderRes = createResponseRecorder();
+    await handler({ headers: { "x-analytics-token": "wrong-token" }, query: {} }, wrongHeaderRes);
+    assert.equal(wrongHeaderRes.statusCode, 401);
+
+    const okRes = createResponseRecorder();
+    await handler({ headers: { "x-analytics-token": "secret-token" }, query: {} }, okRes);
+    assert.equal(okRes.statusCode, 200);
+    assert.deepEqual(okRes.payload, { ok: true });
+  } finally {
+    if (previousToken === undefined) {
+      delete process.env.ANALYTICS_TOKEN;
+    } else {
+      process.env.ANALYTICS_TOKEN = previousToken;
+    }
+  }
 });
 
 test("GET /api/resolve-url returns cache-backed ELI resolution", async () => {


### PR DESCRIPTION
## Summary

Two targeted hardening fixes in `backend/routes/api-routes.js`:

**1. `/api/_stats` token check**
- The analytics token was compared with `!==` (not constant-time, vulnerable to timing side-channels) and accepted via `req.query.token` in addition to a header, which leaks the token into access logs and any intermediate proxy logs.
- Fix: accept the token only via the `x-analytics-token` header, and compare it using `crypto.timingSafeEqual` (with a length check first, since `timingSafeEqual` throws on length mismatch).
- Behavior preserved: 404 `{ error: 'Not found' }` when `ANALYTICS_TOKEN` is unset; 401 `{ error: 'Unauthorized' }` on mismatch/missing header; otherwise `analytics.getStats()`.

**2. AI endpoints did expensive work before checking for an API key**
- `/api/laws/:celex/summary`, `/api/laws/:celex/case-law-digest`, and `/api/laws/:celex/articles/:n/case-law-digest` called `resolveParsedLaw(...)` (which can trigger a ~30s EUR-Lex/Playwright fetch) *before* discovering no OpenRouter key was configured. `/api/laws/:celex/recital-titles` already had this guard.
- Fix: each handler now resolves the API key and returns `503 { error: 'OpenRouter API key is not configured', code: 'openrouter_unconfigured' }` immediately after CELEX/lang validation, before calling `resolveParsedLaw`. The same resolved key is reused when calling the downstream `ensure...()` helper instead of re-reading it from the environment.

## Impact

- Analytics token can no longer be exfiltrated via query-string logging, and comparison is timing-attack resistant.
- Unconfigured-key requests to the three AI digest/summary endpoints now fail in milliseconds instead of after a ~30s upstream fetch attempt, avoiding wasted worker/Playwright time and giving callers a faster, clearer error.

## Verification

- `cd backend && npm test` — all 137 tests pass, including:
  - A new `GET /api/_stats requires the header token and rejects the query-param form` test covering the 404/401/200 paths and confirming the query-param token is rejected.
  - A new `Case-law-digest routes fail fast without an OpenRouter key` test asserting `resolveParsedLaw` is never invoked when no key is configured.
  - Updated the existing summary-route regression tests (`drives the real getSource/getParsedLaw closures...`, `falls back to HTML parsing...`) to supply a dummy API key and stub `global.fetch` so they still exercise the real `getSource`/`getParsedLaw`/`parseFmxXml` code paths despite the new earlier guard.
- `npm run lint` (repo root) — clean, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)