### PR TITLE
Recital→article map: language-aware, computed once per law

### DIFF
--- a/src/components/LawViewer.jsx
+++ b/src/components/LawViewer.jsx
@@ -113,7 +113,6 @@ export function LawViewer() {
   const recitalMap = useRecitalMap({
     data: primaryDocument.data,
     currentLaw: source.currentLaw,
-    formexLang: preferences.formexLang,
   });
   const primarySelectedEntry = useMemo(
     () => getSelectedEntry(primaryDocument.data, selection.selected),

--- a/src/components/PrintView.jsx
+++ b/src/components/PrintView.jsx
@@ -13,8 +13,8 @@ export function PrintView({ data, options, uiLocale = "en", labels }) {
   // Compute related recitals if needed.
   const relatedRecitalsMap = useMemo(() => {
     if (!includeRelatedRecitals || !articles || !recitals) return new Map();
-    return mapRecitalsToArticles(recitals, articles);
-  }, [includeRelatedRecitals, articles, recitals]);
+    return mapRecitalsToArticles(recitals, articles, data?.langCode);
+  }, [includeRelatedRecitals, articles, recitals, data?.langCode]);
 
   if (!data) return null;
 

--- a/src/hooks/law-viewer/useRecitalMap.js
+++ b/src/hooks/law-viewer/useRecitalMap.js
@@ -44,7 +44,7 @@ export function useRecitalMap({ data, currentLaw, formexLang }) {
       }
 
       const timer = setTimeout(() => {
-        const map = mapRecitalsToArticles(data.recitals, data.articles);
+        const map = mapRecitalsToArticles(data.recitals, data.articles, data.langCode);
         setRecitalMap(withOrphanRecitals(map));
 
         if (!cacheKey) return;
@@ -60,7 +60,7 @@ export function useRecitalMap({ data, currentLaw, formexLang }) {
 
     setRecitalMap(withOrphanRecitals(new Map()));
     return undefined;
-  }, [currentLaw, data.articles, data.recitals, formexLang]);
+  }, [currentLaw, data.articles, data.recitals, data.langCode, formexLang]);
 
   return recitalMap;
 }

--- a/src/hooks/law-viewer/useRecitalMap.js
+++ b/src/hooks/law-viewer/useRecitalMap.js
@@ -6,7 +6,7 @@ function withOrphanRecitals(map) {
   return map;
 }
 
-export function useRecitalMap({ data, currentLaw, formexLang }) {
+export function useRecitalMap({ data, currentLaw }) {
   const [recitalMap, setRecitalMap] = useState(() => withOrphanRecitals(new Map()));
 
   useEffect(() => {
@@ -26,9 +26,13 @@ export function useRecitalMap({ data, currentLaw, formexLang }) {
         console.warn("Error cleaning up old NLP cache", error);
       }
 
+      // The map is keyed on article/recital numbers, which are identical across
+      // every language version of a law, so the relationship is language-invariant.
+      // Cache it once per law (no language in the key) and reuse it for every
+      // language instead of recomputing the same mapping per translation.
       let cacheKey = null;
       if (currentLaw?.slug) {
-        cacheKey = `nlp_v${NLP_VERSION}_${currentLaw.slug}_fmx_${formexLang}`;
+        cacheKey = `nlp_v${NLP_VERSION}_${currentLaw.slug}`;
       }
 
       if (cacheKey) {
@@ -60,7 +64,7 @@ export function useRecitalMap({ data, currentLaw, formexLang }) {
 
     setRecitalMap(withOrphanRecitals(new Map()));
     return undefined;
-  }, [currentLaw, data.articles, data.recitals, data.langCode, formexLang]);
+  }, [currentLaw, data.articles, data.recitals, data.langCode]);
 
   return recitalMap;
 }

--- a/src/utils/nlp.js
+++ b/src/utils/nlp.js
@@ -1,5 +1,5 @@
 // NLP Algorithm Version - bump this when algorithm changes to invalidate cache
-export const NLP_VERSION = 13;
+export const NLP_VERSION = 14;
 
 const MONOTONICITY_BETA = 0.9;
 const MONOTONICITY_GAMMA = 2;
@@ -125,18 +125,20 @@ const stripTags = (html) => {
  * 
  * @param {Array} recitals - Array of { recital_number, recital_text, ... }
  * @param {Array} articles - Array of { article_number, article_title, article_html, ... }
+ * @param {string} [langCode] - Language of the law's text (e.g. "DE"), used to pick
+ *   the right stop-word list. Defaults to English when omitted.
  * @returns {Map} - Map where key is article_number, value is array of matching recitals.
  *                  Unmapped recital numbers are exposed under the reserved null key.
  */
-export function mapRecitalsToArticles(recitals, articles) {
+export function mapRecitalsToArticles(recitals, articles, langCode) {
   // Configuration
   const TITLE_WEIGHT = 3; // How many times to repeat title tokens for weighting
 
   // 1. Prepare Article Documents (Corpus)
   // Weight article titles more heavily by repeating their tokens
   const articleDocs = articles.map(a => {
-    const titleTokens = tokenize(a.article_title || "");
-    const bodyTokens = tokenize(stripTags(a.article_html));
+    const titleTokens = tokenize(a.article_title || "", langCode);
+    const bodyTokens = tokenize(stripTags(a.article_html), langCode);
     // Repeat title tokens for increased weight
     const weightedTitleTokens = [];
     for (let i = 0; i < TITLE_WEIGHT; i++) {
@@ -168,7 +170,7 @@ export function mapRecitalsToArticles(recitals, articles) {
   // 4. Process Recitals
   recitals.forEach((r, recitalIndex) => {
     const recitalText = r.recital_text || stripTags(r.recital_html) || "";
-    const tokens = tokenize(recitalText);
+    const tokens = tokenize(recitalText, langCode);
     const recitalVec = computeTFIDFVector(tokens, idf);
 
     // Extract top keywords based on TF-IDF scores

--- a/src/utils/nlp.test.js
+++ b/src/utils/nlp.test.js
@@ -173,6 +173,24 @@ describe("mapRecitalsToArticles", () => {
       }
     }
   });
+
+  it("uses language-specific stop words when a langCode is passed", () => {
+    // "der"/"verordnung" are German stop words but not English ones. Passing
+    // "DE" strips them, so the recital and article share no matchable term and
+    // the recital falls through as an orphan.
+    const deArticles = [
+      { article_number: "1", article_title: "", article_html: "<p>der verordnung</p>" },
+      { article_number: "2", article_title: "", article_html: "<p>fillertwo fillertwo</p>" },
+    ];
+    const deRecitals = [{ recital_number: "1", recital_text: "der verordnung" }];
+
+    expect(
+      mapRecitalsToArticles(deRecitals, deArticles).get("1").map((r) => r.recital_number)
+    ).toContain("1");
+    expect(
+      mapRecitalsToArticles(deRecitals, deArticles, "DE").get(null)
+    ).toEqual(["1"]);
+  });
 });
 
 describe("buildSearchIndex + searchIndex", () => {


### PR DESCRIPTION
Revised, simpler replacement for #73 (now closed).

## Problem
`mapRecitalsToArticles` tokenized article/recital text with **English** stop words regardless of the law's language, degrading TF-IDF recital→article match quality for German, Polish, etc. Separately, the map was cached **per language** (`nlp_v{N}_{slug}_fmx_{lang}`) and recomputed every time you viewed the law in a new language — even though the mapping is the same in every language.

## Key insight
The map's output is purely `article_number → [recital_number]` (plus unused score/keyword fields). The renderer (`RelatedRecitals.jsx`) uses only `recital_number`, resolving the actual text from the currently-displayed language. Article/recital numbers are **identical across all official-language versions** of an EU law, so the mapping is a **language-invariant structural relationship** — it should be computed once and reused, not recomputed per translation.

## Change
1. **Language-aware tokenization** — `mapRecitalsToArticles(recitals, articles, langCode)` threads `langCode` into every `tokenize(...)` call (its sibling `buildSearchIndex` already did). Omitting it keeps the English default.
2. **Compute once per law** — drop the language from the cache key (`nlp_v{N}_{slug}`), so the map is computed a single time and reused across every language rather than recomputed per translation. `langCode` (from `data.langCode`, the parsed content language) ensures that single computation tokenizes well whatever language triggers it first — no separate reference-language fetch needed.
3. Bump `NLP_VERSION` 13 → 14 to invalidate stale, language-blind, per-language caches.
4. One focused test asserting `langCode` is honored.

## Why not fetch a canonical English copy instead
That would force an extra network fetch/parse whenever a non-English law is viewed. Since the map is number-keyed and language-invariant, computing it once from whatever language is loaded first (tokenized correctly via `langCode`) yields the same relationship for free.

## No mixed-language risk
`data.langCode` uniformly describes all of `data.articles`/`data.recitals`: both parsers stamp it once per document, EUR-Lex language fallback swaps the whole document (same requested language), and translation views are separate `data` objects. There is no path that matches recitals against a different-language version of an article.

## Test plan
- [x] `npm run lint` — clean
- [x] `npx vitest run` frontend suite — passes (the one failing test, `fmxParser` "AI Act", fetches live EUR-Lex data and fails independently of this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)