### PR TITLE
Test alias-intent recovery and clarify FTS5 detail=full

### DIFF
--- a/backend/search/build-sqlite-data.js
+++ b/backend/search/build-sqlite-data.js
@@ -98,6 +98,11 @@ function buildSqliteData({
         celex TEXT NOT NULL,
         ordinal INTEGER NOT NULL
       ) STRICT;
+      -- detail=full is FTS5's default; stated explicitly so phrase/NEAR recall
+      -- stays available and a later reviewer does not "simplify" it to a
+      -- narrower detail mode. Because it matches the default, the on-disk
+      -- format is unchanged and SQLITE_SCHEMA_VERSION does not need a bump;
+      -- moving to detail=column/none would change the schema and require one.
       CREATE VIRTUAL TABLE law_excerpts USING fts5(
         excerpt,
         content='',

--- a/backend/search/legal-cache-store.js
+++ b/backend/search/legal-cache-store.js
@@ -572,6 +572,7 @@ module.exports = {
   DEFAULT_SQLITE_DATA_PATH,
   JsonLegalCacheStore,
   SQLITE_SCHEMA_VERSION,
+  containedAliasKeys,
   normalizeCelexLookupKey,
   normalizeEliLookupKey,
   normalizeOfficialReferenceLookupKey,

--- a/backend/search/legal-cache-store.test.js
+++ b/backend/search/legal-cache-store.test.js
@@ -6,6 +6,7 @@ const path = require("node:path");
 
 const {
   JsonLegalCacheStore,
+  containedAliasKeys,
 } = require("./legal-cache-store");
 const { buildSqliteData } = require("./build-sqlite-data");
 
@@ -472,4 +473,52 @@ test("JSON and SQLite both preserve ambiguous lookups", () => {
     assert.equal(store.getByEli("http://data.europa.eu/eli/reg/2020/123/oj"), null);
     store.close();
   }
+});
+
+test("containedAliasKeys yields contiguous multi-word phrases, longest first", () => {
+  const keys = containedAliasKeys("digital services act obligations");
+
+  // Both the spaced and compact form of each sub-phrase are produced so a query
+  // can hit either alias variant stored in byAlias.
+  assert.ok(keys.includes("digital services act"));
+  assert.ok(keys.includes("digitalservicesact"));
+
+  // Longest sub-phrases come first so a more specific alias outranks a shorter
+  // one when several are added before the MiniSearch stage.
+  assert.equal(keys[0], "digital services act");
+
+  // The full query is handled by the exact-alias lookup, and single words are
+  // deliberately excluded to avoid broad, low-precision matches.
+  assert.ok(!keys.includes("digital services act obligations"));
+  assert.ok(!keys.includes("digital"));
+});
+
+test("containedAliasKeys stays bounded and deduplicated", () => {
+  // Fewer than three words cannot contain a shorter contiguous sub-phrase, so
+  // nothing is generated (the exact-alias path covers the whole query itself).
+  assert.deepEqual(containedAliasKeys(""), []);
+  assert.deepEqual(containedAliasKeys("oneword"), []);
+  assert.deepEqual(containedAliasKeys("two words"), []);
+
+  // Repeated phrases collapse to a single spaced/compact pair.
+  assert.deepEqual(containedAliasKeys("act act act"), ["act act", "actact"]);
+});
+
+test("searchLaws recovers a known alias embedded in a modifier-heavy query", () => {
+  const store = new JsonLegalCacheStore(fixturePath, { preferJson: true });
+  assert.equal(store.load(), true);
+
+  // Each query carries an extra modifier token that is absent from the target
+  // law's title, so the exact-alias and strict AND paths cannot surface it; the
+  // contiguous-alias recovery keeps the known law at rank one.
+  const expectations = [
+    ["digital services act obligations", "32022R2065"],
+    ["digital markets act rules", "32022R1925"],
+    ["data governance act scope", "32022R0868"],
+  ];
+  for (const [query, expectedCelex] of expectations) {
+    const results = store.searchLaws(query, { limit: 5 }).map((result) => result.celex);
+    assert.equal(results[0], expectedCelex, `${query} should surface ${expectedCelex} first`);
+  }
+  store.close();
 });


### PR DESCRIPTION
Follow-up to the code review of #103, stacked on that branch so it merges into the same PR.

## What this adds

- **Direct coverage for `containedAliasKeys`** (the new alias-intent recovery). The function is now exported and unit-tested for:
  - contiguous multi-word phrase generation — both spaced and compact variants, longest-first ordering, with single words and the full query deliberately excluded;
  - its bounded/deduplicated edge cases (`""`, one word, two words → `[]`; repeated phrases collapse);
  - an integration test proving a known alias embedded in a modifier-heavy query (`"digital services act obligations"`, `"digital markets act rules"`, `"data governance act scope"`) still ranks the target law first, even though the extra modifier token is absent from the law's title.

  Previously this behavior was only exercised by the full-corpus parity gate, which does not run in `npm test`.

- **Clarifying comment on `detail=full`** in the FTS5 excerpt table: it is FTS5's default, stated explicitly so a later change does not silently narrow it. Because it matches the default, the on-disk format is unchanged and no `SQLITE_SCHEMA_VERSION` bump is required; moving to `detail=column`/`none` would change the schema and require one.

## Why not other review nits

The reviewed `jsonStore.resetIndexes()` call in `compare-search-backends.js` was flagged as redundant, but `close()` only closes the SQLite handle — it does **not** reset the in-memory MiniSearch/alias indexes. That call is what frees them before `global.gc()` in the memory-constrained parity run, so it was left intact.

## Validation

- `npm test` (backend): 292 tests, 290 passed, 2 corpus-dependent skips (the 3 new tests included).
- New tests verified to fail-meaningfully: the integration case surfaces the aliased law via the recovery path rather than a title/AND match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4QcF2JKUYxGqDYKggn5SZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4QcF2JKUYxGqDYKggn5SZ)_