### PR TITLE
Improve privacy-preserving analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Nearly every expensive operation — Formex parsing, TF‑IDF recital mapping, C
 | Law-summary JSON schema / prompt | `SCHEMA_VERSION` / `PROMPT_VERSION` | `backend/shared/law-summary-service.js` |
 | Article-digest JSON schema / prompt | `SCHEMA_VERSION` / `PROMPT_VERSION` | `backend/shared/article-digest-service.js` |
 | Whole-law digest JSON schema / prompt | `SCHEMA_VERSION` / `PROMPT_VERSION` | `backend/shared/case-law-digest-service.js` |
+| Persisted analytics shape (`analytics.json` fields) | `ANALYTICS_SCHEMA_VERSION` | `backend/shared/analytics.js` |
 
 `PARSER_VERSION` is **shared with the frontend** (imported into `src/utils/formexApi.js`), so bumping it re-parses the browser IndexedDB cache too. When you bump `CASE_LAW_CACHE_FILE`, also update `CASE_LAW_CACHE_VERSION` in `article-digest-service.js` **and** `case-law-digest-service.js` — they are kept in lock-step so digests regenerate when enrichment shape changes.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -562,7 +562,8 @@ Current test coverage includes:
 | `RATE_LIMIT_MAX` | Per-IP request cap for the 15-minute window. |
 | `TIMEOUT_MS` | HTTP request timeout in ms. Default `30000`. |
 | `SEARCH_CACHE_PATH` | Optional override for the search cache JSON path. |
-| `ANALYTICS_TOKEN` | Optional Plausible/analytics token for the `/api/_stats` endpoint. |
+| `ANALYTICS_TOKEN` | Token required by the `/api/_stats` endpoint; also used as the analytics sketch key unless `ANALYTICS_HASH_KEY` is set. |
+| `ANALYTICS_HASH_KEY` | Optional stable secret used to key privacy-preserving daily unique-user estimates. Set this separately to allow analytics-token rotation without resetting deduplication. |
 | `OPENROUTER_API_KEY` | Fallback OpenRouter key used by static summaries and recital titles when the feature-specific key is not set. |
 | `OPENROUTER_BASE_URL` | Override (default `https://openrouter.ai/api/v1`). |
 | `LAW_SUMMARY_OPENROUTER_API_KEY` | Optional OpenRouter key used for law summaries and article case-law digests. Falls back to `ARTICLE_QA_OPENROUTER_API_KEY`, then `OPENROUTER_API_KEY`. |

--- a/backend/bin/stats.js
+++ b/backend/bin/stats.js
@@ -105,10 +105,9 @@ function print(d) {
     { label: 'celex', get: (r) => r.celex },
     { label: 'count', get: (r) => r.count },
   ]);
