### PR TITLE
Remove beta references from UI and locales

### DIFF
--- a/design/legalviz-redesign-mockups.html
+++ b/design/legalviz-redesign-mockups.html
@@ -190,7 +190,6 @@ section.shot{margin-top:72px}
 .pill.reg{background:var(--blue-soft);color:var(--blue)}
 .pill.ok{background:var(--green-soft);color:var(--green)}
 .pill.ok i{width:6px;height:6px;border-radius:50%;background:var(--green);display:block}
-.pill.beta{background:var(--gold-soft);color:var(--gold-deep)}
 .mono{font-family:var(--mono);font-size:11.5px;color:var(--faint);letter-spacing:.01em}
 
 .btn{
@@ -676,7 +675,7 @@ section.shot{margin-top:72px}
             </div>
             <div class="law-actions">
               <span class="btn solid">Start reading&nbsp;→</span>
-              <span class="btn outline">⚖&nbsp; CJEU case law &nbsp;<span class="pill beta">beta</span></span>
+              <span class="btn outline">⚖&nbsp; CJEU case law</span>
               <span class="btn ghost">Print / PDF</span>
             </div>
 

--- a/src/components/RelatedCaseLaw.jsx
+++ b/src/components/RelatedCaseLaw.jsx
@@ -118,7 +118,6 @@ export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN" }) {
           <span className="flex min-w-0 items-center gap-2">
             <Scale size={16} className="shrink-0 text-teal-700 dark:text-teal-300" />
             <span className="font-semibold text-gray-900 dark:text-gray-100">{title}</span>
-            <span className="rounded bg-teal-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-800 dark:bg-teal-800 dark:text-teal-200">{t("common.beta")}</span>
           </span>
           <span className="flex shrink-0 items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
             <Loader2 size={14} className="animate-spin" />
@@ -162,7 +161,6 @@ export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN" }) {
           <span className="rounded-full bg-teal-100 px-2.5 py-0.5 text-sm font-medium text-teal-800 dark:bg-teal-900/40 dark:text-teal-200">
             {matching.length}
           </span>
-          <span className="rounded bg-teal-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-teal-800 dark:bg-teal-800 dark:text-teal-200">{t("common.beta")}</span>
         </span>
       </div>
 

--- a/src/components/law-viewer/LawOverviewPage.jsx
+++ b/src/components/law-viewer/LawOverviewPage.jsx
@@ -17,7 +17,7 @@ const ACT_TYPE_KEY = {
 /**
  * CJEU case-law action for the overview header. Mirrors the sidebar
  * CaseLawButton's load-on-click / auto-open behavior, styled as an outline
- * button with a beta pill.
+ * button.
  */
 function OverviewCaseLawButton({ celex, currentLang, t }) {
   const [modalOpen, setModalOpen] = useState(false);
@@ -66,7 +66,6 @@ function OverviewCaseLawButton({ celex, currentLang, t }) {
         {loading ? <Loader2 size={16} className="animate-spin" /> : <Scale size={16} />}
         {t("metadata.caseLaw")}
         {hasCases ? ` (${cases.length})` : ""}
-        <Pill variant="beta">{t("common.beta")}</Pill>
       </button>
       {hasCases ? (
         <CaseLawModal

--- a/src/components/ui/Pill.jsx
+++ b/src/components/ui/Pill.jsx
@@ -1,10 +1,9 @@
 /**
- * Small uppercase status/label pill (e.g. act type, "in force", AI/beta, corrigendum, repealed).
+ * Small uppercase status/label pill (e.g. act type, "in force", AI, corrigendum, repealed).
  */
 const VARIANT_CLASSES = {
   reg: "bg-eu-blue-soft text-eu-blue dark:bg-eu-blue-soft-dark dark:text-eu-blue-bright",
   ok: "bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300",
-  beta: "bg-eu-gold-soft text-eu-gold-deep dark:bg-eu-gold-soft-dark dark:text-eu-gold-bright",
   corr: "bg-eu-gold-soft text-eu-gold-deep dark:bg-eu-gold-soft-dark dark:text-eu-gold-bright",
   muted: "bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400",
 };

--- a/src/i18n/locales/bg.json
+++ b/src/i18n/locales/bg.json
@@ -22,7 +22,6 @@
     "recitals": "Съображения",
     "annexes": "Приложения",
     "noSelection": "Няма избор",
-    "beta": "бета",
     "ai": "ИИ",
     "noneFoundSuffix": "— не са намерени"
   },

--- a/src/i18n/locales/cs.json
+++ b/src/i18n/locales/cs.json
@@ -22,7 +22,6 @@
     "recitals": "Body odůvodnění",
     "annexes": "Přílohy",
     "noSelection": "Nic není vybráno",
-    "beta": "beta",
     "ai": "AI",
     "noneFoundSuffix": "— žádné nenalezeny"
   },

--- a/src/i18n/locales/da.json
+++ b/src/i18n/locales/da.json
@@ -22,7 +22,6 @@
     "recitals": "Betragtninger",
     "annexes": "Bilag",
     "noSelection": "Intet valgt",
-    "beta": "beta",
     "ai": "AI",
     "noneFoundSuffix": "— ingen fundet"
   },

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -22,7 +22,6 @@
     "recitals": "Erwägungsgründe",
     "annexes": "Anhänge",
     "noSelection": "Keine Auswahl",
-    "beta": "Beta",
     "ai": "KI",
     "noneFoundSuffix": "— keine gefunden"
   },

--- a/src/i18n/locales/el.json
+++ b/src/i18n/locales/el.json
@@ -22,7 +22,6 @@
     "recitals": "Αιτιολογικές σκέψεις",
     "annexes": "Παραρτήματα",
     "noSelection": "Καμία επιλογή",
-    "beta": "beta",
     "ai": "ΤΝ",
     "noneFoundSuffix": "— δεν βρέθηκαν"
   },

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -22,7 +22,6 @@
     "recitals": "Recitals",
     "annexes": "Annexes",
     "noSelection": "No selection",
-    "beta": "beta",
     "ai": "AI",
     "noneFoundSuffix": "— none found"
   },

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -22,7 +22,6 @@
     "recitals": "Considerandos",
     "annexes": "Anexos",
     "noSelection": "Sin selección",
