### PR TITLE
Fix citation chip alignment in AI law overview

### DIFF
--- a/src/components/LawSummary.jsx
+++ b/src/components/LawSummary.jsx
@@ -15,15 +15,15 @@ function GoldSparkle({ size = 15 }) {
 
 function CitationChips({ citations, onArticleClick, t }) {
   if (!citations?.length) return null;
-  return (
-    <span className="ml-2 inline-flex flex-wrap gap-1 align-middle">
-      {citations.map((article) => (
-        <Chip key={article} onClick={() => onArticleClick?.(article)}>
-          {t("lawViewer.artShort")} {article}
-        </Chip>
-      ))}
-    </span>
-  );
+  return citations.map((article) => (
+    <Chip
+      key={article}
+      onClick={() => onArticleClick?.(article)}
+      className="ml-1 align-baseline"
+    >
+      {t("lawViewer.artShort")} {article}
+    </Chip>
+  ));
 }
 
 function CitedText({ block, onArticleClick, t }) {
@@ -115,9 +115,13 @@ export function LawSummary({ celex, lang = "EN", onArticleClick, className = "ro
                         <span className="h-1.5 w-1.5 shrink-0 translate-y-1 rounded-full bg-eu-gold dark:bg-eu-gold-bright" />
                         <span className="min-w-0 flex-1">{item.text}</span>
                         {item.citations?.length ? (
-                          <span className="inline-flex shrink-0 flex-wrap justify-end gap-1 pl-2">
+                          <span className="ml-auto shrink-0 space-x-1 pl-3 text-right">
                             {item.citations.map((article) => (
-                              <Chip key={article} onClick={() => onArticleClick?.(article)}>
+                              <Chip
+                                key={article}
+                                onClick={() => onArticleClick?.(article)}
+                                className="align-baseline"
+                              >
                                 {t("lawViewer.artShort")} {article}
                               </Chip>
                             ))}

--- a/src/components/ui/Chip.jsx
+++ b/src/components/ui/Chip.jsx
@@ -3,7 +3,7 @@
  */
 export const Chip = ({ children, onClick, className = "" }) => {
   const classes =
-    `inline-block rounded px-[7px] py-px font-mono text-[11px] text-eu-blue bg-eu-blue-soft dark:text-eu-blue-bright dark:bg-eu-blue-soft-dark ` +
+    `inline-block whitespace-nowrap rounded px-[7px] py-px font-mono text-[11px] text-eu-blue bg-eu-blue-soft dark:text-eu-blue-bright dark:bg-eu-blue-soft-dark ` +
     className;
 
   if (onClick) {


### PR DESCRIPTION
## Summary

The article citation chips (`Art. 1`, `Art. 5`, …) in the AI law overview sat slightly high relative to the surrounding text. This aligns them to the text baseline, matching the design mockup (`design/legalviz-redesign-mockups.html`).

## Root cause

Two separate alignment issues in `src/components/LawSummary.jsx`:

- **Purpose / Scope** chips used `align-middle` on an `inline-flex` wrapper, which centers the chip box on the text's optical midline rather than the baseline — making small chips ride high.
- **Key Points** chips were wrapped in a *nested* `inline-flex flex-wrap` inside an `items-baseline` flex row. A multi-line/nested flex container synthesizes its baseline from its bottom edge, so the chips fell off the text baseline.

The mockup instead uses plain baseline-aligned `inline-block` chips (`.chip{display:inline-block}` with an `.chips{margin-left:auto}` container) and no nested flex.

## Changes

- `src/components/LawSummary.jsx`
  - `CitationChips` (Purpose/Scope): render baseline-aligned inline-block chips directly (`ml-1 align-baseline`) instead of an `align-middle` inline-flex wrapper.
  - Key Points chips: replace the nested `inline-flex flex-wrap justify-end` container with a plain `ml-auto … text-right` container so the chips baseline-align with the point text and still right-align/wrap.
- `src/components/ui/Chip.jsx`: add `whitespace-nowrap` to the base class so a label like `Art. 15` never breaks between `Art.` and the number (matches the mockup's `.chip{white-space:nowrap}`).

Presentational-only; no cached output shape changed, so no cache-version bumps needed.

## Testing

- `npx eslint src/components/LawSummary.jsx src/components/ui/Chip.jsx` — clean
- `npx vitest run src/components` — passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJv1K5FNah5ofDtEShg6Ke

---
_Generated by [Claude Code](https://claude.ai/code/session_01KJv1K5FNah5ofDtEShg6Ke)_