### PR TITLE
Add SQLite release gates

### DIFF
--- a/.github/workflows/backend-docker.yml
+++ b/.github/workflows/backend-docker.yml
@@ -1,0 +1,65 @@
+name: Backend Docker
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-docker.yml"
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+      - ".github/workflows/backend-docker.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: backend
+          load: true
+          tags: legalviz-backend:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+      - name: Start backend
+        run: docker run --detach --name legalviz-backend --publish 3000:3000 legalviz-backend:ci
+      - name: Wait for health
+        run: |
+          for attempt in $(seq 1 60); do
+            if curl --fail --silent http://127.0.0.1:3000/health >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          docker logs legalviz-backend
+          exit 1
+      - name: Smoke-test SQLite-backed interfaces
+        run: |
+          curl --fail --silent "http://127.0.0.1:3000/api/search?q=gdpr&limit=1" \
+            | jq --exit-status '.results[0].celex == "32016R0679"'
+          curl --fail --silent "http://127.0.0.1:3000/api/topics?celex=32016R0679" \
+            | jq --exit-status '.topics["32016R0679"] | length > 0'
+          curl --fail --silent "http://127.0.0.1:3000/api/resolve-reference?actType=regulation&year=2016&number=679" \
+            | jq --exit-status '.resolved.celex == "32016R0679"'
+          docker exec legalviz-backend node -e '
+            const fs = require("node:fs");
+            if (!fs.existsSync("search/data/data.sqlite")) throw new Error("SQLite artifact missing");
+            if (!fs.existsSync("search/data/data.sqlite.manifest.json")) throw new Error("manifest missing");
+            if (fs.readdirSync("search/data").some((name) => name.endsWith(".json.gz"))) {
+              throw new Error("source JSON assets leaked into final image");
+            }
+          '
+      - name: Container logs
+        if: always()
+        run: docker logs legalviz-backend || true
+      - name: Stop backend
+        if: always()
+        run: docker rm --force legalviz-backend || true

--- a/.github/workflows/refresh-case-law-data.yml
+++ b/.github/workflows/refresh-case-law-data.yml
@@ -1,0 +1,146 @@
+name: Refresh case-law data
+
+on:
+  schedule:
+    - cron: "17 2 3 * *"
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: Publish the validated candidate as a GitHub release
+        type: boolean
+        default: false
+      release_tag:
+        description: New immutable release tag, required when publishing (for example data-v7)
+        type: string
+        required: false
+
+permissions:
+  contents: read
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: backend/package-lock.json
+      - run: npm ci --prefix backend
+      - name: Resolve current data release
+        id: current-release
+        shell: bash
+        run: |
+          tag=$(sed -n 's/^ARG DATA_RELEASE_TAG=//p' backend/Dockerfile)
+          test -n "$tag"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+      - name: Download current release inputs
+        run: |
+          mkdir -p refresh-inputs refresh-output backend/law-cache
+          gh release download "${{ steps.current-release.outputs.tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern search-cache.json.gz \
+            --pattern case-law-cache-v5.json.gz \
+            --dir refresh-inputs
+          gzip --decompress --stdout refresh-inputs/case-law-cache-v5.json.gz \
+            > backend/law-cache/case-law-cache-v5.json
+      - name: Restore judgment corpus
+        id: corpus-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            backend/search/data/case-law
+            backend/search/data/case-law-targets.txt
+          key: case-law-corpus-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            case-law-corpus-${{ runner.os }}-
+      - name: Install Chromium for EUR-Lex cookie warming
+        working-directory: backend
+        run: node node_modules/playwright-core/cli.js install --with-deps chromium
+      - name: Discover and harvest judgments
+        working-directory: backend
+        run: |
+          node search/case-law-discover.js
+          node search/case-law-harvest.js --skipDiscover
+      - name: Parse changed judgments
+        working-directory: backend
+        run: node search/case-law-parse.js
+      - name: Build and validate release candidate
+        working-directory: backend
+        run: |
+          gzip --keep --stdout --best law-cache/case-law-cache-v5.json \
+            > ../refresh-output/case-law-cache-v5.json.gz
+          cp ../refresh-inputs/search-cache.json.gz ../refresh-output/search-cache.json.gz
+          node search/build-sqlite-data.js \
+            --search ../refresh-output/search-cache.json.gz \
+            --case-law ../refresh-output/case-law-cache-v5.json.gz \
+            --output ../refresh-output/data.sqlite \
+            --manifest ../refresh-output/data.sqlite.manifest.json
+          node --expose-gc --max-old-space-size=6144 search/compare-search-backends.js \
+            --search ../refresh-output/search-cache.json.gz \
+            --sqlite ../refresh-output/data.sqlite \
+            --report ../refresh-output/search-parity-report.json
+      - name: Save judgment corpus
+        if: success()
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            backend/search/data/case-law
+            backend/search/data/case-law-targets.txt
+          key: case-law-corpus-${{ runner.os }}-${{ github.run_id }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: case-law-data-${{ github.run_id }}
+          path: refresh-output/
+          if-no-files-found: error
+          retention-days: 14
+
+  publish:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish }}
+    needs: refresh
+    runs-on: ubuntu-latest
+    environment: data-release
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: case-law-data-${{ github.run_id }}
+          path: release-assets
+      - name: Validate release tag
+        run: |
+          [[ "$RELEASE_TAG" =~ ^data-v[0-9]+$ ]]
+          ! gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" >/dev/null 2>&1
+      - name: Publish immutable data release
+        run: |
+          gh release create "$RELEASE_TAG" release-assets/* \
+            --repo "${{ github.repository }}" \
+            --title "$RELEASE_TAG" \
+            --notes "Automated offline case-law refresh from workflow run ${{ github.run_id }}."
+      - name: Open Docker tag-bump pull request
+        run: |
+          branch="automation/$RELEASE_TAG"
+          git switch --create "$branch"
+          sed -i "s/^ARG DATA_RELEASE_TAG=.*/ARG DATA_RELEASE_TAG=$RELEASE_TAG/" backend/Dockerfile
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add backend/Dockerfile
+          git commit -m "Deploy $RELEASE_TAG"
+          git push --set-upstream origin "$branch"
+          gh pr create \
+            --repo "${{ github.repository }}" \
+            --base main \
+            --head "$branch" \
+            --title "Deploy $RELEASE_TAG" \
+            --body "Updates the backend Docker build to the validated offline data release produced by workflow run ${{ github.run_id }}."

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -39,12 +39,13 @@ RUN mkdir -p search/data \
               "https://github.com/${DATA_RELEASE_REPO}/releases/download/${DATA_RELEASE_TAG}/$asset"; \
        done \
     && node search/build-sqlite-data.js \
