### PR TITLE
Expose EuroVoc topics on the landing page cards

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -182,6 +182,7 @@ cat input.xml | parse-fmx > output.json
 | `GET` | `/api/laws/:celex/articles/:n/case-law-digest?lang=ENG` | Cached static digest of CJEU case law interpreting one article. Zero-case results are cached without an LLM call. |
 | `GET` | `/api/laws/by-reference?actType=...&year=...&number=...` | Fetch law by official reference |
 | `GET` | `/api/search?q=keyword&limit=10` | Search law metadata |
+| `GET` | `/api/topics?celex=32016R0679,32024R1689` | Bulk EuroVoc topics for up to 200 CELEX ids (`{ topics: { CELEX: string[] } }`) |
 | `GET` | `/api/resolve-reference?actType=...&year=...&number=...` | Resolve legal reference to CELEX |
 | `GET` | `/api/resolve-url?url=...` | Resolve EUR-Lex URL to CELEX |
 | `POST` | `/mcp` | Model Context Protocol endpoint (see [MCP server](#mcp-server)) |

--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -5,6 +5,7 @@ const path = require("path");
 const { ClientError } = require("../shared/api-utils");
 const { parseFmxXml } = require("../shared/fmx-parser-node");
 const { createSearchHandler } = require("../search/search-route");
+const { createTopicsHandler } = require("../search/topics-route");
 const { fetchMetadata, fetchAmendments, fetchImplementing, fetchCaseLaw } = require("../shared/law-queries");
 const { ChatProviderError } = require("../shared/openrouter-chat");
 const { ensureRecitalTitles } = require("../shared/recital-title-service");
@@ -565,6 +566,8 @@ function registerApiRoutes(app, deps) {
   });
 
   app.get('/api/search', rateLimitMiddleware, createSearchHandler(legalCacheStore));
+
+  app.get('/api/topics', rateLimitMiddleware, createTopicsHandler(legalCacheStore));
 
   app.get('/api/resolve-reference', rateLimitMiddleware, async (req, res) => {
     try {

--- a/backend/search/topics-route.js
+++ b/backend/search/topics-route.js
@@ -1,0 +1,62 @@
+// Bulk CELEX → EuroVoc topics lookup. The search endpoint already surfaces
+// topics on live results, but the landing library needs to backfill topics for
+// laws a client opened before that shipped, keyed by the CELEX ids it already
+// holds. This reuses the same eurovoc data attached to each search record.
+const MAX_CELEX_PER_REQUEST = 200;
+const MAX_TOPICS_PER_LAW = 5;
+
+function parseCelexList(raw) {
+  const seen = new Set();
+  const celexes = [];
+  for (const value of String(raw || "").split(",")) {
+    const celex = value.trim().toUpperCase();
+    if (!celex || seen.has(celex)) continue;
+    seen.add(celex);
+    celexes.push(celex);
+  }
+  return celexes;
+}
+
+function createTopicsHandler(legalCacheStore) {
+  return function topicsHandler(req, res) {
+    try {
+      const celexes = parseCelexList(req.query.celex);
+      if (celexes.length === 0) {
+        return res.status(400).json({
+          error: 'Query parameter "celex" required (comma-separated CELEX ids)',
+        });
+      }
+      if (celexes.length > MAX_CELEX_PER_REQUEST) {
+        return res.status(400).json({
+          error: `Too many CELEX ids requested (max ${MAX_CELEX_PER_REQUEST})`,
+        });
+      }
+
+      if (!legalCacheStore.isReady()) {
+        return res.status(503).json({
+          error: "Law search cache is not available",
+          code: "search_cache_unavailable",
+          details: legalCacheStore.getStatus(),
+        });
+      }
+
+      const topics = {};
+      for (const celex of celexes) {
+        const record = legalCacheStore.getByCelex(celex);
+        const labels = record && Array.isArray(record.eurovoc) ? record.eurovoc : [];
+        if (labels.length > 0) {
+          topics[celex] = labels.slice(0, MAX_TOPICS_PER_LAW);
+        }
+      }
+
+      res.json({ topics });
+    } catch (error) {
+      console.error("[Topics] Failed to look up topics:", error.message);
+      res.status(500).json({ error: "Topic lookup failed" });
+    }
+  };
+}
+
+module.exports = {
+  createTopicsHandler,
+};

--- a/backend/search/topics-route.test.js
+++ b/backend/search/topics-route.test.js
@@ -1,0 +1,82 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { createTopicsHandler } = require("./topics-route");
+
+function createResponseRecorder() {
+  return {
+    statusCode: 200,
+    payload: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    },
+  };
+}
+
+function createStore({ ready = true, records = {} } = {}) {
+  return {
+    isReady() {
+      return ready;
+    },
+    getStatus() {
+      return { ready, count: Object.keys(records).length };
+    },
+    getByCelex(celex) {
+      return records[celex] || null;
+    },
+  };
+}
+
+test("topics route requires celex", () => {
+  const handler = createTopicsHandler(createStore());
+  const res = createResponseRecorder();
+  handler({ query: {} }, res);
+  assert.equal(res.statusCode, 400);
+});
+
+test("topics route rejects too many celex ids", () => {
+  const handler = createTopicsHandler(createStore());
+  const res = createResponseRecorder();
+  const many = Array.from({ length: 201 }, (_, i) => `C${i}`).join(",");
+  handler({ query: { celex: many } }, res);
+  assert.equal(res.statusCode, 400);
+});
+
+test("topics route returns 503 when cache is unavailable", () => {
+  const handler = createTopicsHandler(createStore({ ready: false }));
+  const res = createResponseRecorder();
+  handler({ query: { celex: "32016R0679" } }, res);
+  assert.equal(res.statusCode, 503);
+  assert.equal(res.payload.code, "search_cache_unavailable");
+  assert.equal(res.payload.details.ready, false);
+});
+
+test("topics route maps celex ids to their eurovoc labels", () => {
+  const handler = createTopicsHandler(createStore({
+    records: {
+      "32016R0679": { celex: "32016R0679", eurovoc: ["data protection", "personal data"] },
+      "32024R1689": { celex: "32024R1689", eurovoc: [] },
+    },
+  }));
+  const res = createResponseRecorder();
+  // lowercase + duplicate + unknown celex should be normalized/handled.
+  handler({ query: { celex: "32016r0679, 32016R0679 ,32024R1689,39999X9999" } }, res);
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.payload.topics, { "32016R0679": ["data protection", "personal data"] });
+});
+
+test("topics route caps topics at five per law", () => {
+  const handler = createTopicsHandler(createStore({
+    records: {
+      "32016R0679": { celex: "32016R0679", eurovoc: ["a", "b", "c", "d", "e", "f", "g"] },
+    },
+  }));
+  const res = createResponseRecorder();
+  handler({ query: { celex: "32016R0679" } }, res);
+  assert.deepEqual(res.payload.topics["32016R0679"], ["a", "b", "c", "d", "e"]);
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { Landing } from "./components/Landing.jsx";
 import { LawViewer } from "./components/LawViewer.jsx";
 import { ThemeProvider } from "./components/ThemeProvider.jsx";
 import { runOneTimeMigrationReset } from "./utils/resetApp.js";
+import { runOneTimeTopicsBackfill } from "./utils/topicsBackfill.js";
 import { I18nProvider } from "./i18n/I18nProvider.jsx";
 import { useI18n } from "./i18n/useI18n.js";
 import { getLocaleHomePath, isSupportedUiLocale, normalizeUiLocale, SUPPORTED_UI_LOCALES } from "./i18n/localeMeta.js";
@@ -11,8 +12,13 @@ import { getLocaleHomePath, isSupportedUiLocale, normalizeUiLocale, SUPPORTED_UI
 function Layout() {
   useEffect(() => {
     runOneTimeMigrationReset().then((didReset) => {
-      if (!didReset) return;
-      window.location.replace(`${window.location.pathname}${window.location.search}${window.location.hash}`);
+      if (didReset) {
+        window.location.replace(`${window.location.pathname}${window.location.search}${window.location.hash}`);
+        return;
+      }
+      // No reset (which would reload anyway) — backfill EuroVoc topics onto
+      // library laws opened before topics were persisted. Best-effort.
+      runOneTimeTopicsBackfill().catch(() => {});
     });
   }, []);
 

--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -104,6 +104,7 @@ export function Landing({ forcedLocale = null }) {
           celex: item.celex,
           label: item.title,
           officialReference,
+          topics: item.topics,
         }).catch(() => {});
       }
 

--- a/src/components/LandingLibrary.jsx
+++ b/src/components/LandingLibrary.jsx
@@ -171,6 +171,18 @@ function LawLibraryCard({ law, onOpen, t }) {
               </span>
             ) : null}
           </div>
+          {Array.isArray(law?.topics) && law.topics.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-1">
+              {law.topics.slice(0, 3).map((topic) => (
+                <span
+                  key={topic}
+                  className="max-w-[10rem] flex-shrink-0 truncate rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+                >
+                  {topic}
+                </span>
+              ))}
+            </div>
+          ) : null}
         </div>
 
       </div>

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -885,6 +885,31 @@ export async function searchLaws(query, { limit = 10, noRewrite = false, signal 
   return res.json();
 }
 
+/**
+ * Bulk CELEX → EuroVoc topics lookup. Returns a `{ CELEX: string[] }` map;
+ * CELEX ids without known topics are simply omitted. Used to backfill topics
+ * onto library laws opened before topics were persisted.
+ */
+export async function fetchTopicsForCelexes(celexes, { signal } = {}) {
+  const unique = Array.from(new Set(
+    (Array.isArray(celexes) ? celexes : [])
+      .map((celex) => String(celex || "").trim().toUpperCase())
+      .filter(Boolean),
+  ));
+  if (unique.length === 0) return {};
+
+  const params = new URLSearchParams({ celex: unique.join(",") });
+  const url = `${API_BASE}/api/topics?${params.toString()}`;
+  const res = await apiFetch(url, { signal });
+
+  if (!res.ok) {
+    await readApiError(res, `Topic lookup failed (${res.status})`);
+  }
+
+  const payload = await res.json();
+  return payload?.topics && typeof payload.topics === "object" ? payload.topics : {};
+}
+
 export async function fetchFormexByReference(reference, lang = "EN") {
   const query = buildReferenceQuery(reference, lang);
   const url = `${API_BASE}/api/laws/by-reference?${query}`;

--- a/src/utils/library.js
+++ b/src/utils/library.js
@@ -79,6 +79,7 @@ function normalizeLawMetaEntry(entry) {
     officialReference: routeCandidate?.officialReference || null,
     slug: routeCandidate?.slug || null,
     eurlex: entry.eurlex || null,
+    topics: Array.isArray(entry.topics) ? entry.topics.filter(Boolean) : null,
     addedAt: entry.addedAt || Date.now(),
   };
 }
@@ -97,13 +98,20 @@ export async function saveLawMeta(entry) {
   const normalized = normalizeLawMetaEntry(entry);
   if (!normalized) return null;
 
-  const saved = await upsertLawMeta(normalized.celex, {
+  const updates = {
     label: normalized.label,
     raw: normalized.raw,
     officialReference: normalized.officialReference,
     eurlex: normalized.eurlex || buildEurlexCelexUrl(normalized.celex),
     addedAt: normalized.addedAt || Date.now(),
-  });
+  };
+  // Only persist topics when we actually have some, so a later save without
+  // them (or markLawOpened) never wipes previously stored EuroVoc topics.
+  if (normalized.topics && normalized.topics.length > 0) {
+    updates.topics = normalized.topics;
+  }
+
+  const saved = await upsertLawMeta(normalized.celex, updates);
   dispatchLibraryUpdate();
   return saved;
 }
@@ -157,6 +165,7 @@ export async function getLibraryLaws() {
       officialReference: candidate?.officialReference || officialReference || null,
       slug: candidate?.slug || null,
       eurlex: meta?.eurlex || buildEurlexCelexUrl(celex),
+      topics: Array.isArray(meta?.topics) ? meta.topics : null,
       addedAt: meta?.addedAt || 0,
       timestamp: meta?.lastOpened || null,
       route: getCanonicalLawRoute(candidate),

--- a/src/utils/library.test.js
+++ b/src/utils/library.test.js
@@ -45,6 +45,31 @@ describe("saveLawMeta", () => {
       })
     );
   });
+
+  it("persists EuroVoc topics when provided", async () => {
+    upsertLawMeta.mockResolvedValue({ celex: "32016R0679" });
+    await saveLawMeta({
+      celex: "32016R0679",
+      label: "GDPR",
+      topics: ["data protection", "personal data", ""],
+    });
+    expect(upsertLawMeta).toHaveBeenCalledWith(
+      "32016R0679",
+      expect.objectContaining({
+        topics: ["data protection", "personal data"],
+      })
+    );
+  });
+
+  it("does not clobber stored topics when saving without them", async () => {
+    upsertLawMeta.mockResolvedValue({ celex: "32016R0679" });
+    await saveLawMeta({
+      celex: "32016R0679",
+      label: "GDPR",
+    });
+    const updates = upsertLawMeta.mock.calls[0][1];
+    expect(updates).not.toHaveProperty("topics");
+  });
 });
 
 describe("markLawOpened", () => {
@@ -131,6 +156,28 @@ describe("getLibraryLaws", () => {
 
     const laws = await getLibraryLaws();
     expect(laws.map((law) => law.celex)).toEqual(["32016R0679"]);
+  });
+
+  it("exposes stored EuroVoc topics on library laws", async () => {
+    getAllLawMeta.mockResolvedValue([
+      { celex: "32016R0679", lastOpened: 1000, topics: ["data protection", "personal data"] },
+    ]);
+    listCachedCelexes.mockResolvedValue([]);
+
+    const laws = await getLibraryLaws();
+    const gdpr = laws.find((l) => l.celex === "32016R0679");
+    expect(gdpr.topics).toEqual(["data protection", "personal data"]);
+  });
+
+  it("defaults topics to null when none are stored", async () => {
+    getAllLawMeta.mockResolvedValue([
+      { celex: "32016R0679", lastOpened: 1000 },
+    ]);
+    listCachedCelexes.mockResolvedValue([]);
+
+    const laws = await getLibraryLaws();
+    const gdpr = laws.find((l) => l.celex === "32016R0679");
+    expect(gdpr.topics).toBeNull();
   });
 
   it("sorts by lastOpened timestamp descending", async () => {

--- a/src/utils/topicsBackfill.js
+++ b/src/utils/topicsBackfill.js
@@ -1,0 +1,94 @@
+import { fetchTopicsForCelexes, getAllLawMeta, upsertLawMeta } from "./formexApi.js";
+
+const BACKFILL_VERSION_KEY = "legalviz-topics-backfill-version";
+const CURRENT_BACKFILL_VERSION = "v1";
+// The /api/topics endpoint caps each request at 200 CELEX ids.
+const MAX_CELEX_PER_REQUEST = 200;
+
+function chunk(items, size) {
+  const chunks = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+function isVersionCurrent() {
+  try {
+    return window.localStorage.getItem(BACKFILL_VERSION_KEY) === CURRENT_BACKFILL_VERSION;
+  } catch {
+    return false;
+  }
+}
+
+function markVersionCurrent() {
+  try {
+    window.localStorage.setItem(BACKFILL_VERSION_KEY, CURRENT_BACKFILL_VERSION);
+  } catch {
+    // ignore — a failure here just means the backfill retries next load.
+  }
+}
+
+function dispatchLibraryUpdate() {
+  if (typeof window === "undefined") return;
+  try {
+    window.dispatchEvent(new CustomEvent("legalviz-library-updated"));
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * One-time, non-destructive backfill of EuroVoc topics onto library laws that
+ * were opened before topics were persisted. Guarded by its own localStorage
+ * version key (separate from the reset migration in resetApp.js) so it runs at
+ * most once per client. Writes merge into existing meta records via
+ * upsertLawMeta — nothing is wiped.
+ *
+ * Returns true if it wrote any topics, false otherwise.
+ */
+export async function runOneTimeTopicsBackfill() {
+  if (typeof window === "undefined") return false;
+  if (isVersionCurrent()) return false;
+
+  let metaEntries;
+  try {
+    metaEntries = await getAllLawMeta();
+  } catch {
+    // Can't read the library — retry on a later load rather than mark done.
+    return false;
+  }
+
+  // Only laws that lack topics need backfilling; ones saved from search already
+  // carry them.
+  const celexesNeedingTopics = metaEntries
+    .filter((entry) => entry?.celex && !(Array.isArray(entry.topics) && entry.topics.length > 0))
+    .map((entry) => entry.celex);
+
+  if (celexesNeedingTopics.length === 0) {
+    // Nothing to do now — treat the backfill as complete.
+    markVersionCurrent();
+    return false;
+  }
+
+  let wroteAny = false;
+  try {
+    for (const batch of chunk(celexesNeedingTopics, MAX_CELEX_PER_REQUEST)) {
+      const topicsByCelex = await fetchTopicsForCelexes(batch);
+      for (const [celex, topics] of Object.entries(topicsByCelex)) {
+        if (!Array.isArray(topics) || topics.length === 0) continue;
+        await upsertLawMeta(celex, { topics });
+        wroteAny = true;
+      }
+    }
+  } catch {
+    // Network / cache-unavailable error: don't mark done, so it retries later.
+    // Any topics already written this run stay — upsertLawMeta merges.
+    if (wroteAny) dispatchLibraryUpdate();
+    return wroteAny;
+  }
+
+  markVersionCurrent();
+  if (wroteAny) dispatchLibraryUpdate();
+  return wroteAny;
+}

--- a/src/utils/topicsBackfill.test.js
+++ b/src/utils/topicsBackfill.test.js
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./formexApi.js", () => ({
+  fetchTopicsForCelexes: vi.fn().mockResolvedValue({}),
+  getAllLawMeta: vi.fn().mockResolvedValue([]),
+  upsertLawMeta: vi.fn().mockResolvedValue({}),
+}));
+
+const { runOneTimeTopicsBackfill } = await import("./topicsBackfill.js");
+const { fetchTopicsForCelexes, getAllLawMeta, upsertLawMeta } = await import("./formexApi.js");
+
+const VERSION_KEY = "legalviz-topics-backfill-version";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  window.localStorage.clear();
+});
+
+describe("runOneTimeTopicsBackfill", () => {
+  it("does nothing when already run", async () => {
+    window.localStorage.setItem(VERSION_KEY, "v1");
+    const result = await runOneTimeTopicsBackfill();
+    expect(result).toBe(false);
+    expect(getAllLawMeta).not.toHaveBeenCalled();
+  });
+
+  it("marks done and skips fetch when the library is empty", async () => {
+    getAllLawMeta.mockResolvedValue([]);
+    const result = await runOneTimeTopicsBackfill();
+    expect(result).toBe(false);
+    expect(fetchTopicsForCelexes).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(VERSION_KEY)).toBe("v1");
+  });
+
+  it("backfills topics onto laws that lack them", async () => {
+    getAllLawMeta.mockResolvedValue([
+      { celex: "32016R0679" },
+      { celex: "32024R1689", topics: ["already", "here"] },
+    ]);
+    fetchTopicsForCelexes.mockResolvedValue({ "32016R0679": ["data protection"] });
+
+    const result = await runOneTimeTopicsBackfill();
+
+    expect(result).toBe(true);
+    // Only the law without topics is requested.
+    expect(fetchTopicsForCelexes).toHaveBeenCalledWith(["32016R0679"]);
+    expect(upsertLawMeta).toHaveBeenCalledWith("32016R0679", { topics: ["data protection"] });
+    expect(window.localStorage.getItem(VERSION_KEY)).toBe("v1");
+  });
+
+  it("does not persist the version when the fetch fails, so it retries later", async () => {
+    getAllLawMeta.mockResolvedValue([{ celex: "32016R0679" }]);
+    fetchTopicsForCelexes.mockRejectedValue(new Error("network"));
+
+    const result = await runOneTimeTopicsBackfill();
+
+    expect(result).toBe(false);
+    expect(upsertLawMeta).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(VERSION_KEY)).toBeNull();
+  });
+
+  it("does not retry laws that legitimately have no topics", async () => {
+    getAllLawMeta.mockResolvedValue([{ celex: "32016R0679" }]);
+    fetchTopicsForCelexes.mockResolvedValue({});
+
+    const result = await runOneTimeTopicsBackfill();
+
+    // No topics returned, but the endpoint responded — mark done anyway.
+    expect(result).toBe(false);
+    expect(upsertLawMeta).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(VERSION_KEY)).toBe("v1");
+  });
+});