-  section('Top searches', d.topSearches, [
-    { label: 'q', get: (r) => r.q },
-    { label: 'count', get: (r) => r.count },
-  ]);
+  if (Number.isFinite(d.totalSearches)) {
+    console.log(`\nSearches: ${d.totalSearches} total (query text is not stored)`);
+  }
 
   if (d.caseLawCache) {
     console.log('\nCase-law cache:');

--- a/backend/bin/stats.js
+++ b/backend/bin/stats.js
@@ -70,23 +70,46 @@ function print(d) {
   console.log(`Backend: ${base}`);
   console.log(`Uptime:  ${fmtUptime(d.uptimeSec || 0)}`);
   console.log(
-    `Today:   ${d.today?.date}  requests=${d.today?.requests}  uniqueUsers=${d.today?.uniqueUsers}`
+    `Today:   ${d.today?.date}  requests=${d.today?.requests}  uniqueUsers~=${d.today?.uniqueUsers}`
   );
 
-  const days = Object.keys({ ...(d.dayCounts || {}), ...(d.dayUniques || {}) }).sort();
-  const recent = days.slice(-14);
+  // Prefer the schema-v2 `days` map; fall back to the legacy flat counters.
+  const daily = { ...(d.days || {}) };
+  if (d.today?.date) daily[d.today.date] = d.today;
+  if (!d.days) {
+    for (const date of Object.keys({ ...(d.dayCounts || {}), ...(d.dayUniques || {}) })) {
+      daily[date] = {
+        requests: d.dayCounts?.[date] ?? 0,
+        uniqueUsersEstimate: d.dayUniques?.[date] ?? 0,
+      };
+    }
+  }
+  const end = new Date(`${d.today?.date || new Date().toISOString().slice(0, 10)}T00:00:00Z`);
+  const cutoff = new Date(end);
+  cutoff.setUTCDate(cutoff.getUTCDate() - 13);
+  const recent = Object.keys(daily).sort().filter((date) => new Date(`${date}T00:00:00Z`) >= cutoff);
   if (recent.length) {
     console.log('\nLast 14 days:');
     table(
       recent.map((date) => ({
         date,
-        requests: d.dayCounts?.[date] ?? 0,
-        unique: d.dayUniques?.[date] ?? 0,
+        requests: daily[date].requests ?? 0,
+        unique: daily[date].uniqueUsersEstimate ?? daily[date].uniqueUsers ?? 0,
+        web: daily[date].channels?.web ?? 0,
+        api: daily[date].channels?.api ?? 0,
+        mcp: daily[date].channels?.mcp ?? 0,
+        errors: (daily[date].statusCodes?.['4xx'] || 0) + (daily[date].statusCodes?.['5xx'] || 0),
+        searches: daily[date].searches ?? 0,
       })),
       [
         { label: 'date', get: (r) => r.date },
         { label: 'requests', get: (r) => r.requests },
-        { label: 'unique', get: (r) => r.unique },
+        { label: 'unique~', get: (r) => r.unique },
+        { label: 'web', get: (r) => r.web },
+        { label: 'api', get: (r) => r.api },
+        { label: 'mcp', get: (r) => r.mcp },
+        { label: 'errors', get: (r) => r.errors },
+        { label: 'searches', get: (r) => r.searches },
       ]
     );
   }

--- a/backend/shared/analytics.js
+++ b/backend/shared/analytics.js
@@ -55,8 +55,8 @@ function createAnalytics({ cacheDir } = {}) {
 
   const routeCounts = new Map();
   const celexCounts = new Map();
-  const searchCounts = new Map();
   const channelCounts = new Map(); // all-time: 'web' | 'api' | 'mcp' -> count
+  let totalSearches = 0;
   let dayCounts = {};
   let dayUniques = {};
   let dayChannels = {}; // date -> { web, api, mcp }
@@ -72,8 +72,10 @@ function createAnalytics({ cacheDir } = {}) {
         const saved = JSON.parse(fs.readFileSync(analyticsFile, 'utf8'));
         if (saved.routeCounts) for (const [k, v] of Object.entries(saved.routeCounts)) routeCounts.set(k, v);
         if (saved.celexCounts) for (const [k, v] of Object.entries(saved.celexCounts)) celexCounts.set(k, v);
-        if (saved.searchCounts) for (const [k, v] of Object.entries(saved.searchCounts)) searchCounts.set(k, v);
         if (saved.channelCounts) for (const [k, v] of Object.entries(saved.channelCounts)) channelCounts.set(k, v);
+        // Legacy formats persisted per-query counts; keep the aggregate total, drop the raw text.
+        totalSearches = Number(saved.totalSearches) || Object.values(saved.searchCounts || {})
+          .reduce((sum, count) => sum + (Number(count) || 0), 0);
         if (saved.dayCounts) dayCounts = saved.dayCounts;
         if (saved.dayUniques) dayUniques = saved.dayUniques;
         if (saved.dayChannels) dayChannels = saved.dayChannels;
@@ -117,8 +119,8 @@ function createAnalytics({ cacheDir } = {}) {
       const data = {
         routeCounts: Object.fromEntries(routeCounts),
         celexCounts: Object.fromEntries(celexCounts),
-        searchCounts: Object.fromEntries(searchCounts),
         channelCounts: Object.fromEntries(channelCounts),
+        totalSearches,
         dayCounts,
         dayUniques,
         dayChannels,
@@ -166,11 +168,7 @@ function createAnalytics({ cacheDir } = {}) {
       }
 
       if (route && route.includes('search') && res.statusCode === 200) {
-        const q = String(req.query?.q || '').toLowerCase().trim().slice(0, 120);
-        if (q) {
-          searchCounts.set(q, (searchCounts.get(q) || 0) + 1);
-          capMap(searchCounts);
-        }
+        totalSearches++;
       }
     });
     next();
@@ -193,10 +191,8 @@ function createAnalytics({ cacheDir } = {}) {
       capMap(celexCounts);
     }
 
-    const q = String(query || '').toLowerCase().trim().slice(0, 120);
-    if (q) {
-      searchCounts.set(q, (searchCounts.get(q) || 0) + 1);
-      capMap(searchCounts);
+    if (String(query || '').trim()) {
+      totalSearches++;
     }
   }
 
@@ -232,7 +228,6 @@ function createAnalytics({ cacheDir } = {}) {
     rolloverDayIfNeeded();
     const topCelexes = topN(celexCounts).map(({ key, count }) => ({ celex: key, count }));
     const topRoutes = topN(routeCounts).map(({ key, count }) => ({ route: key, count }));
-    const topSearches = topN(searchCounts).map(({ key, count }) => ({ q: key, count }));
     return {
       uptimeSec: Math.floor((Date.now() - startTime) / 1000),
       today: { date: todayDate, requests: todayRequests, uniqueUsers: todayIps.size, channels: { ...todayChannels } },
@@ -240,9 +235,9 @@ function createAnalytics({ cacheDir } = {}) {
       dayUniques,
       dayChannels,
       channels: Object.fromEntries(channelCounts),
+      totalSearches,
       topCelexes,
       topRoutes,
-      topSearches,
       caseLawCache: getCaseLawCacheStats(),
     };
   }

--- a/backend/shared/analytics.js
+++ b/backend/shared/analytics.js
@@ -1,3 +1,4 @@
+const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const { CASE_LAW_CACHE_FILE } = require('./law-queries');
@@ -5,13 +6,15 @@ const { CASE_LAW_CACHE_FILE } = require('./law-queries');
 const FLUSH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const DAY_RETENTION = 90;
 const COUNTER_CAP = 1000;
+const UNIQUE_BITMAP_BITS = 16 * 1024;
+const UNIQUE_BITMAP_BYTES = UNIQUE_BITMAP_BITS / 8;
 
 function getClientIp(req) {
-  return req.ip || req.socket?.remoteAddress || 'unknown';
+  return req.ip || req.socket?.remoteAddress || null;
 }
 
 function truncateIp(ip) {
-  if (!ip || ip === 'unknown') return 'unknown';
+  if (!ip) return null;
   // Strip IPv6 zone ID
   const bare = ip.replace(/%.*$/, '');
   // v4-mapped IPv6: ::ffff:1.2.3.4
@@ -28,8 +31,8 @@ function truncateIp(ip) {
   return bare;
 }
 
-function utcDateString() {
-  return new Date().toISOString().slice(0, 10);
+function utcDateString(now = () => new Date()) {
+  return now().toISOString().slice(0, 10);
 }
 
 function capMap(map) {
@@ -39,31 +42,101 @@ function capMap(map) {
   for (const [k] of toDelete) map.delete(k);
 }
 
-function trimObject(obj, maxEntries) {
-  const keys = Object.keys(obj);
-  if (keys.length <= maxEntries) return obj;
-  const sorted = keys.sort();
-  const keep = sorted.slice(sorted.length - maxEntries);
-  const result = {};
-  for (const k of keep) result[k] = obj[k];
-  return result;
+function increment(obj, key) {
+  obj[key] = (obj[key] || 0) + 1;
 }
 
-function createAnalytics({ cacheDir } = {}) {
+function trimDays(days) {
+  const keys = Object.keys(days).sort();
+  for (const key of keys.slice(0, Math.max(0, keys.length - DAY_RETENTION))) delete days[key];
+}
+
+// A per-day record. Unique users are tracked in a keyed, fixed-size bitmap
+// sketch rather than a stored set of addresses, so we keep no per-visitor
+// identifiers on disk. `uniqueUsersLegacy` carries forward exact counts
+// migrated from the old flat format as a floor for the estimate.
+function newDaily(date) {
+  return {
+    date,
+    requests: 0,
+    uniqueSketch: Buffer.alloc(UNIQUE_BITMAP_BYTES),
+    uniqueUsersLegacy: null,
+    channels: { web: 0, api: 0, mcp: 0 },
+    searches: 0,
+  };
+}
+
+function decodeSketch(value) {
+  if (!value) return Buffer.alloc(UNIQUE_BITMAP_BYTES);
+  try {
+    const decoded = Buffer.from(value, 'base64');
+    if (decoded.length === UNIQUE_BITMAP_BYTES) return decoded;
+  } catch {
+    // Invalid persisted sketches are treated as empty.
+  }
+  return Buffer.alloc(UNIQUE_BITMAP_BYTES);
+}
+
+function hydrateDaily(date, saved = {}) {
+  const daily = newDaily(date);
+  daily.requests = Number(saved.requests) || 0;
+  daily.uniqueSketch = decodeSketch(saved.uniqueSketch);
+  daily.uniqueUsersLegacy = Number.isFinite(saved.uniqueUsers) ? saved.uniqueUsers : null;
+  daily.channels = { ...daily.channels, ...(saved.channels || {}) };
+  daily.searches = Number(saved.searches) || 0;
+  return daily;
+}
+
+function serializeDaily(daily) {
+  return {
+    requests: daily.requests,
+    uniqueSketch: daily.uniqueSketch.toString('base64'),
+    ...(daily.uniqueUsersLegacy == null ? {} : { uniqueUsers: daily.uniqueUsersLegacy }),
+    channels: daily.channels,
+    searches: daily.searches,
+  };
+}
+
+// Fold an anonymized network bucket into the day's sketch. The HMAC key keeps
+// buckets from being reversible and lets the token rotate without resetting
+// deduplication when ANALYTICS_HASH_KEY is set separately.
+function markUnique(daily, ip, hashKey) {
+  const bucket = truncateIp(ip);
+  if (!bucket) return;
+  const digest = crypto.createHmac('sha256', hashKey).update(`${daily.date}:${bucket}`).digest();
+  const bit = digest.readUInt16BE(0) % UNIQUE_BITMAP_BITS;
+  daily.uniqueSketch[bit >> 3] |= 1 << (bit & 7);
+}
+
+// Estimate distinct buckets from the number of set bits using the standard
+// "number of occupied cells" cardinality approximation.
+function estimateUniques(daily) {
+  let occupied = 0;
+  for (const byte of daily.uniqueSketch) {
+    let value = byte;
+    while (value) {
+      occupied += value & 1;
+      value >>= 1;
+    }
+  }
+  const estimated = occupied === UNIQUE_BITMAP_BITS
+    ? UNIQUE_BITMAP_BITS
+    : Math.round(-UNIQUE_BITMAP_BITS * Math.log(1 - occupied / UNIQUE_BITMAP_BITS));
+  return Math.max(estimated, daily.uniqueUsersLegacy || 0);
+}
+
+function createAnalytics({ cacheDir, now = () => new Date(), hashKey } = {}) {
   const startTime = Date.now();
   const analyticsFile = cacheDir ? path.join(cacheDir, 'analytics.json') : null;
+  const uniqueHashKey = hashKey || process.env.ANALYTICS_HASH_KEY
+    || process.env.ANALYTICS_TOKEN || crypto.randomBytes(32);
 
   const routeCounts = new Map();
   const celexCounts = new Map();
   const channelCounts = new Map(); // all-time: 'web' | 'api' | 'mcp' -> count
+  const days = {};
   let totalSearches = 0;
-  let dayCounts = {};
-  let dayUniques = {};
-  let dayChannels = {}; // date -> { web, api, mcp }
-  let todayDate = utcDateString();
-  let todayIps = new Set();
-  let todayRequests = 0;
-  let todayChannels = { web: 0, api: 0, mcp: 0 };
+  let today = newDaily(utcDateString(now));
 
   // Hydrate from disk
   if (analyticsFile) {
@@ -76,55 +149,64 @@ function createAnalytics({ cacheDir } = {}) {
         // Legacy formats persisted per-query counts; keep the aggregate total, drop the raw text.
         totalSearches = Number(saved.totalSearches) || Object.values(saved.searchCounts || {})
           .reduce((sum, count) => sum + (Number(count) || 0), 0);
-        if (saved.dayCounts) dayCounts = saved.dayCounts;
-        if (saved.dayUniques) dayUniques = saved.dayUniques;
-        if (saved.dayChannels) dayChannels = saved.dayChannels;
-        if (saved.today?.date === todayDate) {
-          todayIps = new Set(saved.today.uniqueIps || []);
-          todayRequests = saved.today.requests || 0;
-          if (saved.today.channels) {
-            todayChannels = {
-              web: saved.today.channels.web || 0,
-              api: saved.today.channels.api || 0,
-              mcp: saved.today.channels.mcp || 0,
-            };
+
+        if (saved.days) {
+          for (const [date, daily] of Object.entries(saved.days)) days[date] = hydrateDaily(date, daily);
+        } else {
+          // Migrate the flat v1 layout (dayCounts / dayUniques / dayChannels).
+          for (const date of new Set([
+            ...Object.keys(saved.dayCounts || {}),
+            ...Object.keys(saved.dayUniques || {}),
+            ...Object.keys(saved.dayChannels || {}),
+          ])) {
+            days[date] = hydrateDaily(date, {
+              requests: saved.dayCounts?.[date],
+              uniqueUsers: saved.dayUniques?.[date],
+              channels: saved.dayChannels?.[date],
+            });
           }
         }
+
+        if (saved.today?.date === today.date) {
+          today = hydrateDaily(today.date, saved.today);
+          for (const ip of saved.today.uniqueIps || []) markUnique(today, ip, uniqueHashKey);
+        } else if (saved.today?.date) {
+          // The service restarted on a later date: archive the stale `today`
+          // instead of dropping it.
+          const stale = hydrateDaily(saved.today.date, saved.today);
+          for (const ip of saved.today.uniqueIps || []) markUnique(stale, ip, uniqueHashKey);
+          const existing = days[stale.date];
+          if (!existing || stale.requests > existing.requests) days[stale.date] = stale;
+        }
+        trimDays(days);
       }
     } catch {
-      // best-effort hydration
+      // Analytics must never prevent the API from starting.
     }
   }
 
   function rolloverDayIfNeeded() {
-    const today = utcDateString();
-    if (today !== todayDate) {
-      dayUniques[todayDate] = todayIps.size;
-      dayCounts[todayDate] = (dayCounts[todayDate] || 0) + todayRequests;
-      dayChannels[todayDate] = todayChannels;
-      todayDate = today;
-      todayIps = new Set();
-      todayRequests = 0;
-      todayChannels = { web: 0, api: 0, mcp: 0 };
-      dayCounts = trimObject(dayCounts, DAY_RETENTION);
-      dayUniques = trimObject(dayUniques, DAY_RETENTION);
-      dayChannels = trimObject(dayChannels, DAY_RETENTION);
-    }
+    const date = utcDateString(now);
+    if (date === today.date) return;
+    days[today.date] = today;
+    today = newDaily(date);
+    trimDays(days);
   }
 
   function flush() {
     if (!analyticsFile) return;
     rolloverDayIfNeeded();
     try {
+      const persistedDays = {};
+      for (const [date, daily] of Object.entries(days)) persistedDays[date] = serializeDaily(daily);
       const data = {
+        schemaVersion: 2,
         routeCounts: Object.fromEntries(routeCounts),
         celexCounts: Object.fromEntries(celexCounts),
         channelCounts: Object.fromEntries(channelCounts),
         totalSearches,
-        dayCounts,
-        dayUniques,
-        dayChannels,
-        today: { date: todayDate, requests: todayRequests, uniqueIps: [...todayIps], channels: todayChannels },
+        days: persistedDays,
+        today: { date: today.date, ...serializeDaily(today) },
       };
       const tmp = analyticsFile + '.tmp';
       fs.writeFileSync(tmp, JSON.stringify(data), 'utf8');
@@ -146,13 +228,11 @@ function createAnalytics({ cacheDir } = {}) {
   function middleware(req, res, next) {
     res.on('finish', () => {
       rolloverDayIfNeeded();
-
-      const ip = truncateIp(getClientIp(req));
-      todayIps.add(ip);
-      todayRequests++;
+      today.requests++;
+      markUnique(today, getClientIp(req), uniqueHashKey);
 
       const channel = classifyChannel(req);
-      todayChannels[channel] = (todayChannels[channel] || 0) + 1;
+      increment(today.channels, channel);
       channelCounts.set(channel, (channelCounts.get(channel) || 0) + 1);
 
       const route = req.route?.path;
@@ -168,6 +248,7 @@ function createAnalytics({ cacheDir } = {}) {
       }
 
       if (route && route.includes('search') && res.statusCode === 200) {
+        today.searches++;
         totalSearches++;
       }
     });
@@ -192,6 +273,7 @@ function createAnalytics({ cacheDir } = {}) {
     }
 
     if (String(query || '').trim()) {
+      today.searches++;
       totalSearches++;
     }
   }
@@ -201,6 +283,15 @@ function createAnalytics({ cacheDir } = {}) {
       .sort((a, b) => b[1] - a[1])
       .slice(0, n)
       .map(([key, count]) => ({ key, count }));
+  }
+
+  function publicDaily(daily) {
+    return {
+      requests: daily.requests,
+      uniqueUsersEstimate: estimateUniques(daily),
+      channels: { ...daily.channels },
+      searches: daily.searches,
+    };
   }
 
   function getCaseLawCacheStats() {
@@ -226,18 +317,23 @@ function createAnalytics({ cacheDir } = {}) {
 
   function getStats() {
     rolloverDayIfNeeded();
-    const topCelexes = topN(celexCounts).map(({ key, count }) => ({ celex: key, count }));
-    const topRoutes = topN(routeCounts).map(({ key, count }) => ({ route: key, count }));
+    const publicDays = {};
+    for (const [date, daily] of Object.entries(days)) publicDays[date] = publicDaily(daily);
+    const todayPublic = publicDaily(today);
     return {
+      schemaVersion: 2,
+      privacy: {
+        uniqueUsers: 'daily estimate of anonymized network buckets from a keyed bitmap',
+        searchQueriesStored: false,
+        retentionDays: DAY_RETENTION,
+      },
       uptimeSec: Math.floor((Date.now() - startTime) / 1000),
-      today: { date: todayDate, requests: todayRequests, uniqueUsers: todayIps.size, channels: { ...todayChannels } },
-      dayCounts,
-      dayUniques,
-      dayChannels,
+      today: { date: today.date, ...todayPublic, uniqueUsers: todayPublic.uniqueUsersEstimate },
+      days: publicDays,
       channels: Object.fromEntries(channelCounts),
       totalSearches,
-      topCelexes,
-      topRoutes,
+      topCelexes: topN(celexCounts).map(({ key, count }) => ({ celex: key, count })),
+      topRoutes: topN(routeCounts).map(({ key, count }) => ({ route: key, count })),
       caseLawCache: getCaseLawCacheStats(),
     };
   }

--- a/backend/shared/analytics.js
+++ b/backend/shared/analytics.js
@@ -4,6 +4,9 @@ const path = require('path');
 const { CASE_LAW_CACHE_FILE } = require('./law-queries');
 
 const FLUSH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+// Bump when the persisted analytics.json shape changes (see the cache-version
+// table in the root CLAUDE.md). Older files are migrated on load.
+const ANALYTICS_SCHEMA_VERSION = 2;
 const DAY_RETENTION = 90;
 const COUNTER_CAP = 1000;
 const DAILY_TOP_LIMIT = 20;
@@ -224,7 +227,7 @@ function createAnalytics({ cacheDir, now = () => new Date(), hashKey } = {}) {
       const persistedDays = {};
       for (const [date, daily] of Object.entries(days)) persistedDays[date] = serializeDaily(daily);
       const data = {
-        schemaVersion: 2,
+        schemaVersion: ANALYTICS_SCHEMA_VERSION,
         routeCounts: Object.fromEntries(routeCounts),
         celexCounts: Object.fromEntries(celexCounts),
         channelCounts: Object.fromEntries(channelCounts),
@@ -365,7 +368,7 @@ function createAnalytics({ cacheDir, now = () => new Date(), hashKey } = {}) {
     for (const [date, daily] of Object.entries(days)) publicDays[date] = publicDaily(daily);
     const todayPublic = publicDaily(today);
     return {
-      schemaVersion: 2,
+      schemaVersion: ANALYTICS_SCHEMA_VERSION,
       privacy: {
         uniqueUsers: 'daily estimate of anonymized network buckets from a keyed bitmap',
         searchQueriesStored: false,

--- a/backend/shared/analytics.js
+++ b/backend/shared/analytics.js
@@ -6,6 +6,7 @@ const { CASE_LAW_CACHE_FILE } = require('./law-queries');
 const FLUSH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 const DAY_RETENTION = 90;
 const COUNTER_CAP = 1000;
+const DAILY_TOP_LIMIT = 20;
 const UNIQUE_BITMAP_BITS = 16 * 1024;
 const UNIQUE_BITMAP_BYTES = UNIQUE_BITMAP_BITS / 8;
 
@@ -46,6 +47,20 @@ function increment(obj, key) {
   obj[key] = (obj[key] || 0) + 1;
 }
 
+function capObject(obj) {
+  const entries = Object.entries(obj);
+  if (entries.length <= COUNTER_CAP) return;
+  entries.sort((a, b) => a[1] - b[1]);
+  for (const [key] of entries.slice(0, entries.length - COUNTER_CAP)) delete obj[key];
+}
+
+function topObject(obj, n = DAILY_TOP_LIMIT) {
+  return Object.entries(obj)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, n)
+    .map(([key, count]) => ({ key, count }));
+}
+
 function trimDays(days) {
   const keys = Object.keys(days).sort();
   for (const key of keys.slice(0, Math.max(0, keys.length - DAY_RETENTION))) delete days[key];
@@ -62,6 +77,9 @@ function newDaily(date) {
     uniqueSketch: Buffer.alloc(UNIQUE_BITMAP_BYTES),
     uniqueUsersLegacy: null,
     channels: { web: 0, api: 0, mcp: 0 },
+    statusCodes: {},
+    routes: {},
+    celexes: {},
     searches: 0,
   };
 }
@@ -83,6 +101,9 @@ function hydrateDaily(date, saved = {}) {
   daily.uniqueSketch = decodeSketch(saved.uniqueSketch);
   daily.uniqueUsersLegacy = Number.isFinite(saved.uniqueUsers) ? saved.uniqueUsers : null;
   daily.channels = { ...daily.channels, ...(saved.channels || {}) };
+  daily.statusCodes = { ...(saved.statusCodes || {}) };
+  daily.routes = { ...(saved.routes || {}) };
+  daily.celexes = { ...(saved.celexes || {}) };
   daily.searches = Number(saved.searches) || 0;
   return daily;
 }
@@ -93,6 +114,9 @@ function serializeDaily(daily) {
     uniqueSketch: daily.uniqueSketch.toString('base64'),
     ...(daily.uniqueUsersLegacy == null ? {} : { uniqueUsers: daily.uniqueUsersLegacy }),
     channels: daily.channels,
+    statusCodes: daily.statusCodes,
+    routes: daily.routes,
+    celexes: daily.celexes,
     searches: daily.searches,
   };
 }
@@ -225,6 +249,18 @@ function createAnalytics({ cacheDir, now = () => new Date(), hashKey } = {}) {
     return 'api';
   }
 
+  function recordDailyRoute(route) {
+    if (!route) return;
+    increment(today.routes, route);
+    capObject(today.routes);
+  }
+
+  function recordDailyCelex(celex) {
+    if (!celex) return;
+    increment(today.celexes, celex);
+    capObject(today.celexes);
+  }
+
   function middleware(req, res, next) {
     res.on('finish', () => {
       rolloverDayIfNeeded();
@@ -234,17 +270,20 @@ function createAnalytics({ cacheDir, now = () => new Date(), hashKey } = {}) {
       const channel = classifyChannel(req);
       increment(today.channels, channel);
       channelCounts.set(channel, (channelCounts.get(channel) || 0) + 1);
+      increment(today.statusCodes, `${Math.floor((res.statusCode || 0) / 100)}xx`);
 
       const route = req.route?.path;
       if (route) {
         routeCounts.set(route, (routeCounts.get(route) || 0) + 1);
         capMap(routeCounts);
+        recordDailyRoute(route);
       }
 
       const celex = req.params?.celex;
       if (celex && res.statusCode < 500) {
         celexCounts.set(celex, (celexCounts.get(celex) || 0) + 1);
         capMap(celexCounts);
+        recordDailyCelex(celex);
       }
 
       if (route && route.includes('search') && res.statusCode === 200) {
@@ -266,10 +305,12 @@ function createAnalytics({ cacheDir, now = () => new Date(), hashKey } = {}) {
     const routeKey = `mcp:${toolName}`;
     routeCounts.set(routeKey, (routeCounts.get(routeKey) || 0) + 1);
     capMap(routeCounts);
+    recordDailyRoute(routeKey);
 
     if (celex) {
       celexCounts.set(celex, (celexCounts.get(celex) || 0) + 1);
       capMap(celexCounts);
+      recordDailyCelex(celex);
     }
 
     if (String(query || '').trim()) {
@@ -290,7 +331,10 @@ function createAnalytics({ cacheDir, now = () => new Date(), hashKey } = {}) {
       requests: daily.requests,
       uniqueUsersEstimate: estimateUniques(daily),
       channels: { ...daily.channels },
+      statusCodes: { ...daily.statusCodes },
       searches: daily.searches,
+      topRoutes: topObject(daily.routes).map(({ key, count }) => ({ route: key, count })),
+      topCelexes: topObject(daily.celexes).map(({ key, count }) => ({ celex: key, count })),
     };
   }
 

--- a/backend/shared/analytics.test.js
+++ b/backend/shared/analytics.test.js
@@ -37,7 +37,7 @@ test('recordMcpTool feeds route, celex, and search counters', () => {
   assert.ok(stats.topRoutes.some((r) => r.route === 'mcp:get_law_part' && r.count === 1));
   assert.ok(stats.topRoutes.some((r) => r.route === 'mcp:search_eu_law'));
   assert.ok(stats.topCelexes.some((c) => c.celex === '32016R0679'));
-  assert.ok(stats.topSearches.some((s) => s.q === 'right to erasure'), 'search query is lowercased');
+  assert.equal(stats.totalSearches, 1);
   analytics.shutdown();
 });
 

--- a/backend/shared/analytics.test.js
+++ b/backend/shared/analytics.test.js
@@ -5,9 +5,9 @@ const { createAnalytics } = require('./analytics');
 const { CASE_LAW_CACHE_FILE } = require('./law-queries');
 
 // Drive the finish handler the way Express would.
-function hit(analytics, req) {
+function hit(analytics, req, statusCode = 200) {
   let onFinish;
-  const res = { on: (event, cb) => { if (event === 'finish') onFinish = cb; } };
+  const res = { statusCode, on: (event, cb) => { if (event === 'finish') onFinish = cb; } };
   analytics.middleware(req, res, () => {});
   onFinish();
 }
@@ -53,9 +53,13 @@ test('persists channel counters across a flush/reload cycle', () => {
   first.shutdown(); // flush to disk
 
   const persisted = JSON.parse(fs.readFileSync(path.join(cacheDir, 'analytics.json'), 'utf8'));
+  assert.equal(persisted.schemaVersion, 2);
   assert.equal(persisted.channelCounts.mcp, 1);
   assert.equal(persisted.channelCounts.web, 1);
   assert.deepEqual(persisted.today.channels, { web: 1, api: 0, mcp: 1 });
+  assert.equal(typeof persisted.today.uniqueSketch, 'string');
+  assert.equal('uniqueIps' in persisted.today, false);
+  assert.equal('searchCounts' in persisted, false);
 
   // A fresh instance hydrates the persisted channel state.
   const second = createAnalytics({ cacheDir });
@@ -104,4 +108,72 @@ test('getClientIp prefers req.ip and falls back to the socket address', () => {
   const stats = analytics.getStats();
   assert.equal(stats.today.uniqueUsers, 2);
   analytics.shutdown();
+});
+
+test('exposes useful per-day aggregates without identifiers or query text', () => {
+  let current = new Date('2026-07-12T23:59:00Z');
+  const analytics = createAnalytics({
+    now: () => current,
+    hashKey: 'test-only-secret',
+  });
+
+  hit(analytics, baseReq({
+    ip: '203.0.113.10',
+    path: '/api/search',
+    route: { path: '/api/search' },
+    query: { q: 'possibly sensitive phrase' },
+    headers: { 'x-legalviz-client': 'web' },
+  }));
+  hit(analytics, baseReq({
+    ip: '203.0.113.99', // Same anonymized /24 bucket.
+    path: '/api/search',
+    route: { path: '/api/search' },
+    query: { q: 'another phrase' },
+  }), 503);
+
+  current = new Date('2026-07-13T00:01:00Z');
+  const stats = analytics.getStats();
+  assert.deepEqual(stats.days['2026-07-12'], {
+    requests: 2,
+    uniqueUsersEstimate: 1,
+    channels: { web: 1, api: 1, mcp: 0 },
+    searches: 1,
+  });
+  assert.equal(JSON.stringify(stats).includes('sensitive phrase'), false);
+  analytics.shutdown();
+});
+
+test('migrates legacy history and archives a stale persisted today', () => {
+  const os = require('node:os');
+  const fs = require('node:fs');
+  const path = require('node:path');
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'analytics-migration-'));
+  fs.writeFileSync(path.join(cacheDir, 'analytics.json'), JSON.stringify({
+    dayCounts: { '2026-07-10': 12 },
+    dayUniques: { '2026-07-10': 4 },
+    today: {
+      date: '2026-07-12',
+      requests: 7,
+      uniqueIps: ['203.0.113.0', '198.51.100.0'],
+      channels: { web: 5, api: 2, mcp: 0 },
+    },
+    searchCounts: { private: 3, terms: 2 },
+  }), 'utf8');
+
+  const analytics = createAnalytics({
+    cacheDir,
+    now: () => new Date('2026-07-13T12:00:00Z'),
+    hashKey: 'test-only-secret',
+  });
+  const stats = analytics.getStats();
+  assert.equal(stats.days['2026-07-10'].requests, 12);
+  assert.equal(stats.days['2026-07-10'].uniqueUsersEstimate, 4);
+  assert.equal(stats.days['2026-07-12'].requests, 7);
+  assert.equal(stats.days['2026-07-12'].uniqueUsersEstimate, 2);
+  assert.equal(stats.totalSearches, 5);
+
+  analytics.shutdown();
+  const persisted = fs.readFileSync(path.join(cacheDir, 'analytics.json'), 'utf8');
+  assert.equal(persisted.includes('uniqueIps'), false);
+  assert.equal(persisted.includes('private'), false);
 });

--- a/backend/shared/analytics.test.js
+++ b/backend/shared/analytics.test.js
@@ -137,7 +137,10 @@ test('exposes useful per-day aggregates without identifiers or query text', () =
     requests: 2,
     uniqueUsersEstimate: 1,
     channels: { web: 1, api: 1, mcp: 0 },
+    statusCodes: { '2xx': 1, '5xx': 1 },
     searches: 1,
+    topRoutes: [{ route: '/api/search', count: 2 }],
+    topCelexes: [],
   });
   assert.equal(JSON.stringify(stats).includes('sensitive phrase'), false);
   analytics.shutdown();


### PR DESCRIPTION
## Summary

This reworks the backend analytics to store fewer identifying/sensitive fields while surfacing more useful daily operational insight — the same goal as #81, but split into four independent, individually-reviewable commits with the unrelated cosmetic churn removed.

Review commit-by-commit:

1. **Stop persisting raw search query text** — replace the per-query `searchCounts` map (which stored lowercased search phrases) with a single `totalSearches` counter. Legacy files migrate by summing their counts.
2. **Track analytics per day with a keyed unique-user sketch** — replace `dayCounts`/`dayUniques`/`dayChannels` and the persisted set of truncated visitor IPs with one per-day record. Daily uniqueness is estimated from a keyed, fixed-size HMAC bitmap sketch, so no per-visitor identifiers are written to disk. Persisted format is `schemaVersion` 2; v1 files migrate on load and a stale `today` is archived (not dropped) when the service restarts on a later date.
3. **Add per-day status-class, route, and CELEX insights** — extend the daily record with 2xx/4xx/5xx counts and per-day top routes/CELEXes.
4. **Report richer analytics in the stats CLI and document the schema** — real 14-calendar-day window, per-day channel/error/search columns, unique users labelled as an estimate; document `ANALYTICS_HASH_KEY` and record `ANALYTICS_SCHEMA_VERSION` in the cache-version table.

## Why this instead of #81

#81 bundled all of the above into a single 430-line commit that also carried unrelated reformatting (renamed loop variables, deleted comments, re-flowed unchanged code), which made the real change hard to review and impossible to approve piecemeal. Here each concern is its own commit, the cosmetic churn is gone, and the schema change is guarded by a named version constant per the repo's cache-invalidation discipline (which #81 skipped).

## Config

- `ANALYTICS_TOKEN` still gates `/api/_stats` and doubles as the default sketch key.
- `ANALYTICS_HASH_KEY` (new, optional) keys the unique-user sketch independently, so the token can rotate without resetting deduplication.

## Validation

- `npm test` (backend): **142 tests passing**, including new migration and per-day-aggregate tests that assert no identifiers or query text leak into the persisted file or the stats payload.
- `npx eslint` on all changed files: clean.
- End-to-end smoke of `createAnalytics` → `getStats` → stats-CLI render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPJiKw3Ysk53icXQLqeWtS

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPJiKw3Ysk53icXQLqeWtS)_