### PR TITLE
Citation graph: walk the HTML corpus, serve it from SQLite

### DIFF
--- a/.github/workflows/backend-docker.yml
+++ b/.github/workflows/backend-docker.yml
@@ -57,6 +57,30 @@ jobs:
               throw new Error("source JSON assets leaked into final image");
             }
           '
+      # date and eurovoc are enriched inline onto the records as the cache builders
+      # last step. Publishing a raw search-cache instead of carrying the enriched
+      # asset forward silently strips both: every pre-2010 act serves a null date,
+      # and /api/topics goes empty. The topics endpoint above only catches the
+      # second, so assert the invariant the release notes state -- every record
+      # dated, every record carrying an eurovoc key (an empty array is legitimate).
+      - name: Assert record enrichment survived the data build
+        run: |
+          docker exec legalviz-backend node -e '
+            const Database = require("better-sqlite3");
+            const db = new Database("search/data/data.sqlite", { readonly: true });
+            // The JSON path is bound, not inlined: SQLite reads a double-quoted
+            // literal as an identifier, and this runs inside single quotes already.
+            const missing = (jsonPath) => db.prepare(
+              "SELECT COUNT(*) AS c FROM laws WHERE json_extract(record_json, ?) IS NULL"
+            ).get(jsonPath).c;
+            const laws = db.prepare("SELECT COUNT(*) AS c FROM laws").get().c;
+            const undated = missing("$.date");
+            const untopiced = missing("$.eurovoc");
+            db.close();
+            if (undated > 0) throw new Error(undated + "/" + laws + " laws have no date - search-cache lost its date enrichment");
+            if (untopiced > 0) throw new Error(untopiced + "/" + laws + " laws have no eurovoc key - search-cache lost its EuroVoc enrichment");
+            console.log("enrichment intact: " + laws + " laws, all dated, all carrying eurovoc");
+          '
       - name: Container logs
         if: always()
         run: docker logs legalviz-backend || true

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ backend/search/data/search-cache.json.gz
 backend/search/data/case-law-cache.json
 backend/search/data/case-law-cache.json.gz
 backend/search/data/data.sqlite
+backend/search/data/data.sqlite.manifest.json
 backend/search/data/laws/
 backend/search/data/laws-html/
 backend/search/data/case-law/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -34,12 +34,16 @@ COPY search/build-sqlite-data.js search/search-ranking.js ./search/
 # and are fetched here, then converted into the runtime SQLite store:
 #   search/data/search-cache.json.gz    -> title/alias index + FTS5 excerpts
 #   search/data/case-law-cache.json.gz  -> folded into data.sqlite
-#   search/data/citation-graph.json.gz  -> fetched for the follow-up that folds it
-#                                          into data.sqlite; not used here yet
+#   search/data/citation-graph.json.gz  -> folded into data.sqlite
 # Placed before `COPY . .` so this (large) layer stays cached across code
 # changes and only re-runs when DATA_RELEASE_TAG is bumped for a new data build.
 ARG DATA_RELEASE_REPO=maastrichtlawtech/legalviz.eu
 ARG DATA_RELEASE_TAG=data-v7
+# Every asset comes from this one tag, so a new release must carry the full set —
+# re-upload the unchanged ones alongside the changed one or this fetch 404s.
+# citation-graph.json.gz is a *build input* like the others: it is folded into
+# data.sqlite here and never ships in the runtime image (as raw JSON it is ~373 MB
+# and would cost >1 GB resident to load).
 RUN mkdir -p search/data \
     && for asset in search-cache.json.gz case-law-cache.json.gz citation-graph.json.gz; do \
          echo "Fetching data asset: $asset ($DATA_RELEASE_TAG)" \

--- a/backend/README.md
+++ b/backend/README.md
@@ -525,7 +525,7 @@ Important: restart the API server after rebuilding the cache, because the cache 
 ### Precomputed runtime store
 
 `npm run build:sqlite-data` converts `search-cache.json(.gz)` and
-`case-law-cache-v5.json(.gz)` into `search/data/data.sqlite`. It writes a
+`case-law-cache.json(.gz)` into `search/data/data.sqlite`. It writes a
 temporary database, validates its schema, row counts, and integrity, then
 renames it atomically. The build also emits `data.sqlite.manifest.json` with
 source and artifact SHA-256 checksums, schema version, table counts, and mapping

--- a/backend/docs/case-law-data-refresh.md
+++ b/backend/docs/case-law-data-refresh.md
@@ -30,7 +30,7 @@ The workflow performs these steps in order:
 
 1. Read the current `DATA_RELEASE_TAG` from `backend/Dockerfile`.
 2. Download that release's `search-cache.json.gz` and
-   `case-law-cache-v5.json.gz` assets.
+   `case-law-cache.json.gz` assets.
 3. Restore the raw compressed judgment HTML corpus from the GitHub Actions
    cache, when available.
 4. Query CELLAR's SPARQL endpoint for the complete set of CJEU and General Court
@@ -101,7 +101,7 @@ Open **Actions > Refresh case-law data**, select the run, and download the
 
 | File | Review purpose |
 | --- | --- |
-| `case-law-cache-v5.json.gz` | Updated structured judgment cache |
+| `case-law-cache.json.gz` | Updated structured judgment cache |
 | `search-cache.json.gz` | Legislation search input carried from the current release |
 | `data.sqlite` | Candidate runtime database |
 | `data.sqlite.manifest.json` | Input and artifact hashes, schema version, row counts, and integrity results |

--- a/backend/routes/api-routes.test.js
+++ b/backend/routes/api-routes.test.js
@@ -8,7 +8,7 @@ const { registerApiRoutes } = require("./api-routes");
 const { createParsedLawResolver } = require("../shared/parsed-law-service");
 const { createReferenceResolver } = require("../shared/reference-utils");
 const { ClientError, cacheGet, cacheSet, safeErrorResponse, toSearchLang } = require("../shared/api-utils");
-const { CitationGraphStore } = require("../search/citation-graph-store");
+const { CitationGraphStore, GRAPH_VERSION } = require("../search/citation-graph-store");
 const { JsonLegalCacheStore } = require("../search/legal-cache-store");
 
 const fixturePath = path.join(__dirname, "..", "search", "__fixtures__", "search-fixture.json");
