### PR TITLE
Fix IndexedDB wedge after clear-data that silently broke navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "eslint": "^9.36.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.22",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^16.4.0",
         "jsdom": "^29.0.0",
         "postcss": "^8.5.6",
@@ -5048,6 +5049,16 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint": "^9.36.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.22",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^16.4.0",
     "jsdom": "^29.0.0",
     "postcss": "^8.5.6",

--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -84,7 +84,8 @@ export function Landing({ forcedLocale = null }) {
   const activeLocale = forcedLocale || locale;
 
   const handleOpenLaw = useCallback(async (law) => {
-    await markLawOpened(law.celex);
+    // Best-effort bookkeeping: never let a stuck IndexedDB block navigation.
+    markLawOpened(law.celex).catch(() => {});
     navigate(localizePath(law.route, locale));
   }, [locale, localizePath, markLawOpened, navigate]);
 
@@ -98,11 +99,12 @@ export function Landing({ forcedLocale = null }) {
       });
 
       if (officialReference) {
-        await saveLawMeta({
+        // Best-effort bookkeeping: never let a stuck IndexedDB block navigation.
+        saveLawMeta({
           celex: item.celex,
           label: item.title,
           officialReference,
-        });
+        }).catch(() => {});
       }
 
       navigate(getCanonicalLawRoute(targetLaw, null, null, locale));

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1013,11 +1013,12 @@ export function TopBar({
       });
 
       if (officialReference) {
-        await saveLawMeta({
+        // Best-effort bookkeeping: never let a stuck IndexedDB block navigation.
+        saveLawMeta({
           celex: item.celex,
           label: item.title,
           officialReference,
-        });
+        }).catch(() => {});
       }
 
       navigate(getCanonicalLawRoute(targetLaw, null, null, locale));

--- a/src/hooks/law-viewer/useLawViewerInteractions.js
+++ b/src/hooks/law-viewer/useLawViewerInteractions.js
@@ -136,11 +136,12 @@ export function useLawViewerInteractions({
           celex: result.resolved.celex,
           officialReference: reference,
         });