-    && ls -lh search/data/data.sqlite
+    && ls -lh search/data/data.sqlite search/data/data.sqlite.manifest.json
 
 FROM dependencies AS final
 
 COPY . .
 COPY --from=data-builder /app/search/data/data.sqlite ./search/data/data.sqlite
+COPY --from=data-builder /app/search/data/data.sqlite.manifest.json ./search/data/data.sqlite.manifest.json
 
 RUN mkdir -p law-cache
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -544,6 +544,10 @@ publication with a new immutable `data-vN` tag. Publication is attached to the
 `data-release` GitHub environment and opens a separate pull request that bumps
 the Docker release tag, keeping deployment reviewable and reversible.
 
+See the [case-law data refresh runbook](docs/case-law-data-refresh.md) for the
+schedule, incremental-update model, Chromium/WAF behavior, candidate review and
+approval procedure, recovery steps, and current operational limitations.
+
 ### Metadata that isn't in the corpus (dates + EuroVoc topics)
 
 `date` and `eurovoc` are SPARQL metadata that the gzipped source on disk doesn't

--- a/backend/README.md
+++ b/backend/README.md
@@ -503,7 +503,9 @@ Important: restart the API server after rebuilding the cache, because the cache 
 `npm run build:sqlite-data` converts `search-cache.json(.gz)` and
 `case-law-cache-v5.json(.gz)` into `search/data/data.sqlite`. It writes a
 temporary database, validates its schema, row counts, and integrity, then
-renames it atomically. Runtime opens the result read-only through
+renames it atomically. The build also emits `data.sqlite.manifest.json` with
+source and artifact SHA-256 checksums, schema version, table counts, and mapping
+integrity results. Runtime opens the result read-only through
 `better-sqlite3`; the serving path does not depend on Node's experimental
 `node:sqlite` API.
 
@@ -511,6 +513,36 @@ The in-memory MiniSearch index contains titles and aliases only. Excerpts live
 in a contentless FTS5 index and are consulted after deterministic and title
 matches, so excerpt-only recall cannot outrank a title/alias hit. The JSON path
 keeps the original combined MiniSearch index for fixture and local compatibility.
+
+Before publishing a data artifact, compare JSON and SQLite ranking against the
+full release corpus:
+
+```bash
+npm run test:search-parity -- \
+  --search search/data/search-cache.json.gz \
+  --sqlite search/data/data.sqlite \
+  --report search/data/search-parity-report.json
+```
+
+The committed query contract checks exact identifiers and aliases, common
+misspellings, modifier-heavy natural queries, and documented intentional rank
+changes. The gate fails when expected laws move outside their allowed rank,
+SQLite loses a previous result entirely, or an unapproved previous top result
+moves outside the configured top-N window.
+
+### Automated release gates
+
+`.github/workflows/backend-docker.yml` builds the real multi-stage image when
+backend files change, starts it, exercises SQLite-backed search, topics, and
+reference resolution, and verifies that the final image contains the database
+manifest but not the source JSON artifacts.
+
+`.github/workflows/refresh-case-law-data.yml` runs the offline judgment refresh
+monthly and on demand. Scheduled runs produce a validated candidate artifact and
+retain it for review; they never publish automatically. A manual run may opt into
+publication with a new immutable `data-vN` tag. Publication is attached to the
+`data-release` GitHub environment and opens a separate pull request that bumps
+the Docker release tag, keeping deployment reviewable and reversible.
 
 ### Metadata that isn't in the corpus (dates + EuroVoc topics)
 

