### PR TITLE
Harden EUR-Lex host check and fix definition stem over-matching

### DIFF
--- a/src/hooks/useAddLawImport.js
+++ b/src/hooks/useAddLawImport.js
@@ -87,7 +87,9 @@ export function useAddLawImport({ locale, navigate, t }) {
       return;
     }
 
-    if (!parsedUrl.hostname.includes("eur-lex.europa.eu")) {
+    const host = parsedUrl.hostname.toLowerCase();
+    const isEurlexHost = host === "eur-lex.europa.eu" || host.endsWith(".eur-lex.europa.eu");
+    if (!isEurlexHost) {
       setEurlexError(t("landing.invalidEurlexUrl"));
       return;
     }

--- a/src/utils/definitions.js
+++ b/src/utils/definitions.js
@@ -74,7 +74,7 @@ export function injectDefinitionTooltips(html, definitions, options = {}) {
         // Create a regex that matches the term (with optional inflection for Polish)
         // But NOT inside HTML tags or already-wrapped spans
         const pattern = useInflection
-            ? buildStemPattern(term)
+            ? `(?<![\\w-])${buildStemPattern(term)}`
             : `(?<![\\w-])${escapeRegex(term)}(?![\\w-])`;
         const termPattern = new RegExp(pattern, 'gi');
 

--- a/src/utils/definitions.test.js
+++ b/src/utils/definitions.test.js
@@ -84,6 +84,20 @@ describe("injectDefinitionTooltips", () => {
     expect(result).toContain('class="defined-term"');
   });
 
+  it("does not match the stem of an inflected term inside an unrelated word", () => {
+    const defs = [{ term: "dane", definition: "informacje dotyczące osoby fizycznej" }];
+
+    // "abundance" contains the "dan" stem mid-word — must NOT be wrapped.
+    const unrelatedHtml = "<p>The region saw an abundance of natural resources.</p>";
+    const unrelatedResult = injectDefinitionTooltips(unrelatedHtml, defs, { langCode: "PL" });
+    expect(unrelatedResult).not.toContain('class="defined-term"');
+
+    // "danych" is a genuine inflected form of "dane" and must still be wrapped.
+    const inflectedHtml = "<p>Przetwarzanie danych wymaga podstawy prawnej.</p>";
+    const inflectedResult = injectDefinitionTooltips(inflectedHtml, defs, { langCode: "PL" });
+    expect(inflectedResult).toContain('class="defined-term"');
+  });
+
   it("escapes HTML in definition attributes", () => {
     const defs = [{ term: "test", definition: 'a "special" <value> & entity' }];
     const html = "<p>This is a test.</p>";


### PR DESCRIPTION
## Summary
- **EUR-Lex host validation bypass**: `handleEurlexUrlImport` in `src/hooks/useAddLawImport.js` validated pasted URLs with `parsedUrl.hostname.includes("eur-lex.europa.eu")`, a substring check that also accepts lookalike hosts such as `eur-lex.europa.eu.evil.com`. Replaced it with an exact host match (`host === "eur-lex.europa.eu"` or a genuine subdomain via `.endsWith(".eur-lex.europa.eu")`), preserving the existing error path (`landing.invalidEurlexUrl`) when the host doesn't match.
- **Definition tooltip stem over-matching**: In `src/utils/definitions.js`, the inflected-language stem regex built by `buildStemPattern` (e.g. `dan\S*` for Polish) had no leading word boundary, unlike the non-inflected path. This let a stem match mid-word (e.g. "dan" inside "abundance"). Added a leading `(?<![\w-])` boundary to the inflected branch in `injectDefinitionTooltips` so a match can only *start* at a word boundary, while still allowing inflected endings to match freely (no trailing boundary).

## Test plan
- [x] Added a focused test in `src/utils/definitions.test.js` asserting a stem match inside an unrelated word ("abundance") is NOT wrapped, while a genuine inflected form ("danych") still is.
- [x] `npx vitest run src/utils/definitions.test.js` — all 13 tests pass.
- [x] `npm run lint` — passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)