### PR TITLE
Remove the "Try" chip row from the landing page

### DIFF
--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -1,5 +1,5 @@
-import { Link, useNavigate } from "react-router-dom";
-import { useCallback, useEffect, useMemo } from "react";
+import { useNavigate } from "react-router-dom";
+import { useCallback, useEffect } from "react";
 import { motion as Motion } from "framer-motion";
 import { Github } from "lucide-react";
 import { TopBar, SearchBox } from "./TopBar.jsx";
@@ -10,7 +10,7 @@ import { lawLangFromUiLocale, uiLocaleFromLawLang } from "../i18n/localeMeta.js"
 import { resetWholeApp } from "../utils/resetApp.js";
 import { useLandingLibrary } from "../hooks/useLandingLibrary.js";
 import { useLandingSearchIndex } from "../hooks/useLandingSearchIndex.js";
-import { buildImportedLawCandidate, getCanonicalLawRoute, getBundledLaws } from "../utils/lawRouting.js";
+import { buildImportedLawCandidate, getCanonicalLawRoute } from "../utils/lawRouting.js";
 import { saveLawMeta } from "../utils/library.js";
 
 function inferOfficialReferenceFromCelex(celex) {
@@ -61,24 +61,6 @@ export function Landing({ forcedLocale = null }) {
     libraryVersion,
   });
   const activeLocale = forcedLocale || locale;
-
-  const tryChips = useMemo(() => {
-    const bundled = getBundledLaws();
-    const bySlug = (slug) => bundled.find((law) => law.slug === slug) || null;
-    return [
-      { key: "gdpr", law: bySlug("gdpr"), mono: false },
-      { key: "aia", law: bySlug("aia"), mono: false },
-      { key: "dsa", law: bySlug("dsa"), mono: false },
-      { key: "data-act", law: bySlug("data-act"), mono: true },
-    ]
-      .filter((chip) => chip.law)
-      .map((chip) => ({
-        key: chip.key,
-        label: chip.mono ? chip.law.celex : chip.law.label,
-        mono: chip.mono,
-        to: getCanonicalLawRoute(chip.law, null, null, activeLocale),
-      }));
-  }, [activeLocale]);
 
   const handleOpenLaw = useCallback(async (law) => {
     // Best-effort bookkeeping: never let a stuck IndexedDB block navigation.
@@ -167,24 +149,6 @@ export function Landing({ forcedLocale = null }) {
               triggerVariant="hero"
             />
           </div>
-
-          {tryChips.length > 0 ? (
-            <div className="mt-4 flex flex-wrap items-center justify-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-              <span>{t("landing.tryLabel")}</span>
-              {tryChips.map((chip) => (
-                <Link
-                  key={chip.key}
-                  to={chip.to}
-                  className={
-                    "rounded-full border border-eu-blue-soft-dark/40 bg-paper px-3 py-1 text-gray-600 transition hover:border-eu-blue/50 hover:text-eu-blue dark:border-panel-dark dark:bg-panel-dark dark:text-gray-300 dark:hover:text-eu-blue-bright " +
-                    (chip.mono ? "font-mono text-[11px]" : "")
-                  }
-                >
-                  {chip.label}
-                </Link>
-              ))}
-            </div>
-          ) : null}
         </Motion.div>
 
         <div className="mt-14 w-full max-w-5xl">

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -150,7 +150,6 @@
     "recentShowAll": "Show all {count} last opened laws",
     "recentShowLess": "Show less",
     "heroEyebrow": "Free & open source · 24 official languages",
-    "tryLabel": "Try",
     "continueTitle": "Continue reading",
     "continueSubtitle": "Pick up where you left off.",
     "addLawButton": "Add a law",


### PR DESCRIPTION
Removes the `Try GDPR / AI Act / Digital Services Act / 32023R2854` chip row under the landing page hero search.

The hero search and the "Start with the essentials" shelf already cover the same ground, so the chips were a third entry point to laws reachable two other ways.

Also drops what the removal orphaned: the `Link` / `useMemo` / `getBundledLaws` imports in `Landing.jsx`, and the `landing.tryLabel` string. That key only ever existed in `en.json` — the other 22 locales never had it, so the label was rendering untranslated English everywhere.

## Note for reviewers

Three of the four chips (GDPR, AI Act, DSA) are also in the essentials shelf, but **the Data Act is not** — after this change the landing page's law links are exactly `/dsa`, `/dma`, `/gdpr`, `/aia`, and the Data Act is only reachable via search. If we want to keep a one-click path, adding `"data-act"` to `ESSENTIAL_SLUGS` in `src/components/LandingLibrary.jsx` (plus a description key) would do it. Happy to fold that in.

## Verification

Ran the app and drove the landing page:

- Chip row gone; hero, search, "Continue reading" and essentials all render with no leftover gap. No "Try" text, clean console.
- Stashed the change and reloaded to confirm the chips reappear — i.e. this diff is what removes them.
- Checked dark mode and mobile (375px); the removed block carried its own dark/responsive classes.
- Typed into the hero search (overlay opens, accepts input) and clicked the GDPR essentials card (law page loads).

`npm run lint` clean, `npm run test:web` 335/335 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)