--- a/backend/docs/case-law-data-refresh.md
+++ b/backend/docs/case-law-data-refresh.md
@@ -1,0 +1,201 @@
+# Case-law data refresh runbook
+
+This runbook explains how the `Refresh case-law data` GitHub Actions workflow
+collects, validates, publishes, and deploys case-law data. It is intended for
+repository maintainers operating the data release process.
+
+The workflow is defined in
+[`refresh-case-law-data.yml`](../../.github/workflows/refresh-case-law-data.yml).
+
+## Schedule and operating modes
+
+The automatic refresh runs on the third day of every month at 02:17 UTC
+(`17 2 3 * *`). That is normally 03:17 CET or 04:17 CEST in the Netherlands.
+GitHub may delay scheduled jobs during periods of high Actions load.
+
+The workflow has three modes:
+
+| Invocation | `publish` input | Result |
+| --- | --- | --- |
+| Monthly schedule | Not applicable | Builds and uploads a candidate; never publishes or deploys it |
+| Manual validation | `false` | Builds and uploads a candidate; never publishes or deploys it |
+| Manual publication | `true`, with a new `data-vN` tag | Builds a candidate, waits at the publication gate, creates a release, and opens a deployment PR |
+
+Scheduled and manual triggers only work after the workflow exists on the
+repository's default branch.
+
+## What a refresh does
+
+The workflow performs these steps in order:
+
+1. Read the current `DATA_RELEASE_TAG` from `backend/Dockerfile`.
+2. Download that release's `search-cache.json.gz` and
+   `case-law-cache-v5.json.gz` assets.
+3. Restore the raw compressed judgment HTML corpus from the GitHub Actions
+   cache, when available.
+4. Query CELLAR's SPARQL endpoint for the complete set of CJEU and General Court
+   judgments that formally interpret legislation.
+5. Walk the target list and download judgment HTML that is absent from the raw
+   corpus.
+6. Parse new judgments, plus judgments whose stored citation-parser version is
+   stale, into the case-law JSON cache.
+7. Rebuild the complete standalone SQLite database and its integrity manifest.
+8. Compare JSON and SQLite search behavior against the committed ranking
+   contract.
+9. Save the updated raw corpus in the Actions cache and upload the candidate
+   release files as a workflow artifact retained for 14 days.
+
+The legislation search cache is carried forward unchanged. This workflow
+refreshes case law; it does not discover or rebuild the legislation search
+corpus.
+
+## What is incremental
+
+The expensive network and parsing work is normally incremental, but the entire
+pipeline is not.
+
+| Stage | Incremental behavior |
+| --- | --- |
+| Judgment discovery | Queries the complete target set each run; this is only a small number of paginated SPARQL requests |
+| Raw HTML harvest | Scans every target but skips judgments already present as compressed corpus files |
+| Judgment parsing | Skips entries already parsed with the current citation-parser version |
+| SQLite build | Rebuilds the complete database rather than patching the previous artifact |
+| Ranking validation | Loads both complete backends and runs the committed query contract |
+
+A warm-cache monthly run should therefore make only a few discovery requests,
+perform inexpensive file-existence checks for the existing corpus, download and
+parse new judgments, and then rebuild and validate the complete artifact.
+
+If the Actions cache is cold or has been evicted, the workflow must re-download
+the raw judgment corpus. If the citation-parser version changes, it reparses the
+raw corpus without downloading it again.
+
+The harvest deliberately scans from the start rather than persisting an index
+cursor. Newly discovered CELEX identifiers can sort anywhere in the target list,
+so resuming at an old numeric position could skip new judgments.
+
+## Chromium and EUR-Lex WAF handling
+
+EUR-Lex protects its HTML endpoint with a web application firewall. The
+workflow installs headless Chromium through Playwright for session warming, not
+for rendering every judgment.
+
+For a network fetch, the harvester:
+
+1. Opens the EUR-Lex homepage once in headless Chromium.
+2. Captures the resulting cookies and browser user-agent.
+3. Closes Chromium.
+4. Downloads judgment HTML sequentially with ordinary `fetch` requests carrying
+   those headers.
+5. Invalidates and re-warms the session if EUR-Lex returns another WAF
+   challenge.
+
+This keeps browser use bounded, but access from GitHub-hosted runner IP
+addresses remains an external dependency. A successful browser installation
+does not prove that EUR-Lex accepted the session.
+
+## Reviewing a scheduled candidate
+
+Open **Actions > Refresh case-law data**, select the run, and download the
+`case-law-data-<run-id>` artifact. It contains:
+
+| File | Review purpose |
+| --- | --- |
+| `case-law-cache-v5.json.gz` | Updated structured judgment cache |
+| `search-cache.json.gz` | Legislation search input carried from the current release |
+| `data.sqlite` | Candidate runtime database |
+| `data.sqlite.manifest.json` | Input and artifact hashes, schema version, row counts, and integrity results |
+| `search-parity-report.json` | Per-query JSON/SQLite rankings and the parity summary |
+
+Before publication, verify at minimum:
+
+- the refresh and parity steps completed successfully;
+- the manifest reports `integrity.sqlite` as `ok` and zero orphan mappings;
+- case-law counts did not unexpectedly decrease;
+- the parity report has zero failures and only documented top-result changes;
+- the harvest log shows plausible saved, skipped, missing, and failed counts;
+- a sample of newly added judgments resolves to sensible names, declarations,
+  and article references.
+
+## Configure the publication approval gate
+
+The workflow references a GitHub environment named `data-release`. Repository
+administrators must configure it; naming an environment in YAML is not by
+itself a meaningful approval policy.
+
+In **Settings > Environments > data-release**:
+
+1. Add the maintainers who may approve publication as required reviewers.
+2. Prevent self-review if independent approval is required.
+3. Restrict deployment branches to the default or protected branch as
+   appropriate for the repository.
+
+The publication job receives write permissions only after the refresh job has
+completed and the environment gate has been approved.
+
+## Publishing and deploying a release
+
+To publish:
+
+1. Open **Actions > Refresh case-law data > Run workflow**.
+2. Select the `main` branch.
+3. Set `publish` to `true`.
+4. Enter a new tag matching `data-vN`, for example `data-v7`. Existing tags are
+   rejected.
+5. Start the workflow and inspect the completed refresh job.
+6. When the `publish` job waits for the `data-release` environment, use
+   **Review deployments** to approve or reject it.
+
+After approval, the workflow creates an immutable GitHub release and opens an
+`automation/data-vN` pull request that changes `DATA_RELEASE_TAG` in the backend
+Dockerfile. Review and merge that pull request to deploy the release. The
+environment approval authorizes publication; the tag-bump pull request is a
+separate deployment approval.
+
+Rollback is performed by opening a pull request that restores
+`DATA_RELEASE_TAG` to a previously validated release. Published data tags should
+not be moved or overwritten.
+
+## Current limitations and first-run validation
+
+The refresh workflow has not been proven merely because the separate backend
+Docker workflow passes. Before relying on the schedule, complete a capped or
+otherwise controlled GitHub-hosted smoke harvest and confirm that EUR-Lex
+accepts the warmed session from a runner IP.
+
+The current implementation also has these limitations:
+
+- Individual harvest failures are counted and logged but do not by themselves
+  fail the workflow. A run can therefore remain green while downloading no new
+  judgments.
+- The permanent-miss and transient-failure sidecars are not retained in the
+  Actions cache, so unavailable judgments may be retried on later runs.
+- A scheduled artifact cannot currently be promoted directly. Publication is a
+  new manual refresh, so it may not be byte-for-byte identical to the earlier
+  scheduled candidate.
+- A cold corpus cache can turn the normal incremental update into a complete
+  re-harvest.
+- The GitHub-hosted refresh job is limited to the configured 330 minutes and
+  ultimately to GitHub's hosted-runner job limit.
+
+Before declaring the automation operational, add or perform a GitHub-hosted
+smoke run and confirm all of the following:
+
+1. Chromium installs and launches.
+2. Cookie warming produces an accepted EUR-Lex session.
+3. At least one uncached judgment downloads and is written to the corpus.
+4. The parser adds that judgment to the structured cache.
+5. SQLite construction and ranking parity pass.
+6. The resulting artifact can be downloaded and inspected.
+
+## Failure recovery
+
+| Symptom | Response |
+| --- | --- |
+| Repeated WAF challenges | Retry once to rule out a transient block; inspect Chromium and harvest logs; use a permitted self-hosted runner if GitHub runner IPs are consistently rejected |
+| Cold or evicted corpus cache | Allow a full harvest within the time limit, or seed the cache from a trusted corpus artifact |
+| Parser failures | Fix the parser and rerun; already downloaded raw HTML does not need to be fetched again |
+| Parity failure | Inspect `search-parity-report.json`; document and approve an intentional ranking change or fix the regression before publication |
+| Manifest/count regression | Do not publish; compare the current release inputs, discovery count, harvest log, and parser output |
+| Publication rejected | The candidate remains an Actions artifact until retention expiry; no release or deployment PR is created |
+| Release published but deployment rejected | Leave the immutable release in place and close the Docker tag-bump PR; production remains on the previous tag |

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,8 @@
     "eval:search": "node --expose-gc search/eval/run.js",
     "build:sqlite-data": "node search/build-sqlite-data.js",
     "test": "node --test search/*.test.js shared/*.test.js routes/*.test.js bin/*.test.js mcp/*.test.js",
