### PR TITLE
Review fix: document and pin getActCitations distinct-source counting

### DIFF
--- a/backend/search/citation-graph-store.js
+++ b/backend/search/citation-graph-store.js
@@ -171,6 +171,12 @@ class CitationGraphStore {
     const articles = [...byArticle.entries()]
       .sort(([a], [b]) => a.localeCompare(b, "en", { numeric: true }))
       .map(([citedArticle, articleEdges]) => ({ article: citedArticle, ...countsFor(articleEdges) }));
+    // `actOnly`, `article`, and `totals` each count *distinct source provisions*
+    // within their own edge subset, so they intentionally do NOT sum: a single
+    // provision that cites both the act generally and a specific article is
+    // counted once in `actOnly` and once in `article`, but only once in
+    // `totals` (which dedups across every edge). Treat `totals` as the
+    // authoritative distinct-source count; do not derive it from the parts.
     return { celex: targetCelex, actOnly: countsFor(actOnly), article: countsFor(article), articles, totals: countsFor(edges) };
   }
 }

--- a/backend/search/citation-graph-store.test.js
+++ b/backend/search/citation-graph-store.test.js
@@ -91,3 +91,21 @@ test("act query separates act-only references from article references", () => {
     totals: { provisions: 2, judgments: 1, total: 3 },
   });
 });
+
+test("act query dedups a provision citing both the act and an article across subsets", () => {
+  // 32024R0009 unit 3 cites the act generally (act-only) and Article 6. It must
+  // count once in actOnly, once in article, but only once in the deduplicated
+  // totals — so actOnly.total + article.total (2) intentionally exceeds
+  // totals.total (1). This pins the "totals is not the sum of the parts" contract.
+  const overlappingEdges = [
+    { kind: "legislation", sourceCelex: "32024R0009", sourceTitle: "Dual citer", sourceUnitType: "article", sourceUnit: "3", targetCelex: "32016R0679", targetArticle: null, targetParagraph: null, targetPoint: null },
+    { kind: "legislation", sourceCelex: "32024R0009", sourceTitle: "Dual citer", sourceUnitType: "article", sourceUnit: "3", targetCelex: "32016R0679", targetArticle: "6", targetParagraph: null, targetPoint: null },
+  ];
+  const store = new CitationGraphStore(writeGraph({ graphVersion: 1, edges: overlappingEdges }));
+  assert.equal(store.load(), true);
+  const result = store.getActCitations("32016R0679");
+  assert.deepEqual(result.actOnly, { provisions: 1, judgments: 0, total: 1 });
+  assert.deepEqual(result.article, { provisions: 1, judgments: 0, total: 1 });
+  assert.deepEqual(result.totals, { provisions: 1, judgments: 0, total: 1 });
+  assert.ok(result.actOnly.total + result.article.total > result.totals.total);
+});


### PR DESCRIPTION
## Summary

Follow-up to the review of #82. Addresses the one non-cosmetic issue surfaced there: the counting contract in `CitationGraphStore.getActCitations` was correct but undocumented and untested.

`actOnly`, `article`, and `totals` each count **distinct source provisions within their own edge subset**, so they intentionally do **not** sum. A single provision that cites both an act generally *and* one of its articles is counted once in `actOnly` and once in `article`, but only once in the deduplicated `totals`. That means `actOnly.total + article.total` can exceed `totals.total`. Because no existing test exercised the overlap, this behavior was easy to mistake for a bug and "fix" into a regression.

## Changes

- Clarify the intended semantics with a comment in `getActCitations` (treat `totals` as the authoritative distinct-source count; don't derive it from the parts).
- Add a regression test covering a provision that cites both the act and a specific article, asserting the dedup behavior and that the parts exceed the total.

## Validation

- `npm test` in `backend`: 272 passed, 2 skipped, 0 failed (the new test included).

## Notes

Other review observations were deliberately left as-is: the fixed `limit=200` in the reader UI is an intended MVP limitation (a product decision), the per-worker search-cache reload is a build-time-only performance nicety, and `loadFromDisk()` / the client-side prefix-stripping duplication are intentional (API symmetry with `legal-cache-store` and defense-in-depth, respectively).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfFQVoUwZcTjB2gk1zEw2P

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfFQVoUwZcTjB2gk1zEw2P)_