### PR TITLE
Search: query backend by canonical CELEX for pasted EUR-Lex URLs

### DIFF
--- a/src/components/SearchBox.celex.test.jsx
+++ b/src/components/SearchBox.celex.test.jsx
@@ -135,6 +135,27 @@ describe("SearchBox — CELEX / EUR-Lex direct open", () => {
     expect(document.body.textContent).toContain("Open directly");
   });
 
+  it("queries the backend by canonical CELEX for a pasted EUR-Lex URL", async () => {
+    // The backend anchors its CELEX regex at the start of the query, so a raw
+    // URL never resolves to an exact match. Sending the derived CELEX makes the
+    // indexed act surface as the top result instead of being buried in fuzzy
+    // token hits.
+    searchLaws.mockResolvedValue({
+      results: [{ celex: "32023R2854", title: "Data Act", date: "2023-12-13" }],
+    });
+    renderSearchBox(vi.fn());
+
+    typeQuery("https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R2854");
+    await flush();
+
+    expect(searchLaws).toHaveBeenCalled();
+    expect(searchLaws.mock.calls.at(-1)[0]).toBe("32023R2854");
+    // The indexed exact match wins — no synthetic "Open directly" is injected,
+    // and it isn't duplicated.
+    const lawHits = resultButtons().filter((b) => b.textContent.includes("2023/2854"));
+    expect(lawHits.length).toBe(1);
+  });
+
   it("opens a pasted EUR-Lex URL by deriving its CELEX", async () => {
     searchLaws.mockResolvedValue({ results: [] });
     const onNavigate = vi.fn();

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -261,7 +261,15 @@ export function SearchBox({
       directCelex: true,
     });
 
-    searchLawsApi(trimmedQuery, { limit: 12, signal: controller.signal })
+    // A pasted EUR-Lex URL (or "CELEX:"-prefixed id) identifies exactly one act,
+    // but the backend anchors its CELEX regex at the start of the query, so it
+    // never extracts the id from the surrounding URL text and falls back to a
+    // fuzzy token search — leaving the target buried among unrelated hits. When
+    // we've already resolved the CELEX client-side, query the backend by that
+    // canonical id so it returns the act as the deterministic top result.
+    const backendQuery = celexQuery || trimmedQuery;
+
+    searchLawsApi(backendQuery, { limit: 12, signal: controller.signal })
       .then((payload) => {
         const nextResults = Array.isArray(payload?.results)
           ? payload.results.map((item) => ({


### PR DESCRIPTION
## Problem

Pasting a EUR-Lex URL (e.g. `https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32023R2854`) into the **Find laws** search didn't surface the law it names. Instead of opening the Data Act, the search returned a fuzzy list with the target buried at position 3 among unrelated acts — so from the user's side "nothing happened".

## Root cause

The search box already detects a CELEX / EUR-Lex URL client-side (`parseCelexQuery`, added in #94), but `runLawSearch` still forwarded the **raw URL** to the backend. The backend's `parseStructuredQuery` anchors its CELEX regex at the start of the query (`search-ranking.js`), so it never extracts the id from the surrounding URL text (`https…celex:32023r2854`) and falls back to a fuzzy token search.

Because the Data Act *is* in the index, that fuzzy search happened to include it — which flipped the `hasCelexExact` guard on, suppressing the synthetic "Open directly" result too. Net effect: the act the URL unambiguously identifies sat in fuzzy-ranked order with no signal it had been recognized.

## Fix

When `parseCelexQuery` resolves a CELEX, send that canonical id to the backend instead of the raw text. The backend's deterministic celex lookup (`legal-cache-store.js` prepends the exact `byCelex` match first) then returns the act as the top result. The no-index-match fallback (synthetic direct-open result, and the "still works if the search API is down" path) is unchanged.

```diff
-    searchLawsApi(trimmedQuery, { limit: 12, signal: controller.signal })
+    const backendQuery = celexQuery || trimmedQuery;
+    searchLawsApi(backendQuery, { limit: 12, signal: controller.signal })
```

## Verification

- Built the production bundle, served it, and drove the real flow in a browser with the `/api/search` response stubbed to mimic the backend's deterministic celex lookup: pasting the URL now sends `q=32023R2854` and renders **Data Act — Regulation (EU) 2023/2854** as the single top result.
- Added a component test asserting the backend is queried with the derived CELEX (`32023R2854`) rather than the pasted URL, with no duplicate result.
- `npx vitest run` — 293 passed. `eslint` clean.

## Notes

- Purely a frontend query-shaping change; no cached output shape changed, so no cache-version bump needed.
- Separately observed while reproducing: `npm run dev:web` currently fails to mount the app because Vite's dev optimizer can't resolve the `default` import of `backend/shared/legal-reference-core.cjs` from `fmxParser.mjs`. The **production build is unaffected** (Rollup handles it), so this doesn't touch the deployed site — flagging it as a separate DX issue, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CeATcifHrsWr8PeNy5VbRc)_