-    "test:search": "node --test search/*.test.js"
+    "test:search": "node --test search/*.test.js",
+    "test:search-parity": "node --expose-gc --max-old-space-size=6144 search/compare-search-backends.js"
   },
   "keywords": [
     "eur-lex",

--- a/backend/search/build-sqlite-data.js
+++ b/backend/search/build-sqlite-data.js
@@ -3,6 +3,7 @@
 const fs = require("node:fs");
 const path = require("node:path");
 const zlib = require("node:zlib");
+const crypto = require("node:crypto");
 const Database = require("better-sqlite3");
 
 const { enrichSearchRecord } = require("./search-ranking");
@@ -11,6 +12,22 @@ const DEFAULT_SQLITE_DATA_PATH = path.join(__dirname, "data", "data.sqlite");
 const DEFAULT_CASE_LAW_CACHE_PATH = path.join(__dirname, "data", "case-law-cache-v5.json");
 const SQLITE_SCHEMA_VERSION = 1;
 
+function sha256File(filePath) {
+  const hash = crypto.createHash("sha256");
+  const buffer = Buffer.allocUnsafe(1024 * 1024);
+  const descriptor = fs.openSync(filePath, "r");
+  try {
+    for (;;) {
+      const bytesRead = fs.readSync(descriptor, buffer, 0, buffer.length, null);
+      if (bytesRead === 0) break;
+      hash.update(buffer.subarray(0, bytesRead));
+    }
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  return hash.digest("hex");
+}
+
 function resolveReadablePath(inputPath) {
   if (fs.existsSync(inputPath)) return inputPath;
   if (!inputPath.endsWith(".gz") && fs.existsSync(`${inputPath}.gz`)) return `${inputPath}.gz`;
@@ -18,10 +35,19 @@ function resolveReadablePath(inputPath) {
 }
 
 function readJson(inputPath) {
+  return readJsonAsset(inputPath).payload;
+}
+
+function readJsonAsset(inputPath) {
   const resolved = resolveReadablePath(inputPath);
   const bytes = fs.readFileSync(resolved);
   const raw = resolved.endsWith(".gz") ? zlib.gunzipSync(bytes).toString("utf8") : bytes.toString("utf8");
-  return JSON.parse(raw);
+  return {
+    payload: JSON.parse(raw),
+    path: resolved,
+    bytes: bytes.length,
+    sha256: crypto.createHash("sha256").update(bytes).digest("hex"),
+  };
 }
 
 function isPartialCaseLawEntry(entry) {
@@ -32,14 +58,23 @@ function buildSqliteData({
   searchCachePath = DEFAULT_SEARCH_CACHE_PATH,
   caseLawCachePath = DEFAULT_CASE_LAW_CACHE_PATH,
   outputPath = DEFAULT_SQLITE_DATA_PATH,
+  manifestPath = `${outputPath}.manifest.json`,
 } = {}) {
-  const searchPayload = readJson(searchCachePath);
-  const caseLawPayload = readJson(caseLawCachePath);
+  const searchAsset = readJsonAsset(searchCachePath);
+  const caseLawAsset = readJsonAsset(caseLawCachePath);
+  const searchPayload = searchAsset.payload;
+  const caseLawPayload = caseLawAsset.payload;
   const records = Array.isArray(searchPayload.records) ? searchPayload.records : [];
+  const caseLawEntries = Object.entries(caseLawPayload).filter(([rawCelex, details]) => (
+    String(rawCelex || "").trim() && details && typeof details === "object"
+  ));
 
   fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+  fs.mkdirSync(path.dirname(manifestPath), { recursive: true });
   const tempPath = `${outputPath}.${process.pid}.tmp`;
+  const tempManifestPath = `${manifestPath}.${process.pid}.tmp`;
   fs.rmSync(tempPath, { force: true });
+  fs.rmSync(tempManifestPath, { force: true });
 
   const database = new Database(tempPath);
   try {
@@ -66,6 +101,7 @@ function buildSqliteData({
       CREATE VIRTUAL TABLE law_excerpts USING fts5(
         excerpt,
         content='',
+        detail=full,
         tokenize='unicode61 remove_diacritics 2'
       );
       CREATE TABLE case_law (
@@ -85,11 +121,12 @@ function buildSqliteData({
       "INSERT INTO case_law (celex, details_json, is_partial) VALUES (?, ?, ?)"
     );
 
+    let expectedExcerptCount = 0;
     database.exec("BEGIN IMMEDIATE");
     try {
       insertMetadata.run("generated_at", String(searchPayload.generatedAt || ""));
       insertMetadata.run("search_record_count", String(records.length));
-      insertMetadata.run("case_law_count", String(Object.keys(caseLawPayload).length));
+      insertMetadata.run("case_law_count", String(caseLawEntries.length));
 
       records.forEach((record, ordinal) => {
         const excerpt = typeof record?.excerpt === "string" ? record.excerpt : "";
@@ -114,12 +151,12 @@ function buildSqliteData({
           const rowid = ordinal + 1;
           insertExcerptMap.run(rowid, celex, ordinal);
           insertExcerpt.run(rowid, excerpt);
+          expectedExcerptCount += 1;
         }
       });
 
-      for (const [rawCelex, details] of Object.entries(caseLawPayload)) {
+      for (const [rawCelex, details] of caseLawEntries) {
         const celex = String(rawCelex || "").trim().toUpperCase();
-        if (!celex || !details || typeof details !== "object") continue;
         insertCaseLaw.run(celex, JSON.stringify(details), isPartialCaseLawEntry(details) ? 1 : 0);
       }
       database.exec("COMMIT");
@@ -134,21 +171,93 @@ function buildSqliteData({
 
     const lawCount = database.prepare("SELECT COUNT(*) AS count FROM laws").get().count;
     const caseLawCount = database.prepare("SELECT COUNT(*) AS count FROM case_law").get().count;
+    const excerptCount = database.prepare("SELECT COUNT(*) AS count FROM law_excerpts").get().count;
+    const excerptMapCount = database.prepare("SELECT COUNT(*) AS count FROM law_excerpt_map").get().count;
+    const orphanLawMappings = database.prepare(`
+      SELECT COUNT(*) AS count
+      FROM law_excerpt_map AS mapping
+      LEFT JOIN laws ON laws.ordinal = mapping.ordinal
+      WHERE laws.ordinal IS NULL
+    `).get().count;
+    const orphanFtsMappings = database.prepare(`
+      SELECT COUNT(*) AS count
+      FROM law_excerpt_map AS mapping
+      LEFT JOIN law_excerpts ON law_excerpts.rowid = mapping.rowid
+      WHERE law_excerpts.rowid IS NULL
+    `).get().count;
     if (lawCount !== records.length) {
       throw new Error(`SQLite law count mismatch: wrote ${lawCount}, expected ${records.length}`);
     }
+    if (caseLawCount !== caseLawEntries.length) {
+      throw new Error(`SQLite case-law count mismatch: wrote ${caseLawCount}, expected ${caseLawEntries.length}`);
+    }
+    if (excerptCount !== expectedExcerptCount || excerptMapCount !== expectedExcerptCount) {
+      throw new Error(
+        `SQLite excerpt count mismatch: FTS ${excerptCount}, mapping ${excerptMapCount}, expected ${expectedExcerptCount}`
+      );
+    }
+    if (orphanLawMappings !== 0 || orphanFtsMappings !== 0) {
+      throw new Error(
+        `SQLite excerpt mapping integrity failed: ${orphanLawMappings} missing laws, ` +
+        `${orphanFtsMappings} missing FTS rows`
+      );
+    }
 
     database.close();
+    const outputBytes = fs.statSync(tempPath).size;
+    const outputSha256 = sha256File(tempPath);
+    const manifest = {
+      formatVersion: 1,
+      schemaVersion: SQLITE_SCHEMA_VERSION,
+      builtAt: new Date().toISOString(),
+      source: {
+        search: {
+          file: path.basename(searchAsset.path),
+          bytes: searchAsset.bytes,
+          sha256: searchAsset.sha256,
+          records: records.length,
+          generatedAt: searchPayload.generatedAt || null,
+        },
+        caseLaw: {
+          file: path.basename(caseLawAsset.path),
+          bytes: caseLawAsset.bytes,
+          sha256: caseLawAsset.sha256,
+          records: caseLawEntries.length,
+        },
+      },
+      artifact: {
+        file: path.basename(outputPath),
+        bytes: outputBytes,
+        sha256: outputSha256,
+      },
+      tables: {
+        laws: lawCount,
+        excerpts: excerptCount,
+        excerptMappings: excerptMapCount,
+        caseLaw: caseLawCount,
+      },
+      integrity: {
+        sqlite: integrity,
+        orphanLawMappings,
+        orphanFtsMappings,
+      },
+    };
+    fs.writeFileSync(tempManifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
     fs.renameSync(tempPath, outputPath);
+    fs.renameSync(tempManifestPath, manifestPath);
     return {
       outputPath,
+      manifestPath,
       laws: lawCount,
+      excerpts: excerptCount,
       caseLaw: caseLawCount,
-      bytes: fs.statSync(outputPath).size,
+      bytes: outputBytes,
+      sha256: outputSha256,
     };
   } catch (error) {
     try { database.close(); } catch { /* best effort */ }
     fs.rmSync(tempPath, { force: true });
+    fs.rmSync(tempManifestPath, { force: true });
     throw error;
   }
 }
@@ -161,6 +270,7 @@ function parseArgs(argv) {
     if (token === "--search" && value) options.searchCachePath = path.resolve(value);
     else if (token === "--case-law" && value) options.caseLawCachePath = path.resolve(value);
     else if (token === "--output" && value) options.outputPath = path.resolve(value);
+    else if (token === "--manifest" && value) options.manifestPath = path.resolve(value);
     else continue;
     index += 1;
   }
@@ -185,4 +295,6 @@ module.exports = {
   buildSqliteData,
   isPartialCaseLawEntry,
   readJson,
+  readJsonAsset,
+  sha256File,
 };

--- a/backend/search/build-sqlite-data.js
+++ b/backend/search/build-sqlite-data.js
@@ -98,6 +98,11 @@ function buildSqliteData({
         celex TEXT NOT NULL,
         ordinal INTEGER NOT NULL
       ) STRICT;
+      -- detail=full is FTS5's default; stated explicitly so phrase/NEAR recall
+      -- stays available and a later reviewer does not "simplify" it to a
+      -- narrower detail mode. Because it matches the default, the on-disk
+      -- format is unchanged and SQLITE_SCHEMA_VERSION does not need a bump;
+      -- moving to detail=column/none would change the schema and require one.
       CREATE VIRTUAL TABLE law_excerpts USING fts5(
         excerpt,
         content='',

--- a/backend/search/build-sqlite-data.test.js
+++ b/backend/search/build-sqlite-data.test.js
@@ -1,0 +1,64 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { buildSqliteData } = require("./build-sqlite-data");
+
+function sha256(filePath) {
+  return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
+}
+
+test("buildSqliteData emits a verified manifest with source and table counts", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "sqlite-data-manifest-"));
+  const searchPath = path.join(tempDir, "search.json");
+  const caseLawPath = path.join(tempDir, "case-law.json");
+  const outputPath = path.join(tempDir, "data.sqlite");
+  const manifestPath = path.join(tempDir, "manifest.json");
+  fs.writeFileSync(searchPath, JSON.stringify({
+    generatedAt: "2026-07-15T00:00:00.000Z",
+    records: [
+      {
+        celex: "32024R9001",
+        title: "Widgets Regulation",
+        type: "regulation",
+        eli: "http://data.europa.eu/eli/reg/2024/9001/oj",
+        excerpt: "Harmonised rules for widgets.",
+      },
+      {
+        celex: "32024R9002",
+        title: "Gadgets Regulation",
+        type: "regulation",
+        eli: "http://data.europa.eu/eli/reg/2024/9002/oj",
+        excerpt: "",
+      },
+    ],
+  }), "utf8");
+  fs.writeFileSync(caseLawPath, JSON.stringify({
+    "62020CJ0001": { name: "Example", declarations: [{ text: "Ruling" }] },
+    ignored: null,
+  }), "utf8");
+
+  const result = buildSqliteData({ searchCachePath: searchPath, caseLawCachePath: caseLawPath, outputPath, manifestPath });
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  assert.equal(result.laws, 2);
+  assert.equal(result.excerpts, 1);
+  assert.equal(result.caseLaw, 1);
+  assert.equal(manifest.schemaVersion, 1);
+  assert.deepEqual(manifest.tables, {
+    laws: 2,
+    excerpts: 1,
+    excerptMappings: 1,
+    caseLaw: 1,
+  });
+  assert.deepEqual(manifest.integrity, {
+    sqlite: "ok",
+    orphanLawMappings: 0,
+    orphanFtsMappings: 0,
+  });
+  assert.equal(manifest.source.search.sha256, sha256(searchPath));
+  assert.equal(manifest.source.caseLaw.sha256, sha256(caseLawPath));
+  assert.equal(manifest.artifact.sha256, sha256(outputPath));
+});

--- a/backend/search/compare-search-backends.js
+++ b/backend/search/compare-search-backends.js
@@ -1,0 +1,148 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const { JsonLegalCacheStore } = require("./legal-cache-store");
+
+const DEFAULT_SEARCH_PATH = path.join(__dirname, "data", "search-cache.json");
+const DEFAULT_SQLITE_PATH = path.join(__dirname, "data", "data.sqlite");
+const DEFAULT_CASES_PATH = path.join(__dirname, "search-parity-cases.json");
+
+function parseArgs(argv) {
+  const options = {};
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const value = argv[index + 1];
+    if (token === "--search" && value) options.searchPath = path.resolve(value);
+    else if (token === "--sqlite" && value) options.sqlitePath = path.resolve(value);
+    else if (token === "--cases" && value) options.casesPath = path.resolve(value);
+    else if (token === "--report" && value) options.reportPath = path.resolve(value);
+    else continue;
+    index += 1;
+  }
+  return options;
+}
+
+function runCases(store, cases, limit = 10) {
+  return cases.map((entry) => ({
+    ...entry,
+    results: store.searchLaws(entry.query, { limit }).map((result) => result.celex),
+  }));
+}
+
+function rankOf(results, celex) {
+  const index = results.indexOf(celex);
+  return index < 0 ? null : index + 1;
+}
+
+function evaluateParity(cases, jsonRuns, sqliteRuns, preserveOldTopWithin = 5) {
+  const failures = [];
+  let sameTopResult = 0;
+  const comparisons = cases.map((entry, index) => {
+    const json = jsonRuns[index].results;
+    const sqlite = sqliteRuns[index].results;
+    if (json[0] === sqlite[0]) sameTopResult += 1;
+    if (json.length > 0 && sqlite.length === 0) {
+      failures.push(`${entry.query}: SQLite returned no results; JSON returned ${json[0]}`);
+    }
+    if (!entry.allowTopChange && json[0] && !sqlite.slice(0, preserveOldTopWithin).includes(json[0])) {
+      failures.push(
+        `${entry.query}: previous top result ${json[0]} is outside SQLite top ${preserveOldTopWithin}`
+      );
+    }
+    if (entry.expectedCelex) {
+      const maxRank = entry.maxRank || 1;
+      const jsonRank = rankOf(json, entry.expectedCelex);
+      const sqliteRank = rankOf(sqlite, entry.expectedCelex);
+      if (!entry.allowTopChange && (jsonRank === null || jsonRank > maxRank)) {
+        failures.push(`${entry.query}: expected ${entry.expectedCelex} within JSON top ${maxRank}, rank ${jsonRank}`);
+      }
+      if (sqliteRank === null || sqliteRank > maxRank) {
+        failures.push(`${entry.query}: expected ${entry.expectedCelex} within SQLite top ${maxRank}, rank ${sqliteRank}`);
+      }
+    }
+    return {
+      query: entry.query,
+      expectedCelex: entry.expectedCelex || null,
+      allowTopChange: Boolean(entry.allowTopChange),
+      json,
+      sqlite,
+      sameTopResult: json[0] === sqlite[0],
+    };
+  });
+
+  return {
+    summary: {
+      queries: cases.length,
+      sameTopResult,
+      changedTopResult: cases.length - sameTopResult,
+      failures: failures.length,
+      preserveOldTopWithin,
+    },
+    failures,
+    comparisons,
+  };
+}
+
+function loadStore(store, label) {
+  const startedAt = Date.now();
+  if (!store.load()) throw new Error(`${label} failed to load: ${store.loadError}`);
+  return Date.now() - startedAt;
+}
+
+function writeReport(reportPath, report) {
+  if (!reportPath) return;
+  fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+  fs.writeFileSync(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+}
+
+function main(argv = process.argv.slice(2)) {
+  const options = parseArgs(argv);
+  const searchPath = options.searchPath || DEFAULT_SEARCH_PATH;
+  const jsonCachePath = searchPath.endsWith(".gz") ? searchPath.slice(0, -3) : searchPath;
+  const sqlitePath = options.sqlitePath || DEFAULT_SQLITE_PATH;
+  const casesPath = options.casesPath || DEFAULT_CASES_PATH;
+  const config = JSON.parse(fs.readFileSync(casesPath, "utf8"));
+  const cases = config.cases || [];
+
+  const jsonStore = new JsonLegalCacheStore(jsonCachePath, { preferJson: true });
+  const jsonLoadMs = loadStore(jsonStore, "JSON store");
+  const jsonRuns = runCases(jsonStore, cases);
+  jsonStore.close();
+  jsonStore.resetIndexes();
+  if (typeof global.gc === "function") global.gc();
+
+  const sqliteStore = new JsonLegalCacheStore(jsonCachePath, { sqlitePath, requireSqlite: true });
+  const sqliteLoadMs = loadStore(sqliteStore, "SQLite store");
+  const sqliteRuns = runCases(sqliteStore, cases);
+  sqliteStore.close();
+
+  const report = evaluateParity(
+    cases,
+    jsonRuns,
+    sqliteRuns,
+    config.preserveOldTopWithin || 5
+  );
+  report.generatedAt = new Date().toISOString();
+  report.inputs = { searchPath, sqlitePath, casesPath };
+  report.loadMs = { json: jsonLoadMs, sqlite: sqliteLoadMs };
+  writeReport(options.reportPath, report);
+  console.log(JSON.stringify({ summary: report.summary, loadMs: report.loadMs }, null, 2));
+  if (report.failures.length > 0) {
+    for (const failure of report.failures) console.error(`[search-parity] ${failure}`);
+    process.exitCode = 1;
+  }
+  return report;
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(`[search-parity] fatal: ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { evaluateParity, parseArgs, rankOf, runCases };

--- a/backend/search/compare-search-backends.test.js
+++ b/backend/search/compare-search-backends.test.js
@@ -1,0 +1,24 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { evaluateParity } = require("./compare-search-backends");
+
+test("evaluateParity reports preserved and regressed rankings", () => {
+  const cases = [
+    { query: "gdpr", expectedCelex: "32016R0679", maxRank: 1 },
+    { query: "conceptual query" },
+  ];
+  const jsonRuns = [
+    { results: ["32016R0679", "A"] },
+    { results: ["OLD", "B"] },
+  ];
+  const sqliteRuns = [
+    { results: ["32016R0679", "A"] },
+    { results: ["B", "C", "D", "E", "F", "OLD"] },
+  ];
+  const report = evaluateParity(cases, jsonRuns, sqliteRuns, 5);
+  assert.equal(report.summary.queries, 2);
+  assert.equal(report.summary.sameTopResult, 1);
+  assert.equal(report.summary.failures, 1);
+  assert.match(report.failures[0], /outside SQLite top 5/);
+});

--- a/backend/search/legal-cache-store.js
+++ b/backend/search/legal-cache-store.js
@@ -572,6 +572,7 @@ module.exports = {
   DEFAULT_SQLITE_DATA_PATH,
   JsonLegalCacheStore,
   SQLITE_SCHEMA_VERSION,
+  containedAliasKeys,
   normalizeCelexLookupKey,
   normalizeEliLookupKey,
   normalizeOfficialReferenceLookupKey,

--- a/backend/search/legal-cache-store.js
+++ b/backend/search/legal-cache-store.js
@@ -182,7 +182,7 @@ function compactSqliteRecord(record) {
     fmxAvailable: enriched.fmxAvailable,
     fmxUnavailable: enriched.fmxUnavailable,
     enrichError: enriched.enrichError,
-    eurovoc: Array.isArray(enriched.eurovoc) ? enriched.eurovoc : [],
+    eurovoc: enriched.eurovoc,
     celexYear: enriched.celexYear,
     celexNumber: enriched.celexNumber,
     aliases: enriched.aliases,
@@ -196,19 +196,17 @@ function buildFtsExpression(terms, operator) {
     .join(` ${operator} `);
 }
 
-function searchRelaxedTitles(miniSearch, parsed, boostDocument) {
-  const terms = [...new Set(parsed.terms || [])];
-  // Keep this fallback bounded and high-precision. Dropping one term recovers
-  // natural modifier queries such as "digital services act obligations"
-  // without materializing the very broad result sets produced by a full OR.
-  if (terms.length < 3 || terms.length > 6) return [];
-
-  for (let omitted = terms.length - 1; omitted >= 0; omitted -= 1) {
-    const relaxedQuery = terms.filter((_term, index) => index !== omitted).join(" ");
-    const hits = miniSearch.search(relaxedQuery, { combineWith: "AND", boostDocument });
-    if (hits.length > 0) return hits;
+function containedAliasKeys(normalizedQuery) {
+  const words = String(normalizedQuery || "").split(" ").filter(Boolean);
+  const keys = [];
+  const maxWords = Math.min(8, words.length - 1);
+  for (let length = maxWords; length >= 2; length -= 1) {
+    for (let start = 0; start + length <= words.length; start += 1) {
+      const phrase = words.slice(start, start + length).join(" ");
+      keys.push(phrase, phrase.replace(/\s+/g, ""));
+    }
   }
-  return [];
+  return [...new Set(keys)];
 }
 
 // Re-encodes the act-type priors that the retired scoreLaw ranking applied,
@@ -468,6 +466,14 @@ class JsonLegalCacheStore {
       }
     }
 
+    // Preserve exact known-law intent when the alias is embedded in a longer
+    // natural query (for example "digital services act obligations"). Only
+    // multi-word contiguous aliases qualify, avoiding the huge candidate sets
+    // produced by broad title OR searches.
+    for (const key of containedAliasKeys(parsed.normalized)) {
+      for (const record of this.byAlias.get(key) || []) addMatch(record);
+    }
+
     if (this.miniSearch) {
       const boostDocument = buildDocumentBoost(parsed);
       let hits = this.miniSearch.search(parsed.rewrittenQuery, { combineWith: "AND", boostDocument });
@@ -479,8 +485,6 @@ class JsonLegalCacheStore {
       if (hits.length === 0) {
         if (!this.database || parsed.terms.length < 3) {
           hits = this.miniSearch.search(parsed.rewrittenQuery, { combineWith: "OR", boostDocument });
-        } else {
-          hits = searchRelaxedTitles(this.miniSearch, parsed, boostDocument);
         }
       }
       for (const hit of hits) {

--- a/backend/search/legal-cache-store.test.js
+++ b/backend/search/legal-cache-store.test.js
@@ -11,6 +11,23 @@ const { buildSqliteData } = require("./build-sqlite-data");
 
 const fixturePath = path.join(__dirname, "__fixtures__", "search-fixture.json");
 
+function publicRecord(record) {
+  return {
+    celex: record?.celex,
+    title: record?.title,
+    date: record?.date,
+    eli: record?.eli,
+    type: record?.type,
+    fmxAvailable: record?.fmxAvailable,
+    fmxUnavailable: record?.fmxUnavailable,
+    enrichError: record?.enrichError,
+    eurovoc: record?.eurovoc,
+    celexYear: record?.celexYear,
+    celexNumber: record?.celexNumber,
+    aliases: record?.aliases,
+  };
+}
+
 test("legal cache store loads fixture successfully", () => {
   const store = new JsonLegalCacheStore(fixturePath);
   assert.equal(store.load(), true);
@@ -32,6 +49,24 @@ test("legal cache store loads SQLite records without retaining excerpts", () => 
   assert.equal(store.records.every((record) => !Object.hasOwn(record, "excerpt")), true);
   assert.equal(store.getByCelex("32002L0058")?.celex, "32002L0058");
   store.close();
+});
+
+test("JSON and SQLite hydrate the same public law-record contract", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "legal-cache-store-contract-"));
+  const caseLawPath = path.join(tempDir, "case-law.json");
+  const sqlitePath = path.join(tempDir, "data.sqlite");
+  fs.writeFileSync(caseLawPath, "{}", "utf8");
+  buildSqliteData({ searchCachePath: fixturePath, caseLawCachePath: caseLawPath, outputPath: sqlitePath });
+
+  const jsonStore = new JsonLegalCacheStore(fixturePath, { preferJson: true });
+  const sqliteStore = new JsonLegalCacheStore(fixturePath, { sqlitePath, requireSqlite: true });
+  assert.equal(jsonStore.load(), true);
+  assert.equal(sqliteStore.load(), true);
+  assert.deepEqual(
+    sqliteStore.records.map((record) => publicRecord(record)),
+    jsonStore.records.map((record) => publicRecord(record))
+  );
+  sqliteStore.close();
 });
 
 test("an explicit missing SQLite path fails instead of silently loading JSON", () => {
@@ -391,9 +426,11 @@ test("legal cache store searchLaws keeps a title match ahead of an excerpt-only 
   );
 });
 
-test("legal cache store returns null for ambiguous official reference key", () => {
+test("JSON and SQLite both preserve ambiguous lookups", () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "legal-cache-store-"));
   const tempPath = path.join(tempDir, "ambiguous.json");
+  const caseLawPath = path.join(tempDir, "case-law.json");
+  const sqlitePath = path.join(tempDir, "ambiguous.sqlite");
   fs.writeFileSync(tempPath, JSON.stringify({
     generatedAt: "2026-03-28T00:00:00.000Z",
     count: 2,
@@ -418,13 +455,21 @@ test("legal cache store returns null for ambiguous official reference key", () =
       },
     ],
   }, null, 2));
+  fs.writeFileSync(caseLawPath, "{}", "utf8");
+  buildSqliteData({ searchCachePath: tempPath, caseLawCachePath: caseLawPath, outputPath: sqlitePath });
 
-  const store = new JsonLegalCacheStore(tempPath);
-  store.load();
-  assert.equal(store.getByOfficialReference({
-    actType: "regulation",
-    year: "2020",
-    number: "123",
-  }), null);
-  assert.equal(store.getByEli("http://data.europa.eu/eli/reg/2020/123/oj"), null);
+  const stores = [
+    new JsonLegalCacheStore(tempPath, { preferJson: true }),
+    new JsonLegalCacheStore(tempPath, { sqlitePath, requireSqlite: true }),
+  ];
+  for (const store of stores) {
+    store.load();
+    assert.equal(store.getByOfficialReference({
+      actType: "regulation",
+      year: "2020",
+      number: "123",
+    }), null);
+    assert.equal(store.getByEli("http://data.europa.eu/eli/reg/2020/123/oj"), null);
+    store.close();
+  }
 });

--- a/backend/search/legal-cache-store.test.js
+++ b/backend/search/legal-cache-store.test.js
@@ -6,6 +6,7 @@ const path = require("node:path");
 
 const {
   JsonLegalCacheStore,
+  containedAliasKeys,
 } = require("./legal-cache-store");
 const { buildSqliteData } = require("./build-sqlite-data");
 
@@ -472,4 +473,52 @@ test("JSON and SQLite both preserve ambiguous lookups", () => {
     assert.equal(store.getByEli("http://data.europa.eu/eli/reg/2020/123/oj"), null);
     store.close();
   }
+});
+
+test("containedAliasKeys yields contiguous multi-word phrases, longest first", () => {
+  const keys = containedAliasKeys("digital services act obligations");
+
+  // Both the spaced and compact form of each sub-phrase are produced so a query
+  // can hit either alias variant stored in byAlias.
+  assert.ok(keys.includes("digital services act"));
+  assert.ok(keys.includes("digitalservicesact"));
+
+  // Longest sub-phrases come first so a more specific alias outranks a shorter
+  // one when several are added before the MiniSearch stage.
+  assert.equal(keys[0], "digital services act");
+
+  // The full query is handled by the exact-alias lookup, and single words are
+  // deliberately excluded to avoid broad, low-precision matches.
+  assert.ok(!keys.includes("digital services act obligations"));
+  assert.ok(!keys.includes("digital"));
+});
+
+test("containedAliasKeys stays bounded and deduplicated", () => {
+  // Fewer than three words cannot contain a shorter contiguous sub-phrase, so
+  // nothing is generated (the exact-alias path covers the whole query itself).
+  assert.deepEqual(containedAliasKeys(""), []);
+  assert.deepEqual(containedAliasKeys("oneword"), []);
+  assert.deepEqual(containedAliasKeys("two words"), []);
+
+  // Repeated phrases collapse to a single spaced/compact pair.
+  assert.deepEqual(containedAliasKeys("act act act"), ["act act", "actact"]);
+});
+
+test("searchLaws recovers a known alias embedded in a modifier-heavy query", () => {
+  const store = new JsonLegalCacheStore(fixturePath, { preferJson: true });
+  assert.equal(store.load(), true);
+
+  // Each query carries an extra modifier token that is absent from the target
+  // law's title, so the exact-alias and strict AND paths cannot surface it; the
+  // contiguous-alias recovery keeps the known law at rank one.
+  const expectations = [
+    ["digital services act obligations", "32022R2065"],
+    ["digital markets act rules", "32022R1925"],
+    ["data governance act scope", "32022R0868"],
+  ];
+  for (const [query, expectedCelex] of expectations) {
+    const results = store.searchLaws(query, { limit: 5 }).map((result) => result.celex);
+    assert.equal(results[0], expectedCelex, `${query} should surface ${expectedCelex} first`);
+  }
+  store.close();
 });

--- a/backend/search/search-parity-cases.json
+++ b/backend/search/search-parity-cases.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "preserveOldTopWithin": 5,
+  "cases": [
+    { "query": "32016R0679", "expectedCelex": "32016R0679", "maxRank": 1 },
+    { "query": "regulation 2016/679", "expectedCelex": "32016R0679", "maxRank": 1 },
+    { "query": "general data protection regulation law", "expectedCelex": "32016R0679", "maxRank": 1 },
+    { "query": "digital markets act", "expectedCelex": "32022R1925", "maxRank": 1 },
+    { "query": "digital services act", "expectedCelex": "32022R2065", "maxRank": 1 },
+    { "query": "digital services act obligations", "expectedCelex": "32022R2065", "maxRank": 1 },
+    { "query": "data act", "expectedCelex": "32023R2854", "maxRank": 1 },
+    { "query": "data governance act", "expectedCelex": "32022R0868", "maxRank": 1 },
+    { "query": "ecommerce", "expectedCelex": "32000L0031", "maxRank": 1 },
+    { "query": "eprivacy", "expectedCelex": "32002L0058", "maxRank": 1 },
+    { "query": "payment services directive", "expectedCelex": "32015L2366", "maxRank": 1 },
+    { "query": "genral data protection", "expectedCelex": "32016R0679", "maxRank": 1 },
+    { "query": "artifical intelligence act", "expectedCelex": "32024R1689", "maxRank": 1 },
+    { "query": "digital mark", "expectedCelex": "32022R1925", "maxRank": 1 },
+    { "query": "csrd", "expectedCelex": "32022L2464", "maxRank": 1 },
+    { "query": "mica", "expectedCelex": "32023R1114", "maxRank": 1 },
+    { "query": "emfa", "expectedCelex": "32024R1083", "maxRank": 1 },
+    { "query": "european media freedom act pluralism", "expectedCelex": "32024R1083", "maxRank": 1 },
+    { "query": "right to repair directive consumers", "expectedCelex": "32024L1799", "maxRank": 1 },
+    { "query": "cyber resilience act products", "expectedCelex": "32024R2847", "maxRank": 1 },
+    { "query": "platform work directive workers", "expectedCelex": "32024L2831", "maxRank": 1 },
+    { "query": "automated decision-making" },
+    {
+      "query": "non personal data free flow",
+      "expectedCelex": "32018R1807",
+      "maxRank": 1,
+      "allowTopChange": true
+    },
+    {
+      "query": "payment services directive banking",
+      "expectedCelex": "32015L2366",
+      "maxRank": 1,
+      "allowTopChange": true
+    }
+  ]
+}

--- a/backend/search/search-ranking.js
+++ b/backend/search/search-ranking.js
@@ -23,6 +23,7 @@ const KNOWN_ALIASES = {
     "privacy and electronic communications directive",
     "directive 2002/58",
   ],
+  "32015L2366": ["payment services directive", "psd2"],
   "32018L1972": ["european electronic communications code", "eecc"],
   "32022R0868": ["data governance act"],
   "32022R1925": ["digital markets act"],


### PR DESCRIPTION
Follow-up to #101, rebased onto current main after #102.

## What this adds

- a full-release JSON/SQLite ranking parity gate with a committed query contract and documented intentional changes
- explicit FTS5 detail=full plus SQLite integrity, row-mapping, and count validation
- an external SHA-256 manifest for source inputs and the standalone database artifact
- JSON/SQLite hydration and ambiguity contract tests
- a real multi-stage Docker build and SQLite-backed endpoint smoke test
- a scheduled offline case-law refresh that uploads reviewable candidates; publishing is manual, environment-gated, immutable, and opens a Docker tag-bump PR
- focused alias-intent recovery for modifier-heavy queries without broad OR result expansion

## Validation

- npm test: 289 tests, 287 passed, 2 corpus-dependent skips
- full data-v6 build: 80,440 laws, 8,754 judgments, 145.8 MB SQLite artifact
- full-corpus parity: 24 queries, 23 unchanged top results, 1 documented intentional change, 0 failures
- measured load time in that parity run: JSON about 28.9s; SQLite about 7.6s
- workflow YAML parsed locally; the new Docker workflow performs the container-level verification in CI

Scheduled refreshes never publish automatically. Manual publication requires approval through the data-release environment and a new data-vN tag.