### PR TITLE
Add CI workflow to run lint/test/build on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  pull_request:
+  push: { branches: [ main ] }
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+permissions:
+  contents: read
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with: { node-version: '24' }
+      - run: npm ci
+      - run: npm ci --prefix backend
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build


### PR DESCRIPTION
## Why

Today the only workflow is `pages.yml` ("Deploy Vite to GitHub Pages"), which triggers on `push` to `main` and `workflow_dispatch`. Its `lint`/`test`/`build` steps exist as pre-flight gates *inside the deploy job* so a broken build never gets published.

The side effect: **pull requests and feature branches get no CI**. A PR can be red-in-waiting with no checks shown, and lint/test failures only surface *after* merge — manifesting as a failed Pages deploy rather than a clear "tests failed" signal, when it's already too late to block the merge.

## What

Adds a dedicated `.github/workflows/ci.yml` that runs `npm run lint`, `npm test`, and `npm run build` on:

- `pull_request` (any branch → gives PRs real status checks)
- `push` to `main`

`pages.yml` is intentionally left **unchanged**. Its in-job lint/test steps are kept as a deploy gate: the two workflows run independently on a `main` push, so removing those steps would let `deploy-pages` publish even if CI failed. Keeping them preserves the "never deploy a broken build" guarantee. The minor duplication on `main` pushes is cheap insurance.

## Notes

- Mirrors the existing Node 24 setup and `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env from `pages.yml`.
- Installs both frontend and `backend/` deps, matching the deploy job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BiATzprPN7iaYkZ3zRCknV)_