### PR TITLE
Search harvest: don't couple ELI year to CELEX year (fixes #85)

### DIFF
--- a/backend/search/search-build.js
+++ b/backend/search/search-build.js
@@ -73,6 +73,14 @@ function normalizeYearQueryActTypes(actTypes) {
   return [...new Set(normalized)];
 }
 
+// The ELI filter matches a primary reg/dir/dec ELI but deliberately does NOT
+// require the ELI's year segment to equal `safeYear`. Some acts are adopted
+// (and CELEX-dated) in one year but published in the OJ — and therefore
+// ELI-numbered — the following year (e.g. ECB capital-key decision 32014D0055
+// -> /eli/dec/2015/425/oj). The CELEX filter already scopes this iteration to
+// `safeYear`; coupling the ELI year to it too would drop such cross-year acts
+// from both the CELEX-year pass (ELI year is year+1) and the year+1 pass
+// (CELEX year is `safeYear`). See issue #85.
 function buildYearQuery({ year, limit, offset, actTypes }) {
   const safeYear = Number.parseInt(year, 10);
   const selectedActTypes = normalizeYearQueryActTypes(actTypes);
@@ -94,7 +102,7 @@ WHERE {
 
   FILTER(REGEX(STR(?celex), "^3${safeYear}[${celexMarkers}]"))
   FILTER(!CONTAINS(?celex, "R("))
-  FILTER(REGEX(STR(?eli), "/eli/(${eliTokens})/${safeYear}/[0-9]+/oj$"))
+  FILTER(REGEX(STR(?eli), "/eli/(${eliTokens})/[0-9]+/[0-9]+/oj$"))
 }
 ORDER BY ?celex
 LIMIT ${limit}

--- a/backend/search/search-build.test.js
+++ b/backend/search/search-build.test.js
@@ -48,9 +48,19 @@ test("extractTitleFromEurlexHtml falls back to the title element in the page bod
 test("buildYearQuery can target only directives and regulations", () => {
   const query = buildYearQuery({ year: 2001, limit: 200, offset: 0, actTypes: ["regulation", "directive"] });
   assert.match(query, /\^32001\[RL\]/);
-  assert.match(query, /\/eli\/\(reg\|dir\)\/2001\/\[0-9\]\+\/oj\$/);
+  assert.match(query, /\/eli\/\(reg\|dir\)\/\[0-9\]\+\/\[0-9\]\+\/oj\$/);
   assert.doesNotMatch(query, /\[RLD\]/);
   assert.doesNotMatch(query, /dec/);
+});
+
+test("buildYearQuery does not couple the ELI year to the CELEX year", () => {
+  // ECB decisions are adopted (CELEX-dated) one year but ELI-numbered under the
+  // following year's OJ (e.g. 32014D0055 -> /eli/dec/2015/425/oj). The harvest
+  // for the CELEX year must still accept these, so the ELI filter is year-agnostic.
+  const query = buildYearQuery({ year: 2014, limit: 200, offset: 0 });
+  assert.match(query, /\^32014\[RLD\]/);
+  assert.match(query, /\/eli\/\(reg\|dir\|dec\)\/\[0-9\]\+\/\[0-9\]\+\/oj\$/);
+  assert.doesNotMatch(query, /\/eli\/\([^)]+\)\/2014\//);
 });
 
 test("normalizeYearQueryActTypes drops unknown values and deduplicates", () => {


### PR DESCRIPTION
## Summary

Fixes #85 — 8 primary ECB decisions were dropped from the search cache in the #61 rebuild.

## Root cause

`buildYearQuery` in `backend/search/search-build.js` applies two year filters against the *same* `safeYear`:

- CELEX must start `^3{Y}[…]`
- `FILTER(REGEX(STR(?eli), "/eli/(reg|dir|dec)/{Y}/[0-9]+/oj$"))` — the **ELI year segment must also equal `Y`**.

`harvestPrimaryActs` iterates **by CELEX year**. These 8 acts are adopted (and CELEX-dated) in year `Y` but published in the OJ — and therefore ELI-numbered — in year `Y+1`, so they fall through both passes:

| CELEX | CELEX year | ELI | ELI year |
|---|---|---|---|
| `32014D0055` | 2014 | `…/eli/dec/2015/425/oj` | 2015 |
| `32016D0040` | 2016 | `…/eli/dec/2017/933/oj` | 2017 |
| `32018D0027`–`32018D0032` | 2018 | `…/eli/dec/2019/43…48/oj` | 2019 |

- Year `Y` pass: CELEX matches, but the ELI filter demands `/dec/{Y}/…` while the real ELI is `/dec/{Y+1}/…` → dropped.
- Year `Y+1` pass: ELI would match, but the CELEX filter demands `^3{Y+1}…` while the real CELEX is `3{Y}…` → dropped.

(ELIs confirmed against CELLAR SPARQL.) The `getEliKind`/`isPrimaryAct` classification was never the problem — it correctly flags any `/eli/(reg|dir|dec)/YYYY/N/oj` as primary regardless of year, which is why these were searchable on `main`.

## Fix

Drop the year coupling in the ELI filter while keeping the primary-ELI *shape* requirement — the CELEX filter already scopes each iteration to the year:

```diff
- FILTER(REGEX(STR(?eli), "/eli/(${eliTokens})/${safeYear}/[0-9]+/oj$"))
+ FILTER(REGEX(STR(?eli), "/eli/(${eliTokens})/[0-9]+/[0-9]+/oj$"))
```

Dedup is already keyed by CELEX, so the cross-year acts get captured in their CELEX-year iteration with no duplicates.

## Tests

- Updated the existing `buildYearQuery` assertion for the new year-agnostic ELI pattern.
- Added a regression test asserting the ELI filter is not coupled to the CELEX year.
- `node --test search/search-build.test.js` (7 pass) and related search suites green; eslint clean.

## Note

This fixes the harvest query only. Regenerating the shipped `search-cache.json` (full re-harvest, or a targeted backfill of the 8 CELEX ids) is left to the maintainers' harvest pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GK14YxaQL4kjo17eic6Eg9

---
_Generated by [Claude Code](https://claude.ai/code/session_01GK14YxaQL4kjo17eic6Eg9)_