### PR TITLE
docs: document cache-bump constants and split CLAUDE.md per subtree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ Backend CLI (`eurlex`) commands are documented in [backend/README.md](backend/RE
 
 Requires Node.js v24+.
 
+Subtree-specific guidance lives in nested memory files that Claude Code loads on demand when you work in them: [backend/CLAUDE.md](backend/CLAUDE.md) (API, CLI, MCP, AI services) and [src/CLAUDE.md](src/CLAUDE.md) (React frontend). Keep this root file for cross-cutting concerns; push backend-only or frontend-only detail down into those.
+
 ## Architecture
 
 **Monorepo split**: `src/` (React frontend) and `backend/` (Express API + `eurlex` CLI) share one parser: `backend/shared/formex-parser/fmxParser.mjs`. The frontend imports it directly to parse Formex XML client-side when running against static/offline data; the backend uses the same module to serve parsed JSON over HTTP. Don't fork parsing logic between the two — fix it once in `backend/shared/formex-parser/`.
@@ -39,10 +41,37 @@ Requires Node.js v24+.
 
 **CJEU case law**: judgments are fetched via SPARQL and parsed from three distinct historical HTML/XML shapes (post-2004 EUR-Lex Formex, pre-2004 OJ HTML, older Curia HTML) into structured `articleRefs` so the viewer can show cases citing a given article. This parsing lives in `backend/` and is one of the more fragile/format-sensitive parts of the codebase.
 
-**Optional AI features** (recital titles, static law overviews, per-article case-law digests, and a whole-law case-law digest) call OpenRouter only on cache misses — generated content is validated then cached to disk (`recital-title-cache-v1.json`, `law-summary-cache-v1.json`, `article-digest-cache-v1.json`, `case-law-digest-cache-v1.json`), each versioned with a source-content hash, model, and timestamp so cache invalidation is explicit. The case-law digests additionally fold the enrichment cache version (`case-law-cache-v4`) into their source hash so they regenerate when judgment parsing improves. The web app additionally mirrors recital titles into IndexedDB so a warm cache never triggers a network call to the endpoint. Key resolution order: feature-specific key (`RECITAL_TITLE_OPENROUTER_API_KEY`, `LAW_SUMMARY_OPENROUTER_API_KEY`, `ARTICLE_QA_OPENROUTER_API_KEY`) → `OPENROUTER_API_KEY` fallback. When touching these code paths, preserve the cache-validate-before-write pattern rather than writing raw model output.
+**Optional AI features** (recital titles, static law overviews, per-article case-law digests, and a whole-law case-law digest) call OpenRouter only on cache misses — generated content is validated *before* it is written to the disk cache, so preserve that cache-validate-before-write pattern rather than writing raw model output. The web app also mirrors recital titles into IndexedDB so a warm cache never hits the endpoint. Each cache is versioned (see [Cache & version invalidation](#cache--version-invalidation)). Key resolution order: feature-specific key (`RECITAL_TITLE_OPENROUTER_API_KEY`, `LAW_SUMMARY_OPENROUTER_API_KEY`, `ARTICLE_QA_OPENROUTER_API_KEY`) → `OPENROUTER_API_KEY` fallback.
 
 **Routing/state**: the current reader position (law, article, recital, language) is synced to the URL (`src/utils/lawRouting.js`, `src/utils/url.js`) so every view is bookmarkable/shareable — treat URL state as the source of truth for navigation, not component state.
 
 **`extension/`** is a separate Chrome/Firefox browser extension package, not built by the root `npm run build`.
 
 **`scripts/`** contains build-time Node scripts (prerendering law pages, sitemap generation, 404 copy, `dev.js` which runs frontend + backend concurrently) — not application code.
+
+## Cache & version invalidation
+
+Nearly every expensive operation — Formex parsing, TF‑IDF recital mapping, CJEU enrichment, and the LLM features — is cached, and each cache is guarded by a **hand-maintained version constant**. The model id and source content are folded into a hash so those self-invalidate, but a *code* change (parser output, prompt wording, JSON schema, algorithm) does **not** — you must bump the constant yourself or the stale result is served indefinitely. Forgetting this is the most common way a change silently "doesn't take". When you touch any of the code below, bump the paired constant in the same commit.
+
+**Backend, on-disk** (written under `CACHE_DIR`, default `backend/law-cache`):
+
+| When you change… | Bump | In |
+|---|---|---|
+| Parser output (fields, shape, bug fix) | `PARSER_VERSION` | `backend/shared/formex-parser/fmxParser.mjs` |
+| CJEU enrichment shape (declarations, `articleRefs`) | `CASE_LAW_CACHE_FILE` → `case-law-cache-vN.json` (keep the legacy-migration path) | `backend/shared/law-queries.js` |
+| Recital-title prompt/output format | `CACHE_VERSION` | `backend/shared/recital-title-service.js` |
+| Law-summary JSON schema / prompt | `SCHEMA_VERSION` / `PROMPT_VERSION` | `backend/shared/law-summary-service.js` |
+| Article-digest JSON schema / prompt | `SCHEMA_VERSION` / `PROMPT_VERSION` | `backend/shared/article-digest-service.js` |
+| Whole-law digest JSON schema / prompt | `SCHEMA_VERSION` / `PROMPT_VERSION` | `backend/shared/case-law-digest-service.js` |
+
+`PARSER_VERSION` is **shared with the frontend** (imported into `src/utils/formexApi.js`), so bumping it re-parses the browser IndexedDB cache too. When you bump `CASE_LAW_CACHE_FILE`, also update `CASE_LAW_CACHE_VERSION` in `article-digest-service.js` **and** `case-law-digest-service.js` — they are kept in lock-step so digests regenerate when enrichment shape changes.
+
+**Frontend, browser** (`src/`):
+
+| When you change… | Bump | In |
+|---|---|---|
+| Recital→article NLP algorithm | `NLP_VERSION` | `src/utils/nlp.js` (localStorage keys are `nlp_v<N>_…`) |
+| IndexedDB store shape (DB `formex-cache`) | `CACHE_VERSION` | `src/utils/formexApi.js` |
+| Cached recital-title envelope shape | `RECITAL_TITLE_CACHE_VERSION` | `src/utils/formexApi.js` |
+| Cached API-JSON payload shape | `API_JSON_CACHE_VERSION` | `src/utils/formexApi.js` |
+| Force every client to wipe local data once | `CURRENT_MIGRATION_VERSION` | `src/utils/resetApp.js` |

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+Backend-only notes. The root [CLAUDE.md](../CLAUDE.md) has the monorepo picture and the cross-cutting **cache-version table** (bump these when you change cached output). [backend/README.md](README.md) documents every CLI command, API endpoint, MCP tool, and environment variable in full — read it before adding or changing routes/commands.
+
+## Commands (run from `backend/`)
+
+```bash
+npm start                     # API server on :3000 (or $PORT)
+npm run dev                   # API with --watch (auto-restart)
+npm test                      # node --test search/*.test.js shared/*.test.js routes/*.test.js bin/*.test.js
+npm run test:search           # search tests only
+npm run build:search-cache    # build the MiniSearch metadata cache into search/data/
+npx eurlex <command>          # CLI (or `npm link` once, then `eurlex …`)
+```
+
+Single test file: `node --test search/search-ranking.test.js`.
+
+The search cache is loaded **once at server startup**, so restart the API after `build:search-cache`. Until it exists, `/api/search` returns `503 search_cache_unavailable`.
+
+## What lives where
+
+- **`shared/`** is imported by both the frontend and the CLI. The Formex parser (`shared/formex-parser/fmxParser.mjs`) runs in the browser, so keep it dependency-light and free of Node-only APIs; `shared/fmx-parser-node.js` is the Node wrapper. Fix parsing bugs here once — never fork them into `src/`.
+- **AI services** — `recital-title-service.js`, `law-summary-service.js`, `article-digest-service.js`, `case-law-digest-service.js` — all follow one shape: clip source → hash → single-flight → **validate model output → then write cache** (never cache raw output). Zero-result digests are cached without an LLM call. The summary and two digest services share plumbing in `shared/ai-digest-utils.js` (text clipping, hashing, single-flight, cache read/write, citation grounding); `recital-title-service.js` predates it and keeps its own copy.
+- **API-key resolution** is layered: feature-specific key → `OPENROUTER_API_KEY`. The `ARTICLE_QA_*` env vars are legacy fallbacks still wired into summaries/digests even though the Q&A prototype itself was removed (see [../docs/article-qa-plan.md](../docs/article-qa-plan.md)).
+- **CJEU case-law parsing** (`shared/case-law-parser.js`, `shared/law-queries.js`) handles three historical shapes (post-2004 EUR-Lex Formex, pre-2004 OJ HTML, older Curia HTML) into structured `articleRefs`. This is the most format-fragile code in the repo; changing its output shape means bumping `CASE_LAW_CACHE_FILE` (see the root cache table).
+
+## Gotchas
+
+- SPARQL queries (`shared/law-queries.js`) take user-supplied CELEX ids and language codes — these are validated/escaped to prevent injection. Keep new queries parameterized; don't string-concat untrusted input.
+- Rate limiting, cache eviction (`STORAGE_LIMIT_MB` / `HTML_CACHE_LIMIT_MB`), and timeouts are all env-configurable — see the Environment Variables table in the README before hard-coding limits.

--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -1,0 +1,28 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+Frontend-only notes (React + Vite). The root [CLAUDE.md](../CLAUDE.md) has the monorepo picture and the cross-cutting **cache-version table** (bump these when you change cached output).
+
+## Commands (run from repo root)
+
+```bash
+npm run dev:web               # Vite only (:5173); `npm run dev` also starts the API
+npm run test:web              # vitest run
+npm run test:watch            # vitest watch
+npm run build                 # vite build + copy-404 + prerender featured law pages + sitemap
+```
+
+Single test file: `npx vitest run src/utils/nlp.test.js`.
+
+## Architecture notes
+
+- **URL is the source of truth for navigation.** Reader position (law, article, recital, language) is synced to the URL via `src/utils/lawRouting.js` / `src/utils/url.js` so every view is bookmarkable/shareable. Read navigation state from the URL, don't hold it in component state.
+- **Parsing is not forked here.** `src/utils/fmxParser.js` / `src/utils/parsers.js` wrap the shared backend parser (`backend/shared/formex-parser/fmxParser.mjs`) for the browser. Fix parser bugs in `backend/shared/`, not in `src/`.
+- **`src/utils/formexApi.js`** is the single client for law data — it talks to the backend API or fetches EUR-Lex directly depending on mode, and owns the IndexedDB (`formex-cache`) layer plus the cache envelopes (parsed laws, recital titles, API JSON).
+- **`src/utils/nlp.js`** is the client-side TF‑IDF / inverted index that maps recitals→articles and powers in-document search. It is built from the currently loaded law only; results are cached in localStorage under `nlp_v<NLP_VERSION>_…`.
+- **Client-side storage** spans IndexedDB (parsed laws, recital titles) and localStorage (NLP maps, theme, migration marker). `src/utils/resetApp.js` clears it all; its `CURRENT_MIGRATION_VERSION` triggers a one-time wipe for every client on deploy.
+
+## Bumping caches
+
+Any change to parser output, a cached payload shape, or the NLP algorithm needs a version bump — see the frontend half of the cache table in the root [CLAUDE.md](../CLAUDE.md). Note that `PARSER_VERSION` is defined in the backend parser but consumed here, so a parser change re-parses the browser cache automatically.


### PR DESCRIPTION
## What & why

Auditing the `CLAUDE.md` files revealed that the **cache-invalidation version constants** were largely undocumented. Model id and source content are folded into cache hashes (so they self-invalidate), but a **code** change — parser output, prompt wording, JSON schema, NLP algorithm — is *not*, so a stale cache is served indefinitely unless a hand-maintained constant is bumped. There was no single place telling a contributor (human or agent) which constant to bump when.

This PR captures that knowledge and reorganizes the docs so subtree-specific detail loads only when relevant.

## Changes

- **Root [`CLAUDE.md`](CLAUDE.md)** — new `Cache & version invalidation` section with backend (on-disk) and frontend (browser) tables mapping each code change to the constant to bump (`PARSER_VERSION`, `SCHEMA_VERSION`/`PROMPT_VERSION`, `CACHE_VERSION`, `NLP_VERSION`, `RECITAL_TITLE_CACHE_VERSION`, `API_JSON_CACHE_VERSION`, `CURRENT_MIGRATION_VERSION`). Documents two non-obvious couplings:
  - `PARSER_VERSION` is shared FE↔BE (bumping it re-parses the browser IndexedDB cache too).
  - `CASE_LAW_CACHE_FILE` ↔ `CASE_LAW_CACHE_VERSION` must be kept in lock-step across both digest services.
- **New [`backend/CLAUDE.md`](backend/CLAUDE.md)** — backend commands, the `shared/` FE-safe constraint, the AI-service validate-before-write pattern + `ai-digest-utils.js`, the fragile 3-shape CJEU parser, and SPARQL-injection note. Points to the exhaustive `backend/README.md` rather than duplicating it.
- **New [`src/CLAUDE.md`](src/CLAUDE.md)** — frontend commands, "URL is the source of truth for navigation", "don't fork the parser", and the client-side storage/cache map.
- Trimmed the root "Optional AI features" paragraph to drop the cache-file list now covered by the table.

## Notes for reviewers

- Docs-only; no code or behavior changes.
- The nested `CLAUDE.md` files are loaded by Claude Code **on demand** when working in that subtree, keeping the root lean and reducing token usage — the tables cross-reference the root rather than duplicating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)