@@ -224,7 +224,7 @@ test('GET article cited-by passes validated pagination to the citation graph', a
 test('GET article cited-by returns normalized recital and annex units', async () => {
   const graphPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'api-citation-graph-')), 'graph.json');
   fs.writeFileSync(graphPath, JSON.stringify({
-    graphVersion: 1,
+    graphVersion: GRAPH_VERSION,
     edges: [
       { kind: 'legislation', sourceCelex: '32024R1689', sourceUnitType: 'recital', sourceUnit: 'recital_140', targetCelex: '32016R0679', targetArticle: '6' },
       { kind: 'legislation', sourceCelex: '32024R1689', sourceUnitType: 'annex', sourceUnit: 'annex_I', targetCelex: '32016R0679', targetArticle: '6' },

--- a/backend/search/build-sqlite-data.js
+++ b/backend/search/build-sqlite-data.js
@@ -9,8 +9,27 @@ const Database = require("better-sqlite3");
 const { enrichSearchRecord } = require("./search-ranking");
 const DEFAULT_SEARCH_CACHE_PATH = path.join(__dirname, "data", "search-cache.json");
 const DEFAULT_SQLITE_DATA_PATH = path.join(__dirname, "data", "data.sqlite");
+// Unversioned on purpose: the data-vN release tag already pins which build this
+// came from, so a case-law schema bump no longer has to edit the Dockerfile's asset
+// list. This is the release asset, distinct from law-cache/case-law-cache-v5.json,
+// whose name IS the cache version (CASE_LAW_CACHE_FILE) and must keep its suffix.
 const DEFAULT_CASE_LAW_CACHE_PATH = path.join(__dirname, "data", "case-law-cache.json");
-const SQLITE_SCHEMA_VERSION = 1;
+const DEFAULT_CITATION_GRAPH_PATH = path.join(__dirname, "data", "citation-graph.json");
+// Keep in lock-step with SQLITE_SCHEMA_VERSION in legal-cache-store.js.
+const SQLITE_SCHEMA_VERSION = 2;
+
+// Normalized form of a cited article, matching how the store compares them, so the
+// (target_celex, target_article_key) index can serve the lookup directly rather than
+// forcing a scan through LOWER()/TRIM() at query time.
+function articleKey(article) {
+  return String(article == null ? "" : article).trim().toLowerCase();
+}
+
+function textOrNull(value) {
+  if (value == null) return null;
+  const text = String(value);
+  return text === "" ? null : text;
+}
 
 function sha256File(filePath) {
   const hash = crypto.createHash("sha256");
@@ -57,13 +76,29 @@ function isPartialCaseLawEntry(entry) {
 function buildSqliteData({
   searchCachePath = DEFAULT_SEARCH_CACHE_PATH,
   caseLawCachePath = DEFAULT_CASE_LAW_CACHE_PATH,
+  citationGraphPath = DEFAULT_CITATION_GRAPH_PATH,
   outputPath = DEFAULT_SQLITE_DATA_PATH,
   manifestPath = `${outputPath}.manifest.json`,
+  log = console.warn,
 } = {}) {
   const searchAsset = readJsonAsset(searchCachePath);
   const caseLawAsset = readJsonAsset(caseLawCachePath);
+  // The citation graph is optional: it is a large, separately built artifact, and a
+  // build without it must still produce a usable data.sqlite. The tables are then
+  // empty and the store reports itself unavailable (503) rather than serving a
+  // silently partial graph — the manifest records which case this build was.
+  let citationAsset = null;
+  if (citationGraphPath) {
+    try {
+      citationAsset = readJsonAsset(citationGraphPath);
+    } catch (error) {
+      if (!/not found/.test(String(error?.message))) throw error;
+      log(`[build-sqlite-data] No citation graph at ${citationGraphPath} — citation tables will be empty`);
+    }
+  }
   const searchPayload = searchAsset.payload;
   const caseLawPayload = caseLawAsset.payload;
+  const citationEdges = Array.isArray(citationAsset?.payload?.edges) ? citationAsset.payload.edges : [];
   const records = Array.isArray(searchPayload.records) ? searchPayload.records : [];
   const caseLawEntries = Object.entries(caseLawPayload).filter(([rawCelex, details]) => (
     String(rawCelex || "").trim() && details && typeof details === "object"
@@ -114,6 +149,29 @@ function buildSqliteData({
         details_json TEXT NOT NULL,
         is_partial INTEGER NOT NULL CHECK (is_partial IN (0, 1))
       ) STRICT;
+      -- Citing-act titles live here rather than on every edge: ~84k distinct sources
+      -- carry ~836k edges, so repeating the title per edge is what made the JSON
+      -- artifact enormous.
+      CREATE TABLE citation_sources (
+        celex TEXT PRIMARY KEY,
+        title TEXT
+      ) STRICT;
+      CREATE TABLE citations (
+        id INTEGER PRIMARY KEY,
+        kind TEXT NOT NULL,
+        source_celex TEXT NOT NULL,
+        source_unit_type TEXT,
+        source_unit TEXT,
+        target_celex TEXT NOT NULL,
+        target_article TEXT,
+        target_article_key TEXT NOT NULL,
+        target_paragraph TEXT,
+        target_point TEXT,
+        raw TEXT
+      ) STRICT;
+      -- Serves both cited-by lookups: act-level uses the target_celex prefix,
+      -- article-level uses both columns.
+      CREATE INDEX citations_target ON citations (target_celex, target_article_key);
     `);
 
     const insertMetadata = database.prepare("INSERT INTO metadata (key, value) VALUES (?, ?)");
@@ -125,8 +183,18 @@ function buildSqliteData({
     const insertCaseLaw = database.prepare(
       "INSERT INTO case_law (celex, details_json, is_partial) VALUES (?, ?, ?)"
     );
+    const insertCitationSource = database.prepare(
+      "INSERT INTO citation_sources (celex, title) VALUES (?, ?)"
+    );
+    const insertCitation = database.prepare(`
+      INSERT INTO citations (
+        kind, source_celex, source_unit_type, source_unit,
+        target_celex, target_article, target_article_key, target_paragraph, target_point, raw
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
 
     let expectedExcerptCount = 0;
+    let skippedCitationEdges = 0;
     database.exec("BEGIN IMMEDIATE");
     try {
       insertMetadata.run("generated_at", String(searchPayload.generatedAt || ""));
@@ -164,6 +232,33 @@ function buildSqliteData({
         const celex = String(rawCelex || "").trim().toUpperCase();
         insertCaseLaw.run(celex, JSON.stringify(details), isPartialCaseLawEntry(details) ? 1 : 0);
       }
+
+      if (citationAsset) {
+        const header = citationAsset.payload;
+        insertMetadata.run("citation_graph_version", String(header.graphVersion ?? ""));
+        insertMetadata.run("citation_graph_parser_version", JSON.stringify(header.parserVersion ?? null));
+        insertMetadata.run("citation_graph_generated_at", String(header.generatedAt || ""));
+        insertMetadata.run("citation_graph_coverage", JSON.stringify(header.coverage ?? null));
+        insertMetadata.run("citation_graph_stats", JSON.stringify(header.stats ?? null));
+      }
+      const citationSourceTitles = new Map();
+      for (const edge of citationEdges) {
+        const sourceCelex = String(edge?.sourceCelex || "").trim().toUpperCase();
+        const targetCelex = String(edge?.targetCelex || "").trim().toUpperCase();
+        // An edge without both endpoints cannot be looked up from either side.
+        if (!sourceCelex || !targetCelex) { skippedCitationEdges += 1; continue; }
+        if (!citationSourceTitles.has(sourceCelex)) {
+          citationSourceTitles.set(sourceCelex, textOrNull(edge.sourceTitle));
+        }
+        insertCitation.run(
+          String(edge.kind || ""), sourceCelex,
+          textOrNull(edge.sourceUnitType), textOrNull(edge.sourceUnit),
+          targetCelex, textOrNull(edge.targetArticle), articleKey(edge.targetArticle),
+          textOrNull(edge.targetParagraph), textOrNull(edge.targetPoint), textOrNull(edge.raw),
+        );
+      }
+      for (const [celex, title] of citationSourceTitles) insertCitationSource.run(celex, title);
+      insertMetadata.run("citation_edge_count", String(citationEdges.length - skippedCitationEdges));
       database.exec("COMMIT");
     } catch (error) {
       database.exec("ROLLBACK");
@@ -208,6 +303,22 @@ function buildSqliteData({
       );
     }
 
+    const citationCount = database.prepare("SELECT COUNT(*) AS count FROM citations").get().count;
+    const citationSourceCount = database.prepare("SELECT COUNT(*) AS count FROM citation_sources").get().count;
+    const expectedCitationCount = citationEdges.length - skippedCitationEdges;
+    if (citationCount !== expectedCitationCount) {
+      throw new Error(`SQLite citation count mismatch: wrote ${citationCount}, expected ${expectedCitationCount}`);
+    }
+    const orphanCitationSources = database.prepare(`
+      SELECT COUNT(*) AS count
+      FROM citations
+      LEFT JOIN citation_sources ON citation_sources.celex = citations.source_celex
+      WHERE citation_sources.celex IS NULL
+    `).get().count;
+    if (orphanCitationSources !== 0) {
+      throw new Error(`SQLite citation source integrity failed: ${orphanCitationSources} edges without a source row`);
+    }
+
     database.close();
     const outputBytes = fs.statSync(tempPath).size;
     const outputSha256 = sha256File(tempPath);
@@ -229,6 +340,17 @@ function buildSqliteData({
           sha256: caseLawAsset.sha256,
           records: caseLawEntries.length,
         },
+        // null when this build had no citation graph input, so a deploy serving an
+        // empty graph is attributable from the manifest alone.
+        citationGraph: citationAsset ? {
+          file: path.basename(citationAsset.path),
+          bytes: citationAsset.bytes,
+          sha256: citationAsset.sha256,
+          edges: expectedCitationCount,
+          skippedEdges: skippedCitationEdges,
+          graphVersion: citationAsset.payload?.graphVersion ?? null,
+          generatedAt: citationAsset.payload?.generatedAt || null,
+        } : null,
       },
       artifact: {
         file: path.basename(outputPath),
@@ -240,6 +362,8 @@ function buildSqliteData({
         excerpts: excerptCount,
         excerptMappings: excerptMapCount,
         caseLaw: caseLawCount,
+        citations: citationCount,
+        citationSources: citationSourceCount,
       },
       integrity: {
         sqlite: integrity,
@@ -274,6 +398,7 @@ function parseArgs(argv) {
     const value = argv[index + 1];
     if (token === "--search" && value) options.searchCachePath = path.resolve(value);
     else if (token === "--case-law" && value) options.caseLawCachePath = path.resolve(value);
+    else if (token === "--citation-graph" && value) options.citationGraphPath = path.resolve(value);
     else if (token === "--output" && value) options.outputPath = path.resolve(value);
     else if (token === "--manifest" && value) options.manifestPath = path.resolve(value);
     else continue;
@@ -297,6 +422,9 @@ if (require.main === module) {
 
 module.exports = {
   DEFAULT_CASE_LAW_CACHE_PATH,
+  DEFAULT_CITATION_GRAPH_PATH,
+  SQLITE_SCHEMA_VERSION,
+  articleKey,
   buildSqliteData,
   isPartialCaseLawEntry,
   readJson,

--- a/backend/search/build-sqlite-data.test.js
+++ b/backend/search/build-sqlite-data.test.js
@@ -5,7 +5,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
-const { buildSqliteData } = require("./build-sqlite-data");
+const { buildSqliteData, SQLITE_SCHEMA_VERSION } = require("./build-sqlite-data");
 
 function sha256(filePath) {
   return crypto.createHash("sha256").update(fs.readFileSync(filePath)).digest("hex");
@@ -41,18 +41,27 @@ test("buildSqliteData emits a verified manifest with source and table counts", (
     ignored: null,
   }), "utf8");
 
-  const result = buildSqliteData({ searchCachePath: searchPath, caseLawCachePath: caseLawPath, outputPath, manifestPath });
+  // citationGraphPath is pinned to a non-existent path: left unset it would default
+  // to the real (multi-hundred-MB) data/citation-graph.json in a dev checkout.
+  const result = buildSqliteData({
+    searchCachePath: searchPath, caseLawCachePath: caseLawPath,
+    citationGraphPath: path.join(tempDir, "absent-citation-graph.json"),
+    outputPath, manifestPath, log: () => {},
+  });
   const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
   assert.equal(result.laws, 2);
   assert.equal(result.excerpts, 1);
   assert.equal(result.caseLaw, 1);
-  assert.equal(manifest.schemaVersion, 1);
+  assert.equal(manifest.schemaVersion, SQLITE_SCHEMA_VERSION);
   assert.deepEqual(manifest.tables, {
     laws: 2,
     excerpts: 1,
     excerptMappings: 1,
     caseLaw: 1,
+    citations: 0,
+    citationSources: 0,
   });
+  assert.equal(manifest.source.citationGraph, null);
   assert.deepEqual(manifest.integrity, {
     sqlite: "ok",
     orphanLawMappings: 0,
@@ -61,4 +70,37 @@ test("buildSqliteData emits a verified manifest with source and table counts", (
   assert.equal(manifest.source.search.sha256, sha256(searchPath));
   assert.equal(manifest.source.caseLaw.sha256, sha256(caseLawPath));
   assert.equal(manifest.artifact.sha256, sha256(outputPath));
+});
+
+test("buildSqliteData folds the citation graph into indexed tables and dedups source titles", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "sqlite-data-citations-"));
+  const searchPath = path.join(tempDir, "search.json");
+  const caseLawPath = path.join(tempDir, "case-law.json");
+  const graphPath = path.join(tempDir, "citation-graph.json");
+  const outputPath = path.join(tempDir, "data.sqlite");
+  const manifestPath = path.join(tempDir, "manifest.json");
+  fs.writeFileSync(searchPath, JSON.stringify({ generatedAt: "2026-07-15T00:00:00.000Z", records: [] }), "utf8");
+  fs.writeFileSync(caseLawPath, JSON.stringify({}), "utf8");
+  fs.writeFileSync(graphPath, JSON.stringify({
+    graphVersion: 2, parserVersion: 15, generatedAt: "2026-07-15T19:22:07.710Z",
+    coverage: { legislation: { htmlLaws: 2 } }, stats: { edges: 3 },
+    edges: [
+      // two edges from one source: the title must be stored once
+      { kind: "legislation", sourceCelex: "32020R0001", sourceTitle: "Widgets", sourceUnitType: "article", sourceUnit: "5", targetCelex: "32016R0679", targetArticle: "6", targetParagraph: "1", targetPoint: null, raw: "Article 6(1)" },
+      { kind: "legislation", sourceCelex: "32020R0001", sourceTitle: "Widgets", sourceUnitType: "article", sourceUnit: "6", targetCelex: "32016R0679", targetArticle: null, targetParagraph: null, targetPoint: null, raw: "the GDPR" },
+      { kind: "judgment", sourceCelex: "62020CJ0001", sourceTitle: "Some Case", sourceUnitType: "judgment", sourceUnit: "62020CJ0001", targetCelex: "32016R0679", targetArticle: "6", targetParagraph: null, targetPoint: null, raw: "Article 6" },
+      { kind: "legislation", sourceCelex: "", sourceTitle: "No source", sourceUnitType: "article", sourceUnit: "1", targetCelex: "32016R0679", targetArticle: "6", targetParagraph: null, targetPoint: null, raw: "dropped" },
+    ],
+  }), "utf8");
+
+  buildSqliteData({
+    searchCachePath: searchPath, caseLawCachePath: caseLawPath, citationGraphPath: graphPath,
+    outputPath, manifestPath, log: () => {},
+  });
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+  assert.equal(manifest.tables.citations, 3);        // the endpoint-less edge is dropped
+  assert.equal(manifest.tables.citationSources, 2);  // Widgets stored once, not per edge
+  assert.equal(manifest.source.citationGraph.edges, 3);
+  assert.equal(manifest.source.citationGraph.skippedEdges, 1);
+  assert.equal(manifest.source.citationGraph.graphVersion, 2);
 });

--- a/backend/search/citation-graph-build.js
+++ b/backend/search/citation-graph-build.js
@@ -12,6 +12,10 @@ const { GRAPH_VERSION } = require("./citation-graph-store");
 // applied. At 1 MiB, annex stripping recovers most large acts while keeping
 // both full-DOM and operative-only parses within the empirically safe bound.
 const DEFAULT_MAX_XML_BYTES = 1 * 1024 * 1024;
+// EUR-Lex HTML renditions carry no annexes to strip, so an oversized one has no
+// operative-only fallback — it is simply skipped. The bound is looser than the FMX
+// one because the HTML parser builds a single DOM rather than a full Formex tree.
+const DEFAULT_MAX_HTML_BYTES = 4 * 1024 * 1024;
 const DEFAULT_PROGRESS_INTERVAL = 500;
 const DEFAULT_BATCH_SIZE = 100;
 const DEFAULT_WORKER_HEAP_MB = 768;
@@ -39,6 +43,35 @@ function compareEdges(a, b) {
 
 async function listCorpusFiles(corpusDir, fsApi = fs) {
   return listTreeFiles(corpusDir, ".xml.gz", fsApi);
+}
+
+// The HTML corpus lives beside the FMX one (data/laws -> data/laws-html) and holds
+// the acts EUR-Lex never published as Formex (overwhelmingly pre-2000).
+function htmlCorpusDirFor(corpusDir) {
+  return path.basename(corpusDir) === "laws"
+    ? path.join(path.dirname(corpusDir), "laws-html")
+    : null;
+}
+
+async function listHtmlCorpusFiles(htmlDir, fsApi = fs) {
+  return htmlDir ? listTreeFiles(htmlDir, ".html.gz", fsApi) : [];
+}
+
+// Both corpora are keyed by CELEX, so one combined, year-filterable list drives the
+// build; the per-file handler dispatches on the extension.
+async function listAllCorpusFiles(corpusDir, options = {}, fsApi = fs) {
+  const fmxFiles = await listCorpusFiles(corpusDir, fsApi);
+  if (options.includeHtml === false) return fmxFiles;
+  const htmlDir = options.htmlDir || htmlCorpusDirFor(corpusDir);
+  return [...fmxFiles, ...await listHtmlCorpusFiles(htmlDir, fsApi)];
+}
+
+function isHtmlCorpusFile(file) {
+  return /\.html\.gz$/i.test(String(file));
+}
+
+function celexForCorpusFile(file) {
+  return normalizeCelex(path.basename(file).replace(/\.(?:xml|html)\.gz$/i, ""));
 }
 
 async function listTreeFiles(rootDir, suffix, fsApi = fs) {
@@ -166,24 +199,32 @@ async function writeArtifactAtomic(outputPath, artifact, fsApi = fs) {
 
 function parseCliArgs(argv) {
   const options = {};
+  const valueFlags = ["--corpusDir", "--htmlDir", "--out", "--limit", "--fromYear", "--toYear",
+    "--maxXmlBytes", "--maxHtmlBytes", "--batchSize"];
   for (let index = 0; index < argv.length; index += 1) {
     const flag = argv[index];
-    if (!["--corpusDir", "--out", "--limit", "--fromYear", "--toYear", "--maxXmlBytes", "--batchSize"].includes(flag)) {
+    // --noHtml is the one boolean: it restores the FMX-only graph (and reports the
+    // HTML tree as skipped) for a faster build that ignores the pre-2000 corpus.
+    if (flag === "--noHtml") { options.includeHtml = false; continue; }
+    if (!valueFlags.includes(flag)) {
       throw new Error(`Unknown argument: ${flag}`);
     }
     const value = argv[index += 1];
     if (value == null) throw new Error(`Missing value for ${flag}`);
     if (flag === "--corpusDir") options.corpusDir = value;
+    else if (flag === "--htmlDir") options.htmlDir = value;
     else if (flag === "--out") options.outputPath = value;
     else {
       const number = Number.parseInt(value, 10);
-      if (!Number.isInteger(number) || number < 0 || (["--limit", "--maxXmlBytes", "--batchSize"].includes(flag) && number === 0)) {
+      if (!Number.isInteger(number) || number < 0
+        || (["--limit", "--maxXmlBytes", "--maxHtmlBytes", "--batchSize"].includes(flag) && number === 0)) {
         throw new Error(`Invalid value for ${flag}: ${value}`);
       }
       if (flag === "--limit") options.limit = number;
       if (flag === "--fromYear") options.fromYear = number;
       if (flag === "--toYear") options.toYear = number;
       if (flag === "--maxXmlBytes") options.maxXmlBytes = number;
+      if (flag === "--maxHtmlBytes") options.maxHtmlBytes = number;
       if (flag === "--batchSize") options.batchSize = number;
     }
   }
@@ -193,8 +234,14 @@ function parseCliArgs(argv) {
 async function buildCitationGraph(options = {}) {
   const fsApi = options.fsApi || fs;
   const corpusDir = options.corpusDir || DEFAULT_CORPUS_DIR;
-  const files = filterCorpusFiles(options.files || await listCorpusFiles(corpusDir, fsApi), options);
-  const htmlTreeSkipped = await countHtmlTreeSkipped(corpusDir, options);
+  const files = filterCorpusFiles(
+    options.files || await listAllCorpusFiles(corpusDir, options, fsApi), options);
+  // The HTML tree is only "skipped" when HTML parsing is disabled; otherwise its laws
+  // are in `files` above and counted like any other. An explicit htmlTreeSkipped stays
+  // authoritative either way — shard workers pass 0 and let the merge set the total.
+  const htmlTreeSkipped = options.includeHtml === false
+    ? await countHtmlTreeSkipped(corpusDir, options)
+    : (options.htmlTreeSkipped ?? 0);
   const legalCache = options.legalCache || (() => {
     const { JsonLegalCacheStore } = require("./legal-cache-store");
     return new JsonLegalCacheStore(options.searchCachePath);
@@ -206,19 +253,61 @@ async function buildCitationGraph(options = {}) {
   const parseXml = options.parseXml || require("../shared/fmx-parser-node").parseFmxXml;
   const wrapXml = options.wrapXml || require("./search-build").wrapForParsing;
   const readXml = options.readXml || ((file) => readGzippedXml(file, fsApi));
+  // Lazily required: pulling in the HTML parser (and jsdom) costs real startup time,
+  // so builds that never touch the HTML corpus shouldn't pay for it.
+  const parseHtml = options.parseHtml
+    || ((html) => require("../shared/eurlex-html-parser").parseEurlexHtmlToCombined(html, "ENG"));
+  const readHtml = options.readHtml || ((file) => readGzippedXml(file, fsApi));
   const maxXmlBytes = options.maxXmlBytes ?? DEFAULT_MAX_XML_BYTES;
+  const maxHtmlBytes = options.maxHtmlBytes ?? DEFAULT_MAX_HTML_BYTES;
   const progressInterval = options.progressInterval || DEFAULT_PROGRESS_INTERVAL;
   const progressLog = options.progress ? (options.log || console.log) : null;
   const counters = {
     corpusFiles: files.length, parsedLaws: 0, parseFailures: 0,
     oversizedLawsSkipped: 0, oversizedLawsOperativeOnly: 0, annexElementsOmitted: 0,
+    htmlLaws: 0, oversizedHtmlSkipped: 0,
     externalReferences: 0, unresolvedReferences: 0,
   };
   const failures = [], edges = [], parserVersions = new Set();
+
+  // The HTML renditions carry no <REF.DOC.OJ> markup, so their cross-references come
+  // from the parser's prose grammar instead; the resulting `parsed` shape is the same,
+  // which is why both corpora share legislationEdgesForLaw below.
+  async function collectHtmlLaw(file, sourceCelex) {
+    const html = await readHtml(file);
+    const htmlBytes = Buffer.byteLength(String(html), "utf8");
+    if (htmlBytes > maxHtmlBytes) {
+      counters.oversizedHtmlSkipped += 1;
+      failures.push({
+        celex: sourceCelex, type: "oversized-html", htmlBytes, maxHtmlBytes,
+        error: `Decompressed HTML exceeds ${maxHtmlBytes} bytes`,
+      });
+      return;
+    }
+    const parsed = await parseHtml(html);
+    if (!parsed) {
+      counters.parseFailures += 1;
+      failures.push({ celex: sourceCelex, type: "html", error: "HTML parser returned no document" });
+      return;
+    }
+    counters.parsedLaws += 1;
+    counters.htmlLaws += 1;
+    if (parsed?.parserVersion != null) parserVersions.add(parsed.parserVersion);
+    edges.push(...legislationEdgesForLaw(sourceCelex, parsed, legalCache, counters));
+  }
+
   for (let index = 0; index < files.length; index += 1) {
     const file = files[index];
-    const sourceCelex = normalizeCelex(path.basename(file).replace(/\.xml\.gz$/i, ""));
+    const sourceCelex = celexForCorpusFile(file);
     try {
+      if (isHtmlCorpusFile(file)) {
+        await collectHtmlLaw(file, sourceCelex);
+        const done = index + 1;
+        if (progressLog && (done % progressInterval === 0 || done === files.length)) {
+          progressLog(`[citation-graph] ${done}/${files.length} laws; current=${sourceCelex}; parsed=${counters.parsedLaws}; failed=${counters.parseFailures}; html=${counters.htmlLaws}; oversized-html-skipped=${counters.oversizedHtmlSkipped}`);
+        }
+        continue;
+      }
       const xml = await readXml(file);
       const xmlBytes = Buffer.byteLength(String(xml), "utf8");
       if (xmlBytes > maxXmlBytes) {
@@ -272,7 +361,8 @@ async function buildCitationGraph(options = {}) {
   const caseData = options.caseLawData !== undefined ? options.caseLawData
     : await readCaseLawCache(options.caseLawCachePath, fsApi);
   const artifact = assembleArtifact({
-    counters, failures, edges, parserVersions, htmlTreeSkipped, maxXmlBytes, caseData, now: options.now,
+    counters, failures, edges, parserVersions, htmlTreeSkipped, maxXmlBytes, maxHtmlBytes,
+    caseData, now: options.now,
   });
   const outputPath = options.outputPath === undefined ? DEFAULT_CITATION_GRAPH_PATH : options.outputPath;
   if (outputPath) await writeArtifactAtomic(outputPath, artifact, fsApi);
@@ -303,7 +393,7 @@ async function countHtmlTreeSkipped(corpusDir, options = {}) {
 // single-process builder and the batched shard merge so their output stays
 // byte-identical (JSON.stringify key order is asserted by the tests). Case-law
 // edges are folded in here (before dedup) so both callers get them once.
-function assembleArtifact({ counters, failures, edges, parserVersions, htmlTreeSkipped, maxXmlBytes, caseData, now }) {
+function assembleArtifact({ counters, failures, edges, parserVersions, htmlTreeSkipped, maxXmlBytes, maxHtmlBytes, caseData, now }) {
   const allEdges = [...edges, ...caseLawEdges(caseData)];
   const deduped = [...new Map(allEdges.map((edge) => [edgeKey(edge), edge])).values()].sort(compareEdges);
   const versions = [...parserVersions].sort();
@@ -318,6 +408,9 @@ function assembleArtifact({ counters, failures, edges, parserVersions, htmlTreeS
         oversizedLawsOperativeOnly: counters.oversizedLawsOperativeOnly,
         annexElementsOmitted: counters.annexElementsOmitted,
         annexCoverage: counters.oversizedLawsOperativeOnly > 0 ? "partial-operative-only" : "full-for-parsed-fmx",
+        htmlLaws: counters.htmlLaws || 0,
+        oversizedHtmlSkipped: counters.oversizedHtmlSkipped || 0,
+        maxHtmlBytes: maxHtmlBytes ?? DEFAULT_MAX_HTML_BYTES,
       },
       caseLaw: { status: caseData ? "partial-cache" : "not-included", judgments: caseData ? Object.keys(caseData).length : 0 },
     },
@@ -364,7 +457,8 @@ function runCitationGraphWorker(files, options = {}) {
 function mergeCitationGraphShards(shards, options = {}) {
   const counterNames = [
     "corpusFiles", "parsedLaws", "parseFailures", "oversizedLawsSkipped",
-    "oversizedLawsOperativeOnly", "annexElementsOmitted", "externalReferences", "unresolvedReferences",
+    "oversizedLawsOperativeOnly", "annexElementsOmitted", "htmlLaws", "oversizedHtmlSkipped",
+    "externalReferences", "unresolvedReferences",
   ];
   const counters = Object.fromEntries(counterNames.map((name) => [name, 0]));
   const failures = [];
@@ -381,6 +475,7 @@ function mergeCitationGraphShards(shards, options = {}) {
     counters, failures, edges, parserVersions,
     htmlTreeSkipped: options.htmlTreeSkipped || 0,
     maxXmlBytes: options.maxXmlBytes ?? DEFAULT_MAX_XML_BYTES,
+    maxHtmlBytes: options.maxHtmlBytes ?? DEFAULT_MAX_HTML_BYTES,
     caseData: options.caseLawData, now: options.now,
   });
 }
@@ -388,10 +483,13 @@ function mergeCitationGraphShards(shards, options = {}) {
 async function buildCitationGraphBatched(options = {}) {
   const fsApi = options.fsApi || fs;
   const corpusDir = options.corpusDir || DEFAULT_CORPUS_DIR;
-  const allFiles = options.files || await listCorpusFiles(corpusDir, fsApi);
+  const allFiles = options.files || await listAllCorpusFiles(corpusDir, options, fsApi);
   const files = filterCorpusFiles(allFiles, options);
-  const htmlTreeSkipped = await countHtmlTreeSkipped(corpusDir, options);
+  const htmlTreeSkipped = options.includeHtml === false
+    ? await countHtmlTreeSkipped(corpusDir, options)
+    : (options.htmlTreeSkipped ?? 0);
   const maxXmlBytes = options.maxXmlBytes ?? DEFAULT_MAX_XML_BYTES;
+  const maxHtmlBytes = options.maxHtmlBytes ?? DEFAULT_MAX_HTML_BYTES;
   const batchSize = options.batchSize || DEFAULT_BATCH_SIZE;
   const workerRunner = options.workerRunner || runCitationGraphWorker;
   const shards = [];
@@ -401,11 +499,12 @@ async function buildCitationGraphBatched(options = {}) {
   async function processBatch(batch) {
     try {
       const shard = await workerRunner(batch, {
-        maxXmlBytes, searchCachePath: options.searchCachePath, workerHeapMb: options.workerHeapMb,
+        maxXmlBytes, maxHtmlBytes, searchCachePath: options.searchCachePath,
+        workerHeapMb: options.workerHeapMb,
       });
       shards.push(shard);
       processed += batch.length;
-      if (progressLog) progressLog(`[citation-graph] ${processed}/${files.length} laws completed in isolated workers; last=${path.basename(batch[batch.length - 1]).replace(/\.xml\.gz$/i, "")}`);
+      if (progressLog) progressLog(`[citation-graph] ${processed}/${files.length} laws completed in isolated workers; last=${celexForCorpusFile(batch[batch.length - 1])}`);
     } catch (error) {
       if (batch.length > 1) {
         const middle = Math.floor(batch.length / 2);
@@ -413,7 +512,7 @@ async function buildCitationGraphBatched(options = {}) {
         await processBatch(batch.slice(middle));
         return;
       }
-      const celex = normalizeCelex(path.basename(batch[0]).replace(/\.xml\.gz$/i, ""));
+      const celex = celexForCorpusFile(batch[0]);
       shards.push({
         parserVersion: null,
         stats: { corpusFiles: 1, parseFailures: 1 },
@@ -431,7 +530,7 @@ async function buildCitationGraphBatched(options = {}) {
   const caseData = options.caseLawData !== undefined ? options.caseLawData
     : await readCaseLawCache(options.caseLawCachePath, fsApi);
   const artifact = mergeCitationGraphShards(shards, {
-    caseLawData: caseData, htmlTreeSkipped, maxXmlBytes, now: options.now,
+    caseLawData: caseData, htmlTreeSkipped, maxXmlBytes, maxHtmlBytes, now: options.now,
   });
   const outputPath = options.outputPath === undefined ? DEFAULT_CITATION_GRAPH_PATH : options.outputPath;
   if (outputPath) await writeArtifactAtomic(outputPath, artifact, fsApi);
@@ -473,6 +572,7 @@ function formatSummaryReport(artifact) {
   const lines = [
     `Citation graph: ${artifact.stats.edges} edges (${artifact.stats.legislationEdges} legislation, ${artifact.stats.judgmentEdges} judgments)`,
     `Corpus: ${artifact.stats.parsedLaws}/${artifact.stats.corpusFiles} laws parsed; ${artifact.stats.parseFailures} failed; ${artifact.stats.oversizedLawsSkipped} oversized skipped; ${artifact.stats.oversizedLawsOperativeOnly} operative-only (${artifact.stats.annexElementsOmitted} annexes omitted); ${artifact.coverage.legislation.htmlTreeSkipped} HTML laws skipped`,
+    `HTML corpus: ${artifact.coverage.legislation.htmlLaws} laws parsed from prose; ${artifact.coverage.legislation.oversizedHtmlSkipped} oversized skipped`,
     `References: ${artifact.stats.resolvedReferences} resolved; ${artifact.stats.unresolvedReferences} unresolved`,
     "Top cited articles:",
     ...summary.topArticles.map((entry, index) => `  ${index + 1}. ${entry.target} — ${entry.count}`),
@@ -500,8 +600,10 @@ if (require.main === module) {
 }
 
 module.exports = { DEFAULT_BATCH_SIZE, DEFAULT_CITATION_GRAPH_PATH, DEFAULT_CORPUS_DIR, DEFAULT_MAX_XML_BYTES,
-  GRAPH_VERSION, buildCitationGraph, buildCitationGraphBatched, countHtmlTreeSkipped, filterCorpusFiles,
-  caseLawEdges, edgeKey, formatSummaryReport, legislationEdgesForLaw, listCorpusFiles, listTreeFiles,
+  DEFAULT_MAX_HTML_BYTES, GRAPH_VERSION, buildCitationGraph, buildCitationGraphBatched, celexForCorpusFile,
+  countHtmlTreeSkipped, filterCorpusFiles, htmlCorpusDirFor, isHtmlCorpusFile,
+  caseLawEdges, edgeKey, formatSummaryReport, legislationEdgesForLaw, listAllCorpusFiles, listCorpusFiles,
+  listHtmlCorpusFiles, listTreeFiles,
   mergeCitationGraphShards, parseCliArgs, rankedTargets, resolveExternalReference, runCitationGraphWorker,
   sourceUnitTypeFor, stripCompleteUppercaseAnnexes,
   summarizeArtifact, writeArtifactAtomic };

--- a/backend/search/citation-graph-build.js
+++ b/backend/search/citation-graph-build.js
@@ -240,7 +240,7 @@ async function writeArtifactAtomic(outputPath, artifact, fsApi = fs) {
 function parseCliArgs(argv) {
   const options = {};
   const valueFlags = ["--corpusDir", "--htmlDir", "--out", "--limit", "--fromYear", "--toYear",
-    "--maxXmlBytes", "--maxHtmlBytes", "--batchSize"];
+    "--maxXmlBytes", "--maxHtmlBytes", "--batchSize", "--workerHeapMb"];
   for (let index = 0; index < argv.length; index += 1) {
     const flag = argv[index];
     // --noHtml is the one boolean: it restores the FMX-only graph (and reports the
@@ -257,7 +257,7 @@ function parseCliArgs(argv) {
     else {
       const number = Number.parseInt(value, 10);
       if (!Number.isInteger(number) || number < 0
-        || (["--limit", "--maxXmlBytes", "--maxHtmlBytes", "--batchSize"].includes(flag) && number === 0)) {
+        || (["--limit", "--maxXmlBytes", "--maxHtmlBytes", "--batchSize", "--workerHeapMb"].includes(flag) && number === 0)) {
         throw new Error(`Invalid value for ${flag}: ${value}`);
       }
       if (flag === "--limit") options.limit = number;
@@ -266,6 +266,11 @@ function parseCliArgs(argv) {
       if (flag === "--maxXmlBytes") options.maxXmlBytes = number;
       if (flag === "--maxHtmlBytes") options.maxHtmlBytes = number;
       if (flag === "--batchSize") options.batchSize = number;
+      // The 768 MB default is not enough for the heaviest acts (some 2010s
+      // regulations need ~4 GB to parse). Too low and they OOM their worker, get
+      // split down to a single law, and land as worker_failure contributing no
+      // edges — a silently incomplete graph. Raise it for a full-corpus build.
+      if (flag === "--workerHeapMb") options.workerHeapMb = number;
     }
   }
   return options;

--- a/backend/search/citation-graph-build.js
+++ b/backend/search/citation-graph-build.js
@@ -93,6 +93,46 @@ async function readGzippedXml(filePath, fsApi = fs) {
   return (await gunzip(await fsApi.readFile(filePath))).toString("utf8");
 }
 
+// A legalCache-shaped resolver over the plain index from
+// JsonLegalCacheStore.exportReferenceIndex(). Same lookups, none of the search
+// machinery — cheap enough to hand to every worker.
+function createReferenceResolver(index) {
+  const { normalizeCelexLookupKey, normalizeOfficialReferenceLookupKey } = require("./legal-cache-store");
+  const officialRef = index?.officialRef || {};
+  const celexTitle = index?.celexTitle || {};
+  return {
+    isReady: () => Object.keys(officialRef).length > 0,
+    getStatus: () => ({ ready: Object.keys(officialRef).length > 0 }),
+    getByOfficialReference(reference) {
+      const key = normalizeOfficialReferenceLookupKey(reference);
+      const celex = key ? officialRef[key] : null;
+      return celex ? { celex } : null;
+    },
+    getByCelex(celex) {
+      const key = normalizeCelexLookupKey(celex);
+      if (!key || !(key in celexTitle)) return null;
+      return { celex: key, title: celexTitle[key] };
+    },
+  };
+}
+
+// Load the search cache once and reduce it to a resolver index. Without this each
+// worker would re-read the (hundreds of MB) cache and rebuild a MiniSearch index it
+// never queries — at the default batch size that is ~800 reloads for a full corpus.
+function loadReferenceIndex(options = {}) {
+  if (options.resolverIndex) return options.resolverIndex;
+  if (options.legalCache?.exportReferenceIndex) return options.legalCache.exportReferenceIndex();
+  const { JsonLegalCacheStore } = require("./legal-cache-store");
+  const cache = new JsonLegalCacheStore(options.searchCachePath);
+  cache.load();
+  if (!cache.isReady()) {
+    throw new Error(`Legal search cache is unavailable: ${cache.getStatus?.().error || "not loaded"}`);
+  }
+  const index = cache.exportReferenceIndex();
+  cache.close?.();
+  return index;
+}
+
 function resolveExternalReference(ref, legalCache) {
   if (!ref || ref.type !== "external") return null;
   if (ref.targetCelex || ref.actCelex) return normalizeCelex(ref.targetCelex || ref.actCelex);
@@ -431,7 +471,9 @@ function runCitationGraphWorker(files, options = {}) {
       workerData: {
         files,
         maxXmlBytes: options.maxXmlBytes,
+        maxHtmlBytes: options.maxHtmlBytes,
         searchCachePath: options.searchCachePath,
+        resolverIndex: options.resolverIndex,
       },
       resourceLimits: { maxOldGenerationSizeMb: options.workerHeapMb || DEFAULT_WORKER_HEAP_MB },
     });
@@ -492,6 +534,8 @@ async function buildCitationGraphBatched(options = {}) {
   const maxHtmlBytes = options.maxHtmlBytes ?? DEFAULT_MAX_HTML_BYTES;
   const batchSize = options.batchSize || DEFAULT_BATCH_SIZE;
   const workerRunner = options.workerRunner || runCitationGraphWorker;
+  // Resolve the search cache once here, not once per worker.
+  const resolverIndex = loadReferenceIndex(options);
   const shards = [];
   let processed = 0;
   const progressLog = options.progress ? (options.log || console.log) : null;
@@ -500,7 +544,7 @@ async function buildCitationGraphBatched(options = {}) {
     try {
       const shard = await workerRunner(batch, {
         maxXmlBytes, maxHtmlBytes, searchCachePath: options.searchCachePath,
-        workerHeapMb: options.workerHeapMb,
+        resolverIndex, workerHeapMb: options.workerHeapMb,
       });
       shards.push(shard);
       processed += batch.length;
@@ -601,6 +645,7 @@ if (require.main === module) {
 
 module.exports = { DEFAULT_BATCH_SIZE, DEFAULT_CITATION_GRAPH_PATH, DEFAULT_CORPUS_DIR, DEFAULT_MAX_XML_BYTES,
   DEFAULT_MAX_HTML_BYTES, GRAPH_VERSION, buildCitationGraph, buildCitationGraphBatched, celexForCorpusFile,
+  createReferenceResolver, loadReferenceIndex,
   countHtmlTreeSkipped, filterCorpusFiles, htmlCorpusDirFor, isHtmlCorpusFile,
   caseLawEdges, edgeKey, formatSummaryReport, legislationEdgesForLaw, listAllCorpusFiles, listCorpusFiles,
   listHtmlCorpusFiles, listTreeFiles,

--- a/backend/search/citation-graph-build.test.js
+++ b/backend/search/citation-graph-build.test.js
@@ -5,16 +5,21 @@ const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 
-const { buildCitationGraph, buildCitationGraphBatched, DEFAULT_MAX_XML_BYTES, formatSummaryReport, listCorpusFiles, parseCliArgs, sourceUnitTypeFor, stripCompleteUppercaseAnnexes } = require("./citation-graph-build");
+const { buildCitationGraph, buildCitationGraphBatched, DEFAULT_MAX_XML_BYTES, GRAPH_VERSION, formatSummaryReport, listCorpusFiles, parseCliArgs, sourceUnitTypeFor, stripCompleteUppercaseAnnexes } = require("./citation-graph-build");
 
 test("CLI options and source unit types are normalized", () => {
   assert.equal(DEFAULT_MAX_XML_BYTES, 1024 * 1024);
   assert.deepEqual(parseCliArgs(["--corpusDir", "/corpus", "--out", "/graph.json", "--limit", "20", "--fromYear", "2010", "--toYear", "2020", "--maxXmlBytes", "1024", "--batchSize", "25"]), {
     corpusDir: "/corpus", outputPath: "/graph.json", limit: 20, fromYear: 2010, toYear: 2020, maxXmlBytes: 1024, batchSize: 25,
   });
+  assert.deepEqual(parseCliArgs(["--noHtml", "--htmlDir", "/html", "--maxHtmlBytes", "2048"]), {
+    includeHtml: false, htmlDir: "/html", maxHtmlBytes: 2048,
+  });
   assert.throws(() => parseCliArgs(["--limit", "0"]), /Invalid value/);
   assert.throws(() => parseCliArgs(["--maxXmlBytes", "0"]), /Invalid value/);
+  assert.throws(() => parseCliArgs(["--maxHtmlBytes", "0"]), /Invalid value/);
   assert.throws(() => parseCliArgs(["--batchSize", "0"]), /Invalid value/);
+  assert.throws(() => parseCliArgs(["--bogus", "1"]), /Unknown argument/);
   assert.equal(sourceUnitTypeFor("recital_12"), "recital");
   assert.equal(sourceUnitTypeFor("annex_1"), "annex");
   assert.equal(sourceUnitTypeFor("6"), "article");
@@ -38,7 +43,7 @@ test("listCorpusFiles walks shards deterministically and ignores non-FMX files",
   assert.deepEqual(files.map((file) => path.basename(file)), ["32019L0001.xml.gz", "32020R0002.xml.gz"]);
 });
 
-test("builder dynamically records the skipped sibling HTML corpus", async () => {
+async function writeBothCorpora() {
   const dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "citation-coverage-"));
   const laws = path.join(dataDir, "laws", "2020");
   const html = path.join(dataDir, "laws-html", "1999");
@@ -47,13 +52,56 @@ test("builder dynamically records the skipped sibling HTML corpus", async () => 
   await fsp.writeFile(path.join(laws, "32020R0001.xml.gz"), "unused");
   await fsp.writeFile(path.join(html, "31999L0001.html.gz"), "unused");
   await fsp.writeFile(path.join(html, "31999L0002.html.gz"), "unused");
+  return dataDir;
+}
+
+// The pre-2000 corpus only exists as HTML, and its citations live in prose rather
+// than <REF.DOC.OJ> markup — so walking it is the only way those acts contribute edges.
+test("builder walks the sibling HTML corpus and edges its prose references", async () => {
+  const dataDir = await writeBothCorpora();
   const artifact = await buildCitationGraph({
     corpusDir: path.join(dataDir, "laws"), outputPath: null,
     legalCache: { isReady: () => true, getByCelex: () => null },
     readXml: async () => "xml", wrapXml: (xml) => xml,
     parseXml: async () => ({ parserVersion: 4, crossReferences: {} }),
+    readHtml: async () => "<html/>",
+    parseHtml: async () => ({
+      parserVersion: 4,
+      crossReferences: { 1: [{ type: "external", targetCelex: "31968R1600", articleNumber: "3", raw: "Regulation (EEC) No 1600/68" }] },
+    }),
   });
+
+  assert.equal(artifact.coverage.legislation.corpusFiles, 3);   // 1 FMX + 2 HTML
+  assert.equal(artifact.coverage.legislation.htmlLaws, 2);
+  assert.equal(artifact.coverage.legislation.htmlTreeSkipped, 0); // walked, not skipped
+  assert.deepEqual(artifact.edges.map((edge) => edge.sourceCelex), ["31999L0001", "31999L0002"]);
+  assert.equal(artifact.edges[0].targetCelex, "31968R1600");
+});
+
+test("builder reports the HTML tree as skipped when --noHtml disables it", async () => {
+  const dataDir = await writeBothCorpora();
+  const artifact = await buildCitationGraph({
+    corpusDir: path.join(dataDir, "laws"), outputPath: null, includeHtml: false,
+    legalCache: { isReady: () => true, getByCelex: () => null },
+    readXml: async () => "xml", wrapXml: (xml) => xml,
+    parseXml: async () => ({ parserVersion: 4, crossReferences: {} }),
+    parseHtml: () => assert.fail("HTML must not be parsed when includeHtml is false"),
+  });
+  assert.equal(artifact.coverage.legislation.corpusFiles, 1);
+  assert.equal(artifact.coverage.legislation.htmlLaws, 0);
   assert.equal(artifact.coverage.legislation.htmlTreeSkipped, 2);
+});
+
+test("builder skips oversized HTML, which has no annex-stripping fallback", async () => {
+  const artifact = await buildCitationGraph({
+    files: ["/fake/31999L0001.html.gz"], outputPath: null, maxHtmlBytes: 8,
+    legalCache: { isReady: () => true, getByCelex: () => null },
+    readHtml: async () => "x".repeat(64),
+    parseHtml: () => assert.fail("oversized HTML must not reach the parser"),
+  });
+  assert.equal(artifact.coverage.legislation.oversizedHtmlSkipped, 1);
+  assert.equal(artifact.stats.parsedLaws, 0);
+  assert.equal(artifact.failures[0].type, "oversized-html");
 });
 
 test("builder skips oversized decompressed XML before parsing and reports progress only when enabled", async () => {
@@ -179,7 +227,7 @@ test("builder resolves, deduplicates, reports failures/unresolved refs, and mark
     now: () => new Date("2026-01-02T03:04:05.000Z"),
   });
 
-  assert.equal(artifact.graphVersion, 1);
+  assert.equal(artifact.graphVersion, GRAPH_VERSION);
   assert.equal(artifact.parserVersion, 4);
   assert.equal(artifact.coverage.caseLaw.status, "partial-cache");
   assert.equal(artifact.stats.parseFailures, 1);

--- a/backend/search/citation-graph-build.test.js
+++ b/backend/search/citation-graph-build.test.js
@@ -5,7 +5,7 @@ const os = require("node:os");
 const path = require("node:path");
 const test = require("node:test");
 
-const { buildCitationGraph, buildCitationGraphBatched, DEFAULT_MAX_XML_BYTES, GRAPH_VERSION, formatSummaryReport, listCorpusFiles, parseCliArgs, sourceUnitTypeFor, stripCompleteUppercaseAnnexes } = require("./citation-graph-build");
+const { buildCitationGraph, buildCitationGraphBatched, createReferenceResolver, DEFAULT_MAX_XML_BYTES, GRAPH_VERSION, formatSummaryReport, listCorpusFiles, parseCliArgs, sourceUnitTypeFor, stripCompleteUppercaseAnnexes } = require("./citation-graph-build");
 
 test("CLI options and source unit types are normalized", () => {
   assert.equal(DEFAULT_MAX_XML_BYTES, 1024 * 1024);
@@ -276,6 +276,9 @@ test("batched builder recursively isolates a failing law and merges case law onc
   };
   const artifact = await buildCitationGraphBatched({
     files, batchSize: 4, outputPath: null, workerRunner, htmlTreeSkipped: 9,
+    // Supplied so the parent does not go looking for a real search cache; the
+    // fake workerRunner above never resolves anything with it.
+    resolverIndex: { officialRef: {}, celexTitle: {} },
     caseLawData: { "62020CJ0001": { name: "Case", articleRefs: [{ actCelex: "32016R0679", article: "6" }] } },
     now: () => new Date("2026-01-01T00:00:00.000Z"),
   });
@@ -288,4 +291,45 @@ test("batched builder recursively isolates a failing law and merges case law onc
   assert.equal(artifact.coverage.legislation.htmlTreeSkipped, 9);
   assert.deepEqual(artifact.failures, [{ celex: "32020R0002", type: "worker_failure", error: "worker OOM" }]);
   assert.deepEqual(artifact.edges.map((edge) => edge.sourceCelex), ["62020CJ0001", "32020R0001", "32020R0003", "32020R0004"]);
+});
+
+// Regression guard for the build's dominant cost: each worker used to construct its
+// own JsonLegalCacheStore, re-reading the cache and rebuilding a MiniSearch index it
+// never queries — ~800 reloads over a full corpus. The parent must resolve once and
+// hand every batch the same index.
+test("batched builder resolves the search cache once and shares it with every worker", async () => {
+  let exports = 0;
+  const legalCache = {
+    isReady: () => true,
+    exportReferenceIndex: () => { exports += 1; return { officialRef: { "regulation|2016|679": "32016R0679" }, celexTitle: {} }; },
+  };
+  const seen = [];
+  const workerRunner = async (batch, options) => {
+    seen.push(options.resolverIndex);
+    return { parserVersion: 4, stats: { corpusFiles: batch.length, parsedLaws: batch.length }, failures: [], edges: [] };
+  };
+  await buildCitationGraphBatched({
+    files: ["/fake/32020R0001.xml.gz", "/fake/32020R0002.xml.gz", "/fake/32020R0003.xml.gz"],
+    batchSize: 1, outputPath: null, workerRunner, legalCache, caseLawData: null,
+  });
+  assert.equal(exports, 1, "search cache must be reduced to an index exactly once");
+  assert.equal(seen.length, 3);
+  assert.ok(seen.every((index) => index === seen[0]), "every worker gets the same index instance");
+  assert.equal(seen[0].officialRef["regulation|2016|679"], "32016R0679");
+});
+
+test("createReferenceResolver resolves exactly like the cache it was exported from", () => {
+  const resolver = createReferenceResolver({
+    officialRef: { "regulation|2016|679": "32016R0679" },
+    celexTitle: { "32020R0001": "Widgets", "32020R0002": null },
+  });
+  assert.equal(resolver.isReady(), true);
+  assert.deepEqual(resolver.getByOfficialReference({ actType: "regulation", year: "2016", number: "679" }), { celex: "32016R0679" });
+  // padded/odd-cased input must normalise the same way the store does
+  assert.deepEqual(resolver.getByOfficialReference({ actType: "Regulation", year: "2016", number: "0679" }), { celex: "32016R0679" });
+  assert.equal(resolver.getByOfficialReference({ actType: "directive", year: "2016", number: "679" }), null);
+  assert.equal(resolver.getByCelex("32020r0001").title, "Widgets");
+  assert.equal(resolver.getByCelex("32020R0002").title, null);
+  assert.equal(resolver.getByCelex("39999R9999"), null);
+  assert.equal(createReferenceResolver({ officialRef: {}, celexTitle: {} }).isReady(), false);
 });

--- a/backend/search/citation-graph-build.test.js
+++ b/backend/search/citation-graph-build.test.js
@@ -12,13 +12,14 @@ test("CLI options and source unit types are normalized", () => {
   assert.deepEqual(parseCliArgs(["--corpusDir", "/corpus", "--out", "/graph.json", "--limit", "20", "--fromYear", "2010", "--toYear", "2020", "--maxXmlBytes", "1024", "--batchSize", "25"]), {
     corpusDir: "/corpus", outputPath: "/graph.json", limit: 20, fromYear: 2010, toYear: 2020, maxXmlBytes: 1024, batchSize: 25,
   });
-  assert.deepEqual(parseCliArgs(["--noHtml", "--htmlDir", "/html", "--maxHtmlBytes", "2048"]), {
-    includeHtml: false, htmlDir: "/html", maxHtmlBytes: 2048,
+  assert.deepEqual(parseCliArgs(["--noHtml", "--htmlDir", "/html", "--maxHtmlBytes", "2048", "--workerHeapMb", "4096"]), {
+    includeHtml: false, htmlDir: "/html", maxHtmlBytes: 2048, workerHeapMb: 4096,
   });
   assert.throws(() => parseCliArgs(["--limit", "0"]), /Invalid value/);
   assert.throws(() => parseCliArgs(["--maxXmlBytes", "0"]), /Invalid value/);
   assert.throws(() => parseCliArgs(["--maxHtmlBytes", "0"]), /Invalid value/);
   assert.throws(() => parseCliArgs(["--batchSize", "0"]), /Invalid value/);
+  assert.throws(() => parseCliArgs(["--workerHeapMb", "0"]), /Invalid value/);
   assert.throws(() => parseCliArgs(["--bogus", "1"]), /Unknown argument/);
   assert.equal(sourceUnitTypeFor("recital_12"), "recital");
   assert.equal(sourceUnitTypeFor("annex_1"), "annex");

--- a/backend/search/citation-graph-store.js
+++ b/backend/search/citation-graph-store.js
@@ -4,6 +4,26 @@ const zlib = require("zlib");
 const GRAPH_VERSION = 2;
 
 const DEFAULT_CITATION_GRAPH_PATH = path.join(__dirname, "data", "citation-graph.json");
+const DEFAULT_SQLITE_DATA_PATH = path.join(__dirname, "data", "data.sqlite");
+// Keep in lock-step with SQLITE_SCHEMA_VERSION in build-sqlite-data.js / legal-cache-store.js.
+const SQLITE_SCHEMA_VERSION = 2;
+
+// Columns are aliased to the edge field names so rows drop straight into the same
+// distinctSources/publicCitation helpers the JSON path uses.
+const CITATION_SELECT = `
+  SELECT citations.kind AS kind,
+         citations.source_celex AS sourceCelex,
+         citation_sources.title AS sourceTitle,
+         citations.source_unit_type AS sourceUnitType,
+         citations.source_unit AS sourceUnit,
+         citations.target_celex AS targetCelex,
+         citations.target_article AS targetArticle,
+         citations.target_paragraph AS targetParagraph,
+         citations.target_point AS targetPoint,
+         citations.raw AS raw
+  FROM citations
+  LEFT JOIN citation_sources ON citation_sources.celex = citations.source_celex
+`;
 const normalize = (value) => String(value == null ? "" : value).trim().toUpperCase();
 const sourceKey = (edge) => [edge.kind, edge.sourceCelex, edge.sourceUnitType, edge.sourceUnit].join("|");
 
@@ -67,15 +87,93 @@ function countsFor(edges) {
 }
 
 class CitationGraphStore {
-  constructor(graphPath = DEFAULT_CITATION_GRAPH_PATH) {
+  // Mirrors JsonLegalCacheStore: prefer the SQLite store when one is configured and
+  // present, else fall back to the JSON artifact (local rebuilds, tests). The
+  // deployed image ships only data.sqlite, so it always takes the SQLite path.
+  constructor(graphPath = DEFAULT_CITATION_GRAPH_PATH, options = {}) {
     this.graphPath = graphPath;
+    const explicitSqlitePath = options.sqlitePath || null;
+    const environmentSqlitePath = options.preferJson ? null : (process.env.DATA_SQLITE_PATH || null);
+    const configuredSqlitePath = explicitSqlitePath || environmentSqlitePath;
+    const hasJsonOverride = Boolean(process.env.CITATION_GRAPH_PATH);
+    this.sqlitePath = configuredSqlitePath ||
+      (!options.preferJson && !hasJsonOverride && graphPath === DEFAULT_CITATION_GRAPH_PATH
+        ? DEFAULT_SQLITE_DATA_PATH
+        : null);
+    this.requireSqlite = options.requireSqlite ?? Boolean(configuredSqlitePath);
     this.payload = null;
     this.loadedAt = null;
     this.loadError = null;
     this.byTargetCelex = new Map();
+    this.database = null;
+    this.source = null;
   }
 
   load() {
+    this.close();
+    if (this.sqlitePath && fs.existsSync(this.sqlitePath)) return this.loadFromSqlite();
+    if (this.requireSqlite) {
+      this.loadError = `SQLite data store not found at ${this.sqlitePath}`;
+      return false;
+    }
+    return this.loadFromJson();
+  }
+
+  close() {
+    if (this.database) {
+      try { this.database.close(); } catch { /* already closed */ }
+      this.database = null;
+    }
+  }
+
+  loadFromSqlite() {
+    try {
+      const Database = require("better-sqlite3");
+      const database = new Database(this.sqlitePath, { readonly: true, fileMustExist: true });
+      const schemaVersion = database.prepare("PRAGMA user_version").get().user_version;
+      if (schemaVersion !== SQLITE_SCHEMA_VERSION) {
+        database.close();
+        throw new Error(`Unsupported SQLite data schema ${schemaVersion}; expected ${SQLITE_SCHEMA_VERSION}`);
+      }
+      const metadata = new Map(
+        database.prepare("SELECT key, value FROM metadata").all().map((row) => [row.key, row.value])
+      );
+      const graphVersion = Number.parseInt(metadata.get("citation_graph_version"), 10);
+      if (!metadata.has("citation_graph_version")) {
+        database.close();
+        throw new Error("SQLite data store contains no citation graph");
+      }
+      if (graphVersion !== GRAPH_VERSION) {
+        database.close();
+        throw new Error(`Unsupported citation graph version ${graphVersion}; expected ${GRAPH_VERSION}`);
+      }
+      const parseMeta = (key) => { try { return JSON.parse(metadata.get(key)); } catch { return null; } };
+      this.payload = {
+        graphVersion,
+        parserVersion: parseMeta("citation_graph_parser_version"),
+        generatedAt: metadata.get("citation_graph_generated_at") || null,
+        coverage: parseMeta("citation_graph_coverage"),
+        stats: parseMeta("citation_graph_stats"),
+      };
+      this.database = database;
+      this.byActStatement = database.prepare(`${CITATION_SELECT} WHERE citations.target_celex = ?`);
+      this.byArticleStatement = database.prepare(
+        `${CITATION_SELECT} WHERE citations.target_celex = ? AND citations.target_article_key = ?`
+      );
+      this.source = "sqlite";
+      this.loadedAt = new Date().toISOString();
+      this.loadError = null;
+      return true;
+    } catch (error) {
+      this.payload = null;
+      this.database = null;
+      this.loadedAt = null;
+      this.loadError = error.message;
+      return false;
+    }
+  }
+
+  loadFromJson() {
     try {
       // The graph is too large to commit, so a fresh deploy fetches
       // citation-graph.json.gz as a GitHub Release asset at build time (see
@@ -103,6 +201,7 @@ class CitationGraphStore {
         entries.push(edge);
         this.byTargetCelex.set(target, entries);
       }
+      this.source = "json";
       this.loadedAt = new Date().toISOString();
       this.loadError = null;
       return true;
@@ -119,11 +218,24 @@ class CitationGraphStore {
   isReady() { return Boolean(this.payload); }
   getStatus() {
     return {
-      ready: this.isReady(), graphPath: this.graphPath,
+      ready: this.isReady(), graphPath: this.graphPath, source: this.source,
       graphVersion: this.payload?.graphVersion || null, parserVersion: this.payload?.parserVersion ?? null,
       generatedAt: this.payload?.generatedAt || null, coverage: this.payload?.coverage || null,
       edges: this.payload?.stats?.edges ?? 0, loadedAt: this.loadedAt, error: this.loadError,
     };
+  }
+
+  // The only storage-dependent step: fetch the edges citing this act (optionally a
+  // single article). Everything downstream is shared with the JSON path.
+  edgesForAct(targetCelex) {
+    if (this.database) return this.byActStatement.all(targetCelex);
+    return this.byTargetCelex.get(targetCelex) || [];
+  }
+
+  edgesForArticle(targetCelex, articleKey) {
+    if (this.database) return this.byArticleStatement.all(targetCelex, articleKey);
+    return (this.byTargetCelex.get(targetCelex) || [])
+      .filter((edge) => String(edge.targetArticle == null ? "" : edge.targetArticle).trim().toLowerCase() === articleKey);
   }
 
   assertReady() {
@@ -139,8 +251,7 @@ class CitationGraphStore {
     const targetArticle = String(article == null ? "" : article).trim().toLowerCase();
     const limit = Math.max(1, Math.min(Number.parseInt(options.limit, 10) || 50, 200));
     const offset = Math.max(0, Number.parseInt(options.offset, 10) || 0);
-    const matching = (this.byTargetCelex.get(targetCelex) || [])
-      .filter((edge) => String(edge.targetArticle == null ? "" : edge.targetArticle).trim().toLowerCase() === targetArticle);
+    const matching = this.edgesForArticle(targetCelex, targetArticle);
     const provisions = distinctSources(matching.filter((edge) => edge.kind === "legislation"));
     const judgments = distinctSources(matching.filter((edge) => edge.kind === "judgment"));
     const combined = [...provisions.map((edge) => ({ edge, kind: "legislation" })),
@@ -158,7 +269,7 @@ class CitationGraphStore {
   getActCitations(celex) {
     this.assertReady();
     const targetCelex = normalize(celex);
-    const edges = this.byTargetCelex.get(targetCelex) || [];
+    const edges = this.edgesForAct(targetCelex);
     const actOnly = edges.filter((edge) => edge.targetArticle == null || String(edge.targetArticle).trim() === "");
     const article = edges.filter((edge) => edge.targetArticle != null && String(edge.targetArticle).trim() !== "");
     const byArticle = new Map();
@@ -181,4 +292,4 @@ class CitationGraphStore {
   }
 }
 
-module.exports = { CitationGraphStore, DEFAULT_CITATION_GRAPH_PATH, GRAPH_VERSION, distinctSources };
+module.exports = { CitationGraphStore, DEFAULT_CITATION_GRAPH_PATH, DEFAULT_SQLITE_DATA_PATH, GRAPH_VERSION, SQLITE_SCHEMA_VERSION, distinctSources };

--- a/backend/search/citation-graph-store.js
+++ b/backend/search/citation-graph-store.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
 const path = require("path");
 const zlib = require("zlib");
-const GRAPH_VERSION = 1;
+const GRAPH_VERSION = 2;
 
 const DEFAULT_CITATION_GRAPH_PATH = path.join(__dirname, "data", "citation-graph.json");
 const normalize = (value) => String(value == null ? "" : value).trim().toUpperCase();

--- a/backend/search/citation-graph-store.test.js
+++ b/backend/search/citation-graph-store.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const zlib = require("node:zlib");
 const test = require("node:test");
 
-const { CitationGraphStore } = require("./citation-graph-store");
+const { CitationGraphStore, GRAPH_VERSION } = require("./citation-graph-store");
 
 function writeGraph(payload) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "citation-store-"));
@@ -37,19 +37,19 @@ test("store loads the gzipped artifact when the raw file is absent", () => {
   // JSON exists only after a local rebuild and must win when both are present.
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "citation-store-gz-"));
   const graphPath = path.join(dir, "citation-graph.json");
-  fs.writeFileSync(`${graphPath}.gz`, zlib.gzipSync(JSON.stringify({ graphVersion: 1, stats: { edges: 4 }, edges })));
+  fs.writeFileSync(`${graphPath}.gz`, zlib.gzipSync(JSON.stringify({ graphVersion: GRAPH_VERSION, stats: { edges: 4 }, edges })));
 
   const store = new CitationGraphStore(graphPath);
   assert.equal(store.load(), true);
   assert.deepEqual(store.getActCitations("32016R0679").totals, { provisions: 2, judgments: 1, total: 3 });
 
-  fs.writeFileSync(graphPath, JSON.stringify({ graphVersion: 1, stats: { edges: 0 }, edges: [] }));
+  fs.writeFileSync(graphPath, JSON.stringify({ graphVersion: GRAPH_VERSION, stats: { edges: 0 }, edges: [] }));
   assert.equal(store.load(), true);
   assert.equal(store.getStatus().edges, 0);
 });
 
 test("article queries count distinct sources and paginate the combined result", () => {
-  const store = new CitationGraphStore(writeGraph({ graphVersion: 1, parserVersion: 4, stats: { edges: 4 }, edges }));
+  const store = new CitationGraphStore(writeGraph({ graphVersion: GRAPH_VERSION, parserVersion: 4, stats: { edges: 4 }, edges }));
   assert.equal(store.load(), true);
   const first = store.getArticleCitations("32016r0679", "6", { limit: 1 });
   assert.deepEqual(first.counts, { provisions: 1, judgments: 1, total: 2 });
@@ -68,7 +68,7 @@ test("article query public units remove recital and annex storage prefixes only"
     { kind: "legislation", sourceCelex: "32024R0003", sourceTitle: "Annex source", sourceUnitType: "annex", sourceUnit: "annex_I", targetCelex: "32016R0679", targetArticle: "6" },
     { kind: "legislation", sourceCelex: "32024R0004", sourceTitle: "Malformed source", sourceUnitType: "recital", sourceUnit: "recital_", targetCelex: "32016R0679", targetArticle: "6" },
   ];
-  const store = new CitationGraphStore(writeGraph({ graphVersion: 1, edges: sourceEdges }));
+  const store = new CitationGraphStore(writeGraph({ graphVersion: GRAPH_VERSION, edges: sourceEdges }));
   assert.equal(store.load(), true);
 
   const result = store.getArticleCitations("32016R0679", "6", { limit: 10 });
@@ -81,7 +81,7 @@ test("article query public units remove recital and annex storage prefixes only"
 });
 
 test("act query separates act-only references from article references", () => {
-  const store = new CitationGraphStore(writeGraph({ graphVersion: 1, edges }));
+  const store = new CitationGraphStore(writeGraph({ graphVersion: GRAPH_VERSION, edges }));
   store.load();
   assert.deepEqual(store.getActCitations("32016R0679"), {
     celex: "32016R0679",
@@ -101,7 +101,7 @@ test("act query dedups a provision citing both the act and an article across sub
     { kind: "legislation", sourceCelex: "32024R0009", sourceTitle: "Dual citer", sourceUnitType: "article", sourceUnit: "3", targetCelex: "32016R0679", targetArticle: null, targetParagraph: null, targetPoint: null },
     { kind: "legislation", sourceCelex: "32024R0009", sourceTitle: "Dual citer", sourceUnitType: "article", sourceUnit: "3", targetCelex: "32016R0679", targetArticle: "6", targetParagraph: null, targetPoint: null },
   ];
-  const store = new CitationGraphStore(writeGraph({ graphVersion: 1, edges: overlappingEdges }));
+  const store = new CitationGraphStore(writeGraph({ graphVersion: GRAPH_VERSION, edges: overlappingEdges }));
   assert.equal(store.load(), true);
   const result = store.getActCitations("32016R0679");
   assert.deepEqual(result.actOnly, { provisions: 1, judgments: 0, total: 1 });

--- a/backend/search/citation-graph-store.test.js
+++ b/backend/search/citation-graph-store.test.js
@@ -109,3 +109,58 @@ test("act query dedups a provision citing both the act and an article across sub
   assert.deepEqual(result.totals, { provisions: 1, judgments: 0, total: 1 });
   assert.ok(result.actOnly.total + result.article.total > result.totals.total);
 });
+
+// The SQLite path must be a pure storage swap: same edges in, byte-identical query
+// results out. Anything else is a behaviour change hiding in a deployment detail.
+test("sqlite-backed store returns results identical to the JSON store", (t) => {
+  const { buildSqliteData } = require("./build-sqlite-data");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "citation-parity-"));
+  const graphEdges = [
+    { kind: "legislation", sourceCelex: "32020R0001", sourceTitle: "Widgets", sourceUnitType: "article", sourceUnit: "5", targetCelex: "32016R0679", targetArticle: "6", targetParagraph: "1", targetPoint: "a", raw: "Article 6(1)(a)" },
+    { kind: "legislation", sourceCelex: "32020R0001", sourceTitle: "Widgets", sourceUnitType: "article", sourceUnit: "5", targetCelex: "32016R0679", targetArticle: "6", targetParagraph: "2", targetPoint: null, raw: "Article 6(2)" },
+    { kind: "legislation", sourceCelex: "32019R0009", sourceTitle: "Gadgets", sourceUnitType: "recital", sourceUnit: "recital_3", targetCelex: "32016R0679", targetArticle: null, targetParagraph: null, targetPoint: null, raw: "the GDPR" },
+    { kind: "judgment", sourceCelex: "62020CJ0001", sourceTitle: "Some Case", sourceUnitType: "judgment", sourceUnit: "62020CJ0001", targetCelex: "32016R0679", targetArticle: "6", targetParagraph: null, targetPoint: null, raw: "Article 6" },
+  ];
+  const graph = {
+    graphVersion: GRAPH_VERSION, parserVersion: 15, generatedAt: "2026-07-15T19:22:07.710Z",
+    coverage: { legislation: { htmlLaws: 2 } }, stats: { edges: graphEdges.length }, edges: graphEdges,
+  };
+  const graphPath = path.join(dir, "citation-graph.json");
+  const searchPath = path.join(dir, "search.json");
+  const caseLawPath = path.join(dir, "case-law.json");
+  const sqlitePath = path.join(dir, "data.sqlite");
+  fs.writeFileSync(graphPath, JSON.stringify(graph));
+  fs.writeFileSync(searchPath, JSON.stringify({ generatedAt: "x", records: [] }));
+  fs.writeFileSync(caseLawPath, JSON.stringify({}));
+  buildSqliteData({
+    searchCachePath: searchPath, caseLawCachePath: caseLawPath, citationGraphPath: graphPath,
+    outputPath: sqlitePath, manifestPath: path.join(dir, "manifest.json"), log: () => {},
+  });
+
+  const jsonStore = new CitationGraphStore(graphPath, { preferJson: true });
+  assert.equal(jsonStore.load(), true);
+  assert.equal(jsonStore.getStatus().source, "json");
+
+  const sqliteStore = new CitationGraphStore(graphPath, { sqlitePath });
+  assert.equal(sqliteStore.load(), true, sqliteStore.getStatus().error || "");
+  assert.equal(sqliteStore.getStatus().source, "sqlite");
+  t.after(() => sqliteStore.close());
+
+  assert.deepEqual(sqliteStore.getActCitations("32016R0679"), jsonStore.getActCitations("32016R0679"));
+  assert.deepEqual(
+    sqliteStore.getArticleCitations("32016R0679", "6"),
+    jsonStore.getArticleCitations("32016R0679", "6")
+  );
+  // paginate + an act with no citations
+  assert.deepEqual(
+    sqliteStore.getArticleCitations("32016R0679", "6", { limit: 1, offset: 1 }),
+    jsonStore.getArticleCitations("32016R0679", "6", { limit: 1, offset: 1 })
+  );
+  assert.deepEqual(sqliteStore.getActCitations("32099R9999"), jsonStore.getActCitations("32099R9999"));
+
+  const status = sqliteStore.getStatus();
+  assert.equal(status.graphVersion, GRAPH_VERSION);
+  assert.equal(status.parserVersion, 15);
+  assert.equal(status.edges, 4);
+  assert.deepEqual(status.coverage, { legislation: { htmlLaws: 2 } });
+});

--- a/backend/search/citation-graph-worker.js
+++ b/backend/search/citation-graph-worker.js
@@ -4,6 +4,7 @@ const { buildCitationGraph } = require("./citation-graph-build");
 buildCitationGraph({
   files: workerData.files,
   maxXmlBytes: workerData.maxXmlBytes,
+  maxHtmlBytes: workerData.maxHtmlBytes,
   searchCachePath: workerData.searchCachePath,
   outputPath: null,
   htmlTreeSkipped: 0,

--- a/backend/search/citation-graph-worker.js
+++ b/backend/search/citation-graph-worker.js
@@ -1,10 +1,13 @@
 const { parentPort, workerData } = require("worker_threads");
-const { buildCitationGraph } = require("./citation-graph-build");
+const { buildCitationGraph, createReferenceResolver } = require("./citation-graph-build");
 
 buildCitationGraph({
   files: workerData.files,
   maxXmlBytes: workerData.maxXmlBytes,
   maxHtmlBytes: workerData.maxHtmlBytes,
+  // The parent resolves the search cache once and passes the index down; only fall
+  // back to loading it here if it did not (which costs a full re-index per batch).
+  legalCache: workerData.resolverIndex ? createReferenceResolver(workerData.resolverIndex) : undefined,
   searchCachePath: workerData.searchCachePath,
   outputPath: null,
   htmlTreeSkipped: 0,

--- a/backend/search/legal-cache-store.js
+++ b/backend/search/legal-cache-store.js
@@ -529,6 +529,25 @@ class JsonLegalCacheStore {
     return getDeterministicMatch(this.byOfficialReference, normalizeOfficialReferenceLookupKey(reference));
   }
 
+  // Reference resolution reduced to plain, cloneable data. Consumers that only
+  // resolve citations (the citation graph builder's workers) can rebuild these
+  // lookups in milliseconds instead of re-reading the cache and re-indexing
+  // MiniSearch, which dominates load() and which they never query. Ambiguous keys
+  // are dropped here so the index resolves exactly as getDeterministicMatch does.
+  exportReferenceIndex() {
+    const officialRef = {};
+    for (const [key, matches] of this.byOfficialReference) {
+      if (matches.length === 1 && matches[0]?.celex) {
+        officialRef[key] = String(matches[0].celex).toUpperCase();
+      }
+    }
+    const celexTitle = {};
+    for (const [key, matches] of this.byCelex) {
+      if (matches.length === 1) celexTitle[key] = matches[0]?.title ?? null;
+    }
+    return { officialRef, celexTitle };
+  }
+
   searchExcerpts(expression) {
     if (!this.excerptSearchStatement || !expression) return [];
     return this.excerptSearchStatement.all(expression);

--- a/backend/search/legal-cache-store.js
+++ b/backend/search/legal-cache-store.js
@@ -13,7 +13,7 @@ const {
 const BUILTIN_SEARCH_CACHE_PATH = path.join(__dirname, "data", "search-cache.json");
 const DEFAULT_SEARCH_CACHE_PATH = process.env.SEARCH_CACHE_PATH || BUILTIN_SEARCH_CACHE_PATH;
 const DEFAULT_SQLITE_DATA_PATH = path.join(__dirname, "data", "data.sqlite");
-const SQLITE_SCHEMA_VERSION = 1;
+const SQLITE_SCHEMA_VERSION = 2;
 
 const SUPPLEMENTAL_RECORDS = [
   {


### PR DESCRIPTION
Now that #106 and #82 have merged, this rebases onto `main` and drops the vendored baseline commit — every commit here is new work.

Published data: [`data-v7`](https://github.com/maastrichtlawtech/legalviz.eu/releases/tag/data-v7).

## Why

The builder only walked `data/laws` (Formex), so the ~52k acts EUR-Lex never published as FMX — overwhelmingly pre-2000 — contributed **no edges** and were merely tallied as `htmlTreeSkipped`. Their citations exist only as prose. Now that #106 extracts those, walking `data/laws-html` is what makes those acts citable.

Two further problems blocked using the result:

- The graph was the one data set still shipped to runtime as JSON and loaded whole at startup: 373 MB on disk, **~1.3 GB resident**, to answer lookups that are point queries. #82 also had to keep it out of the final image to satisfy the #103 release gate, which left the cited-by endpoints reporting `citation_graph_unavailable`. This makes them work.
- Every batch worker built its own `JsonLegalCacheStore`, re-reading the ~300 MB search cache and rebuilding a MiniSearch index it never queries — **~800 reloads** for a full corpus. This is why the graph had to be built out-of-band rather than with the CLI.

## What changed

| Commit | |
|---|---|
| Walk the HTML corpus | One combined CELEX-keyed file list; the per-file handler dispatches on extension. Both corpora share `legislationEdgesForLaw` because the HTML parser returns the same parsed shape. The existing batched worker path needs no changes and gives the HTML pass its memory isolation for free. `--noHtml` restores the FMX-only graph. |
| Serve from SQLite | `citation-graph.json.gz` is folded into `citations` / `citation_sources`, following the same asset → data-builder → `data.sqlite` path as every other data set, and stops being copied into the runtime image. |
| Resolve the cache once | `exportReferenceIndex()` reduces resolution to plain data; the parent exports once and shares it with every worker. |
| `--workerHeapMb` | Was plumbed through but had no flag, so CLI builds were stuck at 768 MB — the heaviest acts need ~4 GB, and below that they OOM their worker and land as `worker_failure` contributing no edges. |
| Docs + manifest ignore | Follow-ups to the case-law asset rename that landed with #82. |
| Enrichment gate | See below. |

## Results

Full corpus: **836,407 edges** (762,840 legislation + 73,567 judgment) over 80,439 files (27,916 FMX + 52,523 HTML), 94.9% of references resolved. The HTML corpus alone contributes **243,068 edges** from pre-2000 acts that previously contributed none.

| | Before | After |
|---|---|---|
| Runtime resident | 1,320 MB | **54 MB** |
| Store load | 1.2 s | **5 ms** |
| Release asset | — | 14.3 MB gz |

`GRAPH_VERSION` 1 → 2 and `SQLITE_SCHEMA_VERSION` 1 → 2 (all paired constants), so a pre-HTML artifact is rejected rather than silently served as an incomplete graph. Test fixtures that hardcoded `graphVersion: 1` now derive it from the constant.

## The new gate

`date` and `eurovoc` are enriched inline onto the records as the cache builders' last step. Publishing a raw local `search-cache` instead of carrying the enriched asset forward silently strips both — `/api/topics` empties and every pre-2010 act serves a null date. The existing smoke test catches the first but not the second; **this actually happened while preparing data-v7** and only the topics half was caught. The new step asserts the invariant the release notes state: every record dated, every record carrying an eurovoc key (empty arrays are legitimate). Verified both ways — passes on data-v7, fires with `66947/80440 laws have no date` on an unenriched build.

## Verification

302 backend tests pass, lint clean. Beyond unit tests:

- **SQLite/JSON parity test** runs both stores over the same graph and asserts identical results (act-level, article-level, pagination, empty) — a storage swap, not a behaviour change.
- **Real-corpus check**: 1970 yields 143 laws (2 FMX + 141 HTML) and the HTML-only `31970R0729` edges its citation of Regulation 17/64/EEC. Both the single-process and batched/worker paths were driven against the real corpus.
- The committed builder **reproduces the published artifact exactly** — diffing a full year (1970) gives 732 edges on both sides, zero differences.
- `data.sqlite` built from the published data-v7 assets, then the gate's own assertions run against it: search, topics, resolve-reference, and no JSON in the final image.

## Note on the published artifact

`data-v7`'s graph was built with `PARSER_VERSION` 15; #106 reached 16 before merging. It is valid and loads fine — `graphVersion` is what the store gates on — but it predates the last citation-parsing fixes, so it is marginally less complete than a fresh build. The CLI can now regenerate it directly when that is worth doing.