### PR DESCRIPTION
## What

Surfaces EuroVoc topics on the landing page's "recent laws" cards, showing the same topical tags that already appear in the search dropdown — and backfills them onto laws a client opened before this shipped.

## Why

EuroVoc topics already exist end-to-end (backend `eurovoc.json` → search index → `GET /api/search` results → topic pills in the search dropdown), but the landing library cards are driven by the client-side IndexedDB library, whose records had no topic field.

## How

**Render + capture on open (commit 1)**
- **`src/utils/library.js`** — carry `topics` through `normalizeLawMetaEntry`, persist them via `upsertLawMeta` **only when present** (so `markLawOpened` or a later topic-less save never wipes stored topics), and expose them on `getLibraryLaws`.
- **`src/components/Landing.jsx`** — pass the search result's `topics` into `saveLawMeta` when a law is opened from search.
- **`src/components/LandingLibrary.jsx`** — render up to 3 topic pills per card, mirroring the search-dropdown pill styling.

**One-time backfill for existing clients (commit 2)**
- **Backend** — new `GET /api/topics?celex=a,b,c` (`backend/search/topics-route.js`) returns a `{ topics: { CELEX: string[] } }` map from the same EuroVoc data attached to each search record; capped at 200 CELEX ids/request and 5 topics/law; `503 search_cache_unavailable` when the cache isn't loaded. Documented in `backend/README.md`.
- **`src/utils/formexApi.js`** — `fetchTopicsForCelexes()` client.
- **`src/utils/topicsBackfill.js`** — `runOneTimeTopicsBackfill()`, guarded by its **own** localStorage version key (separate from the destructive reset migration in `resetApp.js`). It reads library CELEXes lacking topics, fetches them, and merges via `upsertLawMeta` — **wiping nothing**. On a fetch error it does not mark done (retries next load); on success it dispatches `legalviz-library-updated` so the cards refresh in place.
- **`src/App.jsx`** — wired into startup, after the reset migration.

Topics live in the free-form IndexedDB meta records, so **no cache-version bump is required**; pre-existing records without topics default to `null` and render nothing.

## Coverage

Every existing client gets topics on its next visit (via the backfill); laws opened from search thereafter capture topics directly. Laws whose CELEX isn't in the search index simply have no topics — same coverage as the search endpoint.

## Testing

- `src/utils/library.test.js` — topic persistence, no-clobber, exposure.
- `backend/search/topics-route.test.js` — validation, 503-when-unavailable, celex→labels mapping, 5-topic cap.
- `src/utils/topicsBackfill.test.js` — version gate, filtering to laws lacking topics, retry-on-error, no-retry when the endpoint legitimately returns no topics.
- `eslint` clean; backend search + routes suites pass (93 pass / 2 network-skipped).
- Booted the server and probed `/api/topics`: `400` on missing param, `503` with the correct code when the cache is absent, genuine `404` for unknown routes (confirms registration). The 200 happy path is covered by mock-store unit tests (the full search cache is a ~48 MB release asset not present in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)