### PR TITLE
Use path-only canonical URL to avoid duplicate query-string variants

### DIFF
--- a/src/components/SEO.jsx
+++ b/src/components/SEO.jsx
@@ -15,7 +15,10 @@ export function SEO({
   const metaDescription = description || t("seo.defaultDescription");
   const metaKeywords = keywords || t("seo.defaultKeywords");
   const siteUrl = 'https://legalviz.eu';
-  const currentUrl = canonical || (typeof window !== 'undefined' ? window.location.href : siteUrl);
+  const currentUrl = canonical
+    || (typeof window !== 'undefined'
+      ? `${window.location.origin}${window.location.pathname}`
+      : siteUrl);
   const imageUrl = image.startsWith('http') ? image : `${siteUrl}${image}`;
 
   return (


### PR DESCRIPTION
## Problem

`SEO.jsx` falls back to `window.location.href` for the canonical URL (and reuses that value for `og:url`) when no explicit `canonical` prop is passed:

```js
const currentUrl = canonical || (typeof window !== 'undefined' ? window.location.href : siteUrl);
```

`location.href` includes the query string, so transient/duplicative params such as `?celex=`, `?raw=`, `?sourceUrl=`, and `?lang=` each produce a distinct "canonical" URL for what is really the same law page. That defeats the purpose of the canonical tag: search engines see many canonical variants instead of one, diluting signals and potentially causing duplicate-content issues. The meaningful identity of a law page lives in the URL path, not its query string.

## Fix

When falling back (no explicit `canonical` prop), use `origin + pathname` only, dropping `search` and `hash`:

```js
const currentUrl = canonical
  || (typeof window !== 'undefined'
    ? `${window.location.origin}${window.location.pathname}`
    : siteUrl);
```

- Behavior is unchanged when an explicit `canonical` prop is passed.
- SSR fallback to `siteUrl` when `window` is undefined is preserved.
- `currentUrl` is also reused for `og:url`, so Open Graph links benefit from the same de-duplication.

Diff is a single logical change, scoped to `src/components/SEO.jsx`.

## Test plan

- [x] `npm run lint` passes with no errors or warnings
- [x] `npx vitest run` — full suite passes (207/207 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)