### PR TITLE
Localize remaining hardcoded UI strings (case law, metadata, SEO)

### DIFF
--- a/src/components/AddLawDialog.jsx
+++ b/src/components/AddLawDialog.jsx
@@ -167,7 +167,7 @@ export function AddLawDialog({
                 >
                   Edge
                 </a>
-                {" or "}
+                {t("landing.orConjunction")}
                 <a
                   href="https://addons.mozilla.org/en-US/firefox/addon/eur-lex-visualiser/"
                   target="_blank"

--- a/src/components/CaseLawModal.jsx
+++ b/src/components/CaseLawModal.jsx
@@ -22,6 +22,7 @@ function formatDate(isoDate) {
 const MAX_VISIBLE_ARTICLES = 5;
 
 function CaseCard({ c, currentLang }) {
+  const { t } = useI18n();
   const [expanded, setExpanded] = useState(false);
   const [showAllArticles, setShowAllArticles] = useState(false);
   const eurlexUrl = `https://eur-lex.europa.eu/legal-content/${currentLang || "EN"}/TXT/?uri=CELEX:${c.celex}`;
@@ -75,7 +76,7 @@ function CaseCard({ c, currentLang }) {
                 onClick={() => setShowAllArticles(true)}
                 className="inline-block rounded-full bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-400 dark:hover:bg-gray-600 transition-colors"
               >
-                +{hiddenArticleCount} more
+                {t("metadata.caseLawMoreArticles", { count: hiddenArticleCount })}
               </button>
             )}
           </div>
@@ -90,13 +91,13 @@ function CaseCard({ c, currentLang }) {
                 onClick={() => setExpanded(true)}
                 className="w-full text-left"
               >
-                <span className="text-[10px] font-medium text-gray-500 dark:text-gray-400">Decision:</span>
+                <span className="text-[10px] font-medium text-gray-500 dark:text-gray-400">{t("metadata.caseLawDecisionLabel")}</span>
                 <p className="mt-0.5 text-[11px] text-gray-500 dark:text-gray-400 leading-relaxed line-clamp-2">
                   {c.declarations.map((d) => `${d.number}. ${d.text}`).join(" ")}
                 </p>
                 <span className="mt-0.5 inline-flex items-center gap-0.5 text-[10px] font-medium text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300">
                   <ChevronDown size={10} />
-                  Expand decision
+                  {t("metadata.caseLawExpandDecision")}
                 </span>
               </button>
             ) : (
@@ -115,7 +116,7 @@ function CaseCard({ c, currentLang }) {
                   className="mt-0.5 inline-flex items-center gap-0.5 text-[10px] font-medium text-teal-600 dark:text-teal-400 hover:text-teal-800 dark:hover:text-teal-300"
                 >
                   <ChevronUp size={10} />
-                  Collapse
+                  {t("metadata.caseLawCollapse")}
                 </button>
               </div>
             )}
@@ -135,7 +136,7 @@ function CaseCard({ c, currentLang }) {
             rel="noopener noreferrer"
             className="ml-auto shrink-0 inline-flex items-center gap-1 rounded-md bg-teal-50 px-2.5 py-1 text-[11px] font-medium text-teal-700 hover:bg-teal-100 transition-colors dark:bg-teal-900/30 dark:text-teal-300 dark:hover:bg-teal-900/50"
           >
-            Read full judgment
+            {t("metadata.caseLawReadFullJudgment")}
             <ExternalLink size={10} />
           </a>
         </div>
@@ -265,7 +266,7 @@ export function CaseLawModal({ isOpen, onClose, cases, currentLang, celex }) {
               onClick={() => setVisibleCount((v) => v + PAGE_SIZE)}
               className="mt-3 w-full rounded-lg border border-gray-200 bg-gray-50 py-2 text-xs font-medium text-gray-600 hover:bg-gray-100 transition-colors dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700"
             >
-              Show {Math.min(PAGE_SIZE, remaining)} more ({remaining} remaining)
+              {t("metadata.caseLawShowMore", { count: Math.min(PAGE_SIZE, remaining), remaining })}
             </button>
           )}
         </div>

--- a/src/components/MetadataPanel.jsx
+++ b/src/components/MetadataPanel.jsx
@@ -63,7 +63,7 @@ export function CaseLawButton({ celex, currentLang = "EN" }) {
     return (
       <div className="flex w-full items-center gap-2 rounded-xl border border-gray-200 bg-gray-50 px-3 py-2.5 text-sm text-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-500">
         <Scale size={16} />
-        {t("metadata.caseLaw")} — none found
+        {t("metadata.caseLaw")} {t("metadata.noneFound")}
       </div>
     );
   }
@@ -113,6 +113,7 @@ const TYPE_BADGE = {
  */
 // Renders with the same shell as Accordion so there's no layout shift on load
 function LoadButton({ label, count, loading, loaded, onClick }) {
+  const { t } = useI18n();
   return (
     <div className="rounded-xl border border-gray-200 bg-white dark:bg-gray-800 dark:border-gray-700">
       <button
@@ -125,7 +126,7 @@ function LoadButton({ label, count, loading, loaded, onClick }) {
           {loading && <Loader2 size={12} className="animate-spin text-gray-400" />}
           {label}
           {loaded && count === 0 && (
-            <span className="text-xs font-normal text-gray-400 dark:text-gray-500">— none found</span>
+            <span className="text-xs font-normal text-gray-400 dark:text-gray-500">{t("metadata.noneFound")}</span>
           )}
         </span>
         {!loaded && !loading && <ChevronDown size={16} />}
@@ -138,6 +139,7 @@ function LoadButton({ label, count, loading, loaded, onClick }) {
  * Renders a list of acts (amendments or implementing acts) as cards.
  */
 function ActList({ acts, currentLang, type = "amendment" }) {
+  const { t } = useI18n();
   if (!acts || acts.length === 0) return null;
 
   return (
@@ -149,8 +151,8 @@ function ActList({ acts, currentLang, type = "amendment" }) {
           ? "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300"
           : (TYPE_BADGE[a.type] || TYPE_BADGE.amendment);
         const typeLabel = type === "implementing"
-          ? "Impl/Del"
-          : (a.type === "corrigendum" ? "Corrigendum" : "Amendment");
+          ? t("metadata.implDelBadge")
+          : (a.type === "corrigendum" ? t("amendmentHistory.corrigendum") : t("amendmentHistory.amendment"));
 
         return (
           <li key={a.celex}>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -26,7 +26,8 @@
   "seo": {
     "defaultDescription": "Read EU laws like the GDPR, AI Act, DMA, DSA and Data Act with ease. Navigate articles, recitals, annexes and cross-references, side by side.",
     "defaultKeywords": "EU law, GDPR, AI Act, DMA, DSA, Data Act, read EU law, EU regulation reader, legal tech",
-    "landingDescription": "Read EU laws like the GDPR, AI Act, DMA, DSA and Data Act with ease. Navigate articles, recitals, annexes and cross-references, side by side."
+    "landingDescription": "Read EU laws like the GDPR, AI Act, DMA, DSA and Data Act with ease. Navigate articles, recitals, annexes and cross-references, side by side.",
+    "itemDescription": "Read {kind} {id} of {law} on {app}."
   },
   "error": {
     "somethingWentWrong": "Something went wrong",
@@ -155,7 +156,8 @@
     "addFromUrl": "Add from URL",
     "invalidEurlexUrl": "Enter a valid EUR-Lex URL.",
     "importResolveFailed": "This EUR-Lex page could not be resolved to a law LegalViz can open.",
-    "extensionInline": "Or install our extension to open any law directly from EUR-Lex by clicking the extension icon, without copying URLs:"
+    "extensionInline": "Or install our extension to open any law directly from EUR-Lex by clicking the extension icon, without copying URLs:",
+    "orConjunction": " or "
   },
   "resetFooter": {
     "title": "Something isn't working?",
@@ -253,8 +255,16 @@
     "eea": "EEA relevant",
     "yes": "Yes",
     "implementingActs": "Implementing / Delegated Acts",
+    "implDelBadge": "Impl/Del",
+    "noneFound": "— none found",
     "caseLaw": "CJEU Case Law",
     "caseLawSearchPlaceholder": "Search by party, case number, or article…",
-    "caseLawNoResults": "No cases match your search."
+    "caseLawNoResults": "No cases match your search.",
+    "caseLawDecisionLabel": "Decision:",
+    "caseLawExpandDecision": "Expand decision",
+    "caseLawCollapse": "Collapse",
+    "caseLawReadFullJudgment": "Read full judgment",
+    "caseLawMoreArticles": "+{count} more",
+    "caseLawShowMore": "Show {count} more ({remaining} remaining)"
   }
 }

--- a/src/utils/law-viewer/content.js
+++ b/src/utils/law-viewer/content.js
@@ -163,7 +163,12 @@ export function buildSeoData({ dataTitle, currentLaw, selected, t }) {
         ? t("common.recital")
         : t("common.annex");
     title = `${kindLabel} ${selected.id} - ${lawName}`;
-    description = `Read ${kindLabel} ${selected.id} of ${lawName} on ${t("app.name")}.`;
+    description = t("seo.itemDescription", {
+      kind: kindLabel,
+      id: selected.id,
+      law: lawName,
+      app: t("app.name"),
+    });
   }
 
   return { title, description };


### PR DESCRIPTION
## Summary
- Replaced remaining hardcoded English literals with `t(...)` calls, backed by new keys added only to `src/i18n/locales/en.json`.
- **CaseLawModal.jsx**: `Decision:`, `Expand decision`, `Collapse`, `Read full judgment`, the `+{count} more` pill, and the `Show {count} more ({remaining} remaining)` pagination button. `CJEU` and `CELEX` were left as-is (proper acronyms).
- **MetadataPanel.jsx**: both `— none found` occurrences now use `metadata.noneFound`; the `Impl/Del` badge uses a new `metadata.implDelBadge` key; the `Corrigendum`/`Amendment` badges now reuse the existing `amendmentHistory.corrigendum` / `amendmentHistory.amendment` keys (already present in `en.json` and already used elsewhere in the app) instead of hardcoded strings.
- **content.js** (`buildSeoData`): per-item meta descriptions (used when prerendering individual article/recital/annex pages) now go through `t("seo.itemDescription", { kind, id, law, app })` instead of an untranslatable template string, so non-English prerendered law pages no longer ship an English-only meta description.
- **AddLawDialog.jsx**: the `" or "` conjunction between the Edge/Firefox extension links now uses `t("landing.orConjunction")`.

Only `en.json` gained new keys — the other 23 locale files automatically fall back to English for these keys via the existing `t()` fallback behavior in `I18nProvider.jsx`, so visible text is unchanged until each locale is translated.

## Test plan
- [x] `npm run lint` passes
- [x] `npx vitest run` passes (full suite, 207 tests)
- [x] `node -e "JSON.parse(require('fs').readFileSync('src/i18n/locales/en.json','utf8'))"` confirms `en.json` is valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)