-        await saveLawMeta({
+        // Best-effort bookkeeping: never let a stuck IndexedDB block navigation.
+        saveLawMeta({
           celex: result.resolved.celex,
           officialReference: reference,
           label: refLike?.raw || refLike?.label || refLike?.target || `CELEX ${result.resolved.celex}`,
-        });
+        }).catch(() => {});
         navigate(getCanonicalLawRoute(
           targetLaw,
           refLike?.articleNumber ? "article" : null,

--- a/src/utils/formexApi.indexedDb.test.js
+++ b/src/utils/formexApi.indexedDb.test.js
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { IDBFactory } from "fake-indexeddb";
+
+async function importFormexApi() {
+  vi.resetModules();
+  return import("./formexApi.js");
+}
+
+function deleteDatabase(indexedDb, name) {
+  return new Promise((resolve, reject) => {
+    const request = indexedDb.deleteDatabase(name);
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => reject(new Error("Database deletion was blocked"));
+  });
+}
+
+describe("Formex IndexedDB connection lifecycle", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("shares one connection and releases it when another client deletes the database", async () => {
+    const indexedDb = new IDBFactory();
+    const openSpy = vi.spyOn(indexedDb, "open");
+    vi.stubGlobal("indexedDB", indexedDb);
+
+    const { getLawMeta, upsertLawMeta } = await importFormexApi();
+
+    await upsertLawMeta("32016R0679", { label: "GDPR" });
+    expect(await getLawMeta("32016R0679")).toMatchObject({
+      celex: "32016R0679",
+      label: "GDPR",
+    });
+    expect(openSpy).toHaveBeenCalledTimes(1);
+
+    // This models clear-data running in another tab. The cached connection's
+    // versionchange handler must close it or this request fires `blocked`.
+    await deleteDatabase(indexedDb, "formex-cache");
+
+    expect(await getLawMeta("32016R0679")).toBeNull();
+    expect(openSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("times out a wedged open and closes its connection if it succeeds later", async () => {
+    vi.useFakeTimers();
+
+    const lateDb = { close: vi.fn() };
+    const request = { result: lateDb };
+    vi.stubGlobal("indexedDB", {
+      open: vi.fn(() => request),
+    });
+
+    const { getLawMeta } = await importFormexApi();
+    const result = getLawMeta("32016R0679");
+
+    await vi.advanceTimersByTimeAsync(3000);
+    await expect(result).resolves.toBeNull();
+
+    request.onsuccess();
+    expect(lateDb.close).toHaveBeenCalledOnce();
+  });
+});

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -60,8 +60,24 @@ export class FormexApiError extends Error {
 // IndexedDB helpers
 // ---------------------------------------------------------------------------
 
+// A pending indexedDB.deleteDatabase() (e.g. the "reset whole app" flow in
+// another tab) queues every later open() behind it, so an open that never
+// settles would otherwise hang all cache/meta operations indefinitely.
+const OPEN_DB_TIMEOUT_MS = 3000;
+
+let dbPromise = null;
+
 function openDb() {
-  return new Promise((resolve, reject) => {
+  if (dbPromise) return dbPromise;
+
+  const promise = new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (fn, value) => {
+      if (settled) return;
+      settled = true;
+      fn(value);
+    };
+
     try {
       const req = indexedDB.open(DB_NAME, CACHE_VERSION);
       req.onupgradeneeded = () => {
@@ -73,13 +89,54 @@ function openDb() {
           db.createObjectStore(META_STORE_NAME, { keyPath: "celex" });
         }
       };
-      req.onsuccess = () => resolve(req.result);
-      req.onerror = () => reject(req.error);
-      req.onblocked = () => reject(new Error("IndexedDB open blocked"));
+      req.onsuccess = () => {
+        const db = req.result;
+        if (settled) {
+          // The timeout already rejected this attempt; don't leak the handle.
+          try { db.close(); } catch { /* ignore */ }
+          return;
+        }
+        // Release the connection when another tab (or the reset flow) asks to
+        // delete or upgrade the database. Without this, deleteDatabase() blocks
+        // forever and wedges IndexedDB for every tab until browser restart.
+        db.onversionchange = () => {
+          try { db.close(); } catch { /* ignore */ }
+          if (dbPromise === promise) dbPromise = null;
+        };
+        db.onclose = () => {
+          if (dbPromise === promise) dbPromise = null;
+        };
+        settle(resolve, db);
+      };
+      req.onerror = () => settle(reject, req.error);
+      req.onblocked = () => settle(reject, new Error("IndexedDB open blocked"));
+      setTimeout(() => settle(reject, new Error("IndexedDB open timed out")), OPEN_DB_TIMEOUT_MS);
     } catch (err) {
-      reject(err);
+      settle(reject, err);
     }
   });
+
+  dbPromise = promise;
+  promise.catch(() => {
+    if (dbPromise === promise) dbPromise = null;
+  });
+  return promise;
+}
+
+/**
+ * Close this tab's shared IndexedDB connection so a following
+ * deleteDatabase() is not blocked by our own handle.
+ */
+export async function closeFormexDb() {
+  const promise = dbPromise;
+  dbPromise = null;
+  if (!promise) return;
+  try {
+    const db = await promise;
+    db.close();
+  } catch {
+    // ignore — connection never opened or already closed
+  }
 }
 
 function makeCacheKey(celex, lang = "EN") {

--- a/src/utils/resetApp.js
+++ b/src/utils/resetApp.js
@@ -1,3 +1,5 @@
+import { closeFormexDb } from "./formexApi.js";
+
 const FORMEX_DB_NAME = "formex-cache";
 const MIGRATION_VERSION_KEY = "legalviz-migration-version";
 const CURRENT_MIGRATION_VERSION = "2026-03-v2-meta-upgrade";
@@ -79,6 +81,10 @@ async function unregisterServiceWorkers() {
 async function clearLocalBrowserData() {
   removeAppStorageKeys();
   clearSessionStorage();
+  // Close our own IndexedDB connection first so the delete below isn't
+  // blocked by this very tab. Other tabs release theirs via the
+  // versionchange handler installed in formexApi's openDb().
+  await closeFormexDb();
   await deleteIndexedDb(FORMEX_DB_NAME);
   await clearBrowserCaches();
   await unregisterServiceWorkers();

--- a/src/utils/resetApp.test.js
+++ b/src/utils/resetApp.test.js
@@ -1,0 +1,52 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  closeFormexDb: vi.fn(),
+}));
+
+vi.mock("./formexApi.js", () => ({
+  closeFormexDb: mocks.closeFormexDb,
+}));
+
+const { runOneTimeMigrationReset } = await import("./resetApp.js");
+
+describe("application data reset", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("closes this tab's Formex connection before deleting its database", async () => {
+    const calls = [];
+    let finishClosing;
+    mocks.closeFormexDb.mockImplementation(() => new Promise((resolve) => {
+      calls.push("close");
+      finishClosing = resolve;
+    }));
+
+    const deleteDatabase = vi.fn(() => {
+      calls.push("delete");
+      const request = {};
+      queueMicrotask(() => request.onsuccess?.());
+      return request;
+    });
+    vi.stubGlobal("indexedDB", { deleteDatabase });
+
+    const reset = runOneTimeMigrationReset();
+    await Promise.resolve();
+    expect(deleteDatabase).not.toHaveBeenCalled();
+
+    finishClosing();
+    await reset;
+
+    expect(calls).toEqual(["close", "delete"]);
+    expect(deleteDatabase).toHaveBeenCalledWith("formex-cache");
+  });
+});


### PR DESCRIPTION
## Problem

After clicking **"Clear data" / reset whole app**, clicking a search result closed the modal but never opened the law — and the app stayed broken until a full browser restart.

## Root cause

`resetWholeApp()` calls `indexedDB.deleteDatabase("formex-cache")`. But `openDb()` in `formexApi.js` opened a **new connection on every call, never closed any of them, and installed no `versionchange` handler**. Any surviving connection — a second tab of the app, or the pre-reload page kept alive in the back/forward cache — blocks that delete **forever**. Per the IndexedDB spec, every later `indexedDB.open()` then queues silently behind the pending delete.

So after clear-data, every DB operation hung. Clicking a search result ran `await saveLawMeta(...)` *before* `navigate(...)`: the modal closed (synchronous), the await never resolved, and navigation never happened.

Reproduced end-to-end in the browser: with a second app tab open, clear data → search "data" → click a result → modal closes, nothing opens; `indexedDB.open()` confirmed hanging behind the blocked delete.

## Fix (three layers)

1. **`src/utils/formexApi.js`** — `openDb()` now keeps a single shared connection (was leaking one per call) and installs `onversionchange` so the connection closes itself the moment any tab requests a delete/upgrade — clear-data can no longer be blocked by other app tabs. A 3s open timeout makes a wedged DB degrade to network fetches instead of hanging forever. New `closeFormexDb()` export.
2. **`src/utils/resetApp.js`** — closes this tab's own connection before `deleteDatabase()`.
3. **`Landing.jsx` / `TopBar.jsx` / `useLawViewerInteractions.js`** — law-meta writes are best-effort bookkeeping; they no longer block navigation (fire-and-forget with `.catch`).

## Verification

- Reproduced the original bug, then re-ran the same flow on the fix: clear-data with a second app tab open now completes cleanly, and search → click opens the law instantly.
- Artificially re-wedged the DB with a rogue connection ignoring `versionchange` (what an old pre-fix tab would do): clicking a result still navigates immediately and the law loads fully from the network.
- `npm run test:web`: 208 tests pass. `npm run lint`: clean.

Note: users currently stuck still need one browser restart — nothing can unwedge an already-pending delete held by an old tab — but it cannot recur afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)