-    "beta": "beta",
     "ai": "IA",
     "noneFoundSuffix": "— no se encontraron"
   },

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -22,7 +22,6 @@
     "recitals": "Põhjendused",
     "annexes": "Lisad",
     "noSelection": "Valik puudub",
-    "beta": "beeta",
     "ai": "TI",
     "noneFoundSuffix": "— ei leitud ühtegi"
   },

--- a/src/i18n/locales/fi.json
+++ b/src/i18n/locales/fi.json
@@ -22,7 +22,6 @@
     "recitals": "Johdanto-osan kappaleet",
     "annexes": "Liitteet",
     "noSelection": "Ei valintaa",
-    "beta": "beta",
     "ai": "tekoäly",
     "noneFoundSuffix": "— ei löytynyt yhtään"
   },

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -22,7 +22,6 @@
     "recitals": "Considérants",
     "annexes": "Annexes",
     "noSelection": "Aucune sélection",
-    "beta": "bêta",
     "ai": "IA",
     "noneFoundSuffix": "— aucun trouvé"
   },

--- a/src/i18n/locales/ga.json
+++ b/src/i18n/locales/ga.json
@@ -22,7 +22,6 @@
     "recitals": "Aithrisí",
     "annexes": "Iarscríbhinní",
     "noSelection": "Gan roghnú",
-    "beta": "beite",
     "ai": "AI",
     "noneFoundSuffix": "— níor aimsíodh aon cheann"
   },

--- a/src/i18n/locales/hr.json
+++ b/src/i18n/locales/hr.json
@@ -22,7 +22,6 @@
     "recitals": "Uvodne izjave",
     "annexes": "Prilozi",
     "noSelection": "Nema odabira",
-    "beta": "beta",
     "ai": "UI",
     "noneFoundSuffix": "— nije pronađeno"
   },

--- a/src/i18n/locales/hu.json
+++ b/src/i18n/locales/hu.json
@@ -22,7 +22,6 @@
     "recitals": "Preambulumbekezdések",
     "annexes": "Mellékletek",
     "noSelection": "Nincs kijelölés",
-    "beta": "béta",
     "ai": "MI",
     "noneFoundSuffix": "— nem található"
   },

--- a/src/i18n/locales/it.json
+++ b/src/i18n/locales/it.json
@@ -22,7 +22,6 @@
     "recitals": "Considerando",
     "annexes": "Allegati",
     "noSelection": "Nessuna selezione",
-    "beta": "beta",
     "ai": "IA",
     "noneFoundSuffix": "— nessuno trovato"
   },

--- a/src/i18n/locales/lt.json
+++ b/src/i18n/locales/lt.json
@@ -22,7 +22,6 @@
     "recitals": "Konstatuojamosios dalys",
     "annexes": "Priedai",
     "noSelection": "Nieko nepasirinkta",
-    "beta": "beta",
     "ai": "DI",
     "noneFoundSuffix": "— nerasta"
   },

--- a/src/i18n/locales/lv.json
+++ b/src/i18n/locales/lv.json
@@ -22,7 +22,6 @@
     "recitals": "Apsvērumi",
     "annexes": "Pielikumi",
     "noSelection": "Nav izvēles",
-    "beta": "beta",
     "ai": "MI",
     "noneFoundSuffix": "— nekas nav atrasts"
   },

--- a/src/i18n/locales/mt.json
+++ b/src/i18n/locales/mt.json
@@ -22,7 +22,6 @@
     "recitals": "Premessi",
     "annexes": "Annessi",
     "noSelection": "Ebda għażla",
-    "beta": "beta",
     "ai": "AI",
     "noneFoundSuffix": "— l-ebda wieħed misjub"
   },

--- a/src/i18n/locales/nl.json
+++ b/src/i18n/locales/nl.json
@@ -22,7 +22,6 @@
     "recitals": "Overwegingen",
     "annexes": "Bijlagen",
     "noSelection": "Geen selectie",
-    "beta": "bèta",
     "ai": "AI",
     "noneFoundSuffix": "— geen gevonden"
   },

--- a/src/i18n/locales/pl.json
+++ b/src/i18n/locales/pl.json
@@ -22,7 +22,6 @@
     "recitals": "Motywy",
     "annexes": "Załączniki",
     "noSelection": "Brak wyboru",
-    "beta": "beta",
     "ai": "AI",
     "noneFoundSuffix": "— nie znaleziono"
   },

--- a/src/i18n/locales/pt.json
+++ b/src/i18n/locales/pt.json
@@ -22,7 +22,6 @@
     "recitals": "Considerandos",
     "annexes": "Anexos",
     "noSelection": "Sem seleção",
-    "beta": "beta",
     "ai": "IA",
     "noneFoundSuffix": "— nenhum encontrado"
   },

--- a/src/i18n/locales/ro.json
+++ b/src/i18n/locales/ro.json
@@ -22,7 +22,6 @@
     "recitals": "Considerente",
     "annexes": "Anexe",
     "noSelection": "Nicio selecție",
-    "beta": "beta",
     "ai": "IA",
     "noneFoundSuffix": "— niciunul găsit"
   },

--- a/src/i18n/locales/sk.json
+++ b/src/i18n/locales/sk.json
@@ -22,7 +22,6 @@
     "recitals": "Odôvodnenia",
     "annexes": "Prílohy",
     "noSelection": "Žiadny výber",
-    "beta": "beta",
     "ai": "AI",
     "noneFoundSuffix": "— žiadne nenájdené"
   },

--- a/src/i18n/locales/sl.json
+++ b/src/i18n/locales/sl.json
@@ -22,7 +22,6 @@
     "recitals": "Uvodne izjave",
     "annexes": "Priloge",
     "noSelection": "Ni izbire",
-    "beta": "beta",
     "ai": "UI",
     "noneFoundSuffix": "— ni najdenih"
   },

--- a/src/i18n/locales/sv.json
+++ b/src/i18n/locales/sv.json
@@ -22,7 +22,6 @@
     "recitals": "Skäl",
     "annexes": "Bilagor",
     "noSelection": "Inget valt",
-    "beta": "beta",
     "ai": "AI",
     "noneFoundSuffix": "— inga hittades"
   },


### PR DESCRIPTION
## Summary

Removes all product "beta" references from the codebase.

- **`src/components/law-viewer/LawOverviewPage.jsx`** — drop the `<Pill variant="beta">` badge from the CJEU case-law header button (and update its doc comment).
- **`src/components/RelatedCaseLaw.jsx`** — remove the "beta" badge span from both the loading and populated states of the related case-law section.
- **`src/components/ui/Pill.jsx`** — remove the now-unused `beta` variant and update the component comment.
- **`src/i18n/locales/*.json`** — remove the now-unreferenced `common.beta` translation key from all 24 locale files.
- **`design/legalviz-redesign-mockups.html`** — remove the beta pill markup and its `.pill.beta` CSS rule.

## Notes

Two `beta`-substring matches were intentionally left untouched because they are not product-status references: the `MONOTONICITY_BETA` math constant in `src/utils/nlp.js`, and the "Beta Data Authority" test fixture name in `backend/search/case-law-parse.test.js`.

## Testing

- `npm run lint` — passes
- `npm run test:web` — 324 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0165J1cfMtRaE45bQjqvuZTg)_