### PR TITLE
Compact context-rail panels: grouped Cited-by, fixed recitals/references/case-law rendering

### DIFF
--- a/src/components/CitedByPanel.jsx
+++ b/src/components/CitedByPanel.jsx
@@ -2,11 +2,14 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { BookOpen, ChevronDown, ChevronUp, Link2, Loader2, RefreshCw, Scale } from "lucide-react";
 import { useI18n } from "../i18n/useI18n.js";
 import { fetchArticleCitedBy } from "../utils/formexApi.js";
+import { buildLawDisplayLabel } from "../utils/lawDisplay.js";
 import { Button } from "./Button.jsx";
 import { JudgmentCite } from "./ArticleCaseLawDigest.jsx";
 import { buildCitedByDisplay, isCitedByUnavailableError } from "./citedByDisplay.js";
 
-export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenLaw }) {
+// `compact` renders the panel for the narrow context rail: no outer gutters
+// and no title row (the rail tab already says "Cited by").
+export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenLaw, compact = false }) {
   const { t } = useI18n();
   const [payload, setPayload] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -14,6 +17,8 @@ export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenL
   const [error, setError] = useState(null);
   const [suppressed, setSuppressed] = useState(false);
   const [expanded, setExpanded] = useState(false);
+
+  const outerClass = compact ? "py-1" : "mt-6 px-6 md:px-12";
 
   useEffect(() => {
     setPayload(null);
@@ -82,8 +87,16 @@ export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenL
   if (!celex || !articleNumber || suppressed) return null;
 
   if (loading && !loaded) {
+    if (compact) {
+      return (
+        <p className={`${outerClass} flex items-center justify-center gap-2 py-6 text-xs text-gray-400 dark:text-gray-500`}>
+          <Loader2 size={14} className="animate-spin" />
+          {t("citedBy.loading")}
+        </p>
+      );
+    }
     return (
-      <div className="mt-6 px-6 md:px-12">
+      <div className={outerClass}>
         <div className="flex items-center justify-between gap-3 border-y border-gray-200 py-3 dark:border-gray-800">
           <span className="flex min-w-0 items-center gap-2">
             <Link2 size={16} className="shrink-0 text-teal-700 dark:text-teal-300" />
@@ -100,8 +113,8 @@ export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenL
 
   if (error) {
     return (
-      <div className="mt-6 px-6 md:px-12">
-        <div className="flex flex-wrap items-center justify-between gap-3 border-y border-amber-300 py-3 text-sm text-amber-800 dark:border-amber-700 dark:text-amber-200">
+      <div className={outerClass}>
+        <div className={`flex flex-wrap items-center justify-between gap-3 py-3 text-sm text-amber-800 dark:text-amber-200 ${compact ? "" : "border-y border-amber-300 dark:border-amber-700"}`}>
           <span>{t("citedBy.unavailable")}</span>
           <Button type="button" variant="outline" size="sm" onClick={retry}>
             <RefreshCw size={14} />
@@ -115,56 +128,65 @@ export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenL
   if (!loaded || !payload) return null;
 
   return (
-    <div className="mt-6 px-6 md:px-12">
-      <div className="flex flex-wrap items-center justify-between gap-3 border-y border-gray-200 py-3 dark:border-gray-800">
-        <span className="flex min-w-0 items-center gap-2">
-          <Link2 size={16} className="shrink-0 text-teal-700 dark:text-teal-300" />
-          <span className="font-semibold text-gray-900 dark:text-gray-100">{t("citedBy.title")}</span>
-          <span className="rounded-full bg-teal-100 px-2.5 py-0.5 text-sm font-medium text-teal-800 dark:bg-teal-900/40 dark:text-teal-200">
-            {display.counts.total}
+    <div className={outerClass}>
+      {compact ? null : (
+        <div className="flex flex-wrap items-center justify-between gap-3 border-y border-gray-200 py-3 dark:border-gray-800">
+          <span className="flex min-w-0 items-center gap-2">
+            <Link2 size={16} className="shrink-0 text-teal-700 dark:text-teal-300" />
+            <span className="font-semibold text-gray-900 dark:text-gray-100">{t("citedBy.title")}</span>
+            <span className="rounded-full bg-teal-100 px-2.5 py-0.5 text-sm font-medium text-teal-800 dark:bg-teal-900/40 dark:text-teal-200">
+              {display.counts.total}
+            </span>
           </span>
-        </span>
-        <span className="text-sm text-gray-500 dark:text-gray-400">{t("citedBy.subtitle")}</span>
-      </div>
+          <span className="text-sm text-gray-500 dark:text-gray-400">{t("citedBy.subtitle")}</span>
+        </div>
+      )}
 
       {display.empty ? (
-        <p className="border-b border-gray-200 py-3 text-sm text-gray-500 dark:border-gray-800 dark:text-gray-400">
+        <p className={compact
+          ? "py-6 text-center text-xs text-gray-400 dark:text-gray-500"
+          : "border-b border-gray-200 py-3 text-sm text-gray-500 dark:border-gray-800 dark:text-gray-400"}>
           {t("citedBy.empty")}
         </p>
       ) : (
         <>
-          {display.visibleProvisions.length ? (
-            <section aria-labelledby="cited-by-legislation-heading" className="border-b border-gray-200 py-3 dark:border-gray-800">
+          {display.visibleProvisionGroups.length ? (
+            <section aria-labelledby="cited-by-legislation-heading" className={`py-3 ${compact ? "" : "border-b border-gray-200 dark:border-gray-800"}`}>
               <h3 id="cited-by-legislation-heading" className="mb-1.5 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
                 <BookOpen size={13} />
                 {t("citedBy.legislationLabel", { count: display.counts.provisions })}
               </h3>
               <div className="divide-y divide-gray-100 dark:divide-gray-800">
-                {display.visibleProvisions.map((source, index) => {
-                  const lawLabel = source.title || source.celex;
+                {display.visibleProvisionGroups.map((group) => {
+                  const { label, fullTitle } = buildLawDisplayLabel(group);
                   return (
-                    <button
-                      key={`${source.celex}-${source.unitType}-${source.unit}-${index}`}
-                      type="button"
-                      className="flex w-full items-start justify-between gap-4 rounded-sm px-1 py-2.5 text-left transition hover:bg-teal-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 dark:hover:bg-teal-950/30 dark:focus-visible:ring-teal-400 dark:focus-visible:ring-offset-gray-900"
-                      aria-label={t("citedBy.openLaw", { law: lawLabel, unit: source.unitLabel })}
-                      onClick={() => onOpenLaw?.(source.celex, {
-                        articleNumber: source.articleNumber,
-                        label: source.title,
-                      })}
-                    >
-                      <span className="min-w-0">
-                        <span className="block font-medium text-gray-900 dark:text-gray-100">{lawLabel}</span>
-                        <span className="block text-xs text-gray-500 dark:text-gray-400">{source.unitLabel}</span>
+                    <div key={group.celex} className="px-1 py-2.5">
+                      <button
+                        type="button"
+                        className="block w-full rounded-sm text-left text-sm font-medium text-gray-900 transition hover:text-teal-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 dark:text-gray-100 dark:hover:text-teal-200 dark:focus-visible:ring-teal-400 dark:focus-visible:ring-offset-gray-900"
+                        title={fullTitle || undefined}
+                        onClick={() => onOpenLaw?.(group.celex, { label: group.title })}
+                      >
+                        <span className="line-clamp-2">{label}</span>
+                      </button>
+                      <span className="mt-1.5 flex flex-wrap gap-1">
+                        {group.units.map((unit, index) => (
+                          <button
+                            key={`${unit.unitType}-${unit.unit}-${index}`}
+                            type="button"
+                            className="rounded bg-gray-100 px-1.5 py-0.5 text-[11px] font-medium text-gray-600 transition hover:bg-teal-100 hover:text-teal-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-teal-900/40 dark:hover:text-teal-200 dark:focus-visible:ring-teal-400 dark:focus-visible:ring-offset-gray-900"
+                            title={unit.referenceChips.join(", ") || undefined}
+                            aria-label={t("citedBy.openLaw", { law: label, unit: unit.unitLabel })}
+                            onClick={() => onOpenLaw?.(group.celex, {
+                              articleNumber: unit.articleNumber,
+                              label: group.title,
+                            })}
+                          >
+                            {unit.unitLabel}
+                          </button>
+                        ))}
                       </span>
-                      {source.referenceChips.length ? (
-                        <span className="flex shrink-0 flex-wrap justify-end gap-1">
-                          {source.referenceChips.map((chip) => (
-                            <span key={chip} className="rounded bg-gray-100 px-1.5 py-0.5 text-[11px] font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-300">{chip}</span>
-                          ))}
-                        </span>
-                      ) : null}
-                    </button>
+                    </div>
                   );
                 })}
               </div>
@@ -172,7 +194,7 @@ export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenL
           ) : null}
 
           {display.visibleJudgments.length ? (
-            <section aria-labelledby="cited-by-judgments-heading" className="border-b border-gray-200 py-3 dark:border-gray-800">
+            <section aria-labelledby="cited-by-judgments-heading" className={`py-3 ${compact ? "" : "border-b border-gray-200 dark:border-gray-800"}`}>
               <h3 id="cited-by-judgments-heading" className="mb-2 flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
                 <Scale size={13} />
                 {t("citedBy.judgmentsLabel", { count: display.counts.judgments })}
@@ -188,7 +210,7 @@ export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenL
           {display.hasHiddenResults || expanded ? (
             <button
               type="button"
-              className="flex w-full items-center justify-between gap-3 border-b border-gray-200 py-3 text-left text-sm font-medium text-teal-700 transition hover:text-teal-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 dark:border-gray-800 dark:text-teal-300 dark:hover:text-teal-100 dark:focus-visible:ring-teal-400 dark:focus-visible:ring-offset-gray-900"
+              className={`flex w-full items-center justify-between gap-3 py-3 text-left text-sm font-medium text-teal-700 transition hover:text-teal-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-600 focus-visible:ring-offset-2 dark:text-teal-300 dark:hover:text-teal-100 dark:focus-visible:ring-teal-400 dark:focus-visible:ring-offset-gray-900 ${compact ? "border-t border-gray-100 dark:border-gray-800" : "border-b border-gray-200 dark:border-gray-800"}`}
               aria-expanded={expanded}
               onClick={() => setExpanded((current) => !current)}
             >
@@ -198,7 +220,7 @@ export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenL
           ) : null}
 
           {display.overflowCount > 0 ? (
-            <p className="border-b border-gray-200 py-2 text-xs text-gray-500 dark:border-gray-800 dark:text-gray-400">
+            <p className={`py-2 text-xs text-gray-500 dark:text-gray-400 ${compact ? "" : "border-b border-gray-200 dark:border-gray-800"}`}>
               {t("citedBy.andMore", { count: display.overflowCount })}
             </p>
           ) : null}

--- a/src/components/CrossReferences.jsx
+++ b/src/components/CrossReferences.jsx
@@ -8,6 +8,10 @@ import { useI18n } from "../i18n/useI18n.js";
  *
  * Shows which other articles are referenced by the current article,
  * and which articles reference the current article (back-references).
+ *
+ * `compact` renders for the narrow context rail: no outer gutters, no
+ * collapsible header (the rail tab already labels and counts the section),
+ * content always expanded.
  */
 export function CrossReferences({
   articleNumber,
@@ -20,9 +24,11 @@ export function CrossReferences({
   currentLang = "EN",
   onOpenExternalReference,
   isExternalReferencePending,
+  compact = false,
 }) {
   const { t } = useI18n();
   const [isOpen, setIsOpen] = useState(false);
+  const showContent = compact || isOpen;
   const referenceKey = entryKey || articleNumber;
   if (!crossReferences || !referenceKey) return null;
 
@@ -58,28 +64,30 @@ export function CrossReferences({
   }
 
   return (
-    <div className="mt-8 px-6 md:px-12">
-      <button
-        type="button"
-        className="flex w-full items-center justify-between gap-3 border-y border-gray-200 py-3 text-left transition hover:border-amber-200 dark:border-gray-800 dark:hover:border-amber-900/70"
-        aria-expanded={isOpen}
-        onClick={() => setIsOpen((current) => !current)}
-      >
-        <span className="flex min-w-0 items-center gap-2">
-          <span className="font-semibold text-gray-900 dark:text-gray-100">{t("crossReferences.title")}</span>
-          <span className="rounded-full bg-amber-100 px-2.5 py-0.5 text-sm font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
-            {forwardRefs.length + backRefs.length + externalRefs.length}
-          </span>
-        </span>
-        <span
-          aria-hidden="true"
-          className={`shrink-0 text-sm text-gray-500 transition-transform dark:text-gray-400 ${isOpen ? "rotate-90" : ""}`}
+    <div className={compact ? "" : "mt-8 px-6 md:px-12"}>
+      {compact ? null : (
+        <button
+          type="button"
+          className="flex w-full items-center justify-between gap-3 border-y border-gray-200 py-3 text-left transition hover:border-amber-200 dark:border-gray-800 dark:hover:border-amber-900/70"
+          aria-expanded={isOpen}
+          onClick={() => setIsOpen((current) => !current)}
         >
-          &gt;
-        </span>
-      </button>
-      {isOpen ? (
-        <div className="space-y-4 border-b border-gray-200 py-3 dark:border-gray-800">
+          <span className="flex min-w-0 items-center gap-2">
+            <span className="font-semibold text-gray-900 dark:text-gray-100">{t("crossReferences.title")}</span>
+            <span className="rounded-full bg-amber-100 px-2.5 py-0.5 text-sm font-medium text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+              {forwardRefs.length + backRefs.length + externalRefs.length}
+            </span>
+          </span>
+          <span
+            aria-hidden="true"
+            className={`shrink-0 text-sm text-gray-500 transition-transform dark:text-gray-400 ${isOpen ? "rotate-90" : ""}`}
+          >
+            &gt;
+          </span>
+        </button>
+      )}
+      {showContent ? (
+        <div className={`space-y-4 py-3 ${compact ? "" : "border-b border-gray-200 dark:border-gray-800"}`}>
           {forwardRefs.length > 0 && (
             <div>
               <p className="mb-2 text-sm text-gray-500 dark:text-gray-400">

--- a/src/components/LawViewer.jsx
+++ b/src/components/LawViewer.jsx
@@ -492,7 +492,6 @@ export function LawViewer() {
                   relatedRecitals={recitalMap.get(selection.selected.id) || []}
                   orphanRecitalNumbers={recitalMap.orphanRecitalNumbers || []}
                   allRecitals={primaryDocument.data.recitals}
-                  recitalTitlesLoading={primaryDocument.recitalTitlesLoading}
                   onSelectRecital={selection.onClickRecital}
                   celex={source.effectiveCelex}
                   articleNumber={selection.selected.id}

--- a/src/components/RelatedCaseLaw.jsx
+++ b/src/components/RelatedCaseLaw.jsx
@@ -91,9 +91,12 @@ function CaseCard({ c, currentLang }) {
   );
 }
 
-export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN" }) {
+// `compact` renders for the narrow context rail: no outer gutters, no title
+// row (the rail tab already says "Case law"), the judgment list open by
+// default and in a single column.
+export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN", compact = false }) {
   const { t } = useI18n();
-  const [isListOpen, setIsListOpen] = useState(false);
+  const [isListOpen, setIsListOpen] = useState(compact);
   const [digestRequested, setDigestRequested] = useState(false);
   const title = t("relatedCaseLaw.title");
   const { cases, loading, loaded } = useCaseLaw(celex, { autoLoad: true });
@@ -112,6 +115,14 @@ export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN" }) {
   if (!articleNumber) return null;
 
   if (loading && !loaded) {
+    if (compact) {
+      return (
+        <p className="flex items-center justify-center gap-2 py-6 text-xs text-gray-400 dark:text-gray-500">
+          <Loader2 size={14} className="animate-spin" />
+          {t("relatedCaseLaw.loading")}
+        </p>
+      );
+    }
     return (
       <div className="mt-6 px-6 md:px-12">
         <div className="flex items-center justify-between gap-3 border-y border-gray-200 py-3 dark:border-gray-800">
@@ -137,8 +148,8 @@ export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN" }) {
     const total = cases?.length || 0;
     if (total === 0) return null;
     return (
-      <div className="mt-6 px-6 md:px-12">
-        <div className="flex flex-wrap items-center gap-2 border-y border-gray-200 py-3 text-sm dark:border-gray-800">
+      <div className={compact ? "" : "mt-6 px-6 md:px-12"}>
+        <div className={`flex flex-wrap items-center gap-2 py-3 text-sm ${compact ? "" : "border-y border-gray-200 dark:border-gray-800"}`}>
           <Scale size={16} className="shrink-0 text-gray-400 dark:text-gray-500" />
           <span className="text-gray-500 dark:text-gray-400">
             {t("relatedCaseLaw.noMatchPrefix", {
@@ -153,16 +164,18 @@ export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN" }) {
   }
 
   return (
-    <div className="mt-6 px-6 md:px-12">
-      <div className="flex w-full items-center justify-between gap-3 border-y border-gray-200 py-3 text-left dark:border-gray-800">
-        <span className="flex min-w-0 items-center gap-2">
-          <Scale size={16} className="shrink-0 text-teal-700 dark:text-teal-300" />
-          <span className="font-semibold text-gray-900 dark:text-gray-100">{title}</span>
-          <span className="rounded-full bg-teal-100 px-2.5 py-0.5 text-sm font-medium text-teal-800 dark:bg-teal-900/40 dark:text-teal-200">
-            {matching.length}
+    <div className={compact ? "" : "mt-6 px-6 md:px-12"}>
+      {compact ? null : (
+        <div className="flex w-full items-center justify-between gap-3 border-y border-gray-200 py-3 text-left dark:border-gray-800">
+          <span className="flex min-w-0 items-center gap-2">
+            <Scale size={16} className="shrink-0 text-teal-700 dark:text-teal-300" />
+            <span className="font-semibold text-gray-900 dark:text-gray-100">{title}</span>
+            <span className="rounded-full bg-teal-100 px-2.5 py-0.5 text-sm font-medium text-teal-800 dark:bg-teal-900/40 dark:text-teal-200">
+              {matching.length}
+            </span>
           </span>
-        </span>
-      </div>
+        </div>
+      )}
 
       {digestRequested ? (
         <ArticleCaseLawDigest
@@ -199,7 +212,9 @@ export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN" }) {
         </span>
       </button>
       {isListOpen ? (
-        <div className="grid gap-4 border-b border-gray-200 py-4 dark:border-gray-800 sm:grid-cols-2">
+        <div className={compact
+          ? "grid gap-3 py-3"
+          : "grid gap-4 border-b border-gray-200 py-4 dark:border-gray-800 sm:grid-cols-2"}>
           {matching.map((c) => (
             <CaseCard key={c.celex} c={c} currentLang={currentLang} />
           ))}

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -9,59 +9,12 @@ import { searchContent, searchIndex as searchWithIndex, buildSearchIndex } from 
 import { useI18n } from "../i18n/useI18n.js";
 import { searchLaws as searchLawsApi } from "../utils/formexApi.js";
 import { buildImportedLawCandidate, getCanonicalLawRoute, parseCelexQuery } from "../utils/lawRouting.js";
-import { saveLawMeta } from "../utils/library.js";
+import { inferOfficialReferenceFromCelex, saveLawMeta } from "../utils/library.js";
+import { cleanLawTitle, extractShortLawTitle, formatOfficialReference } from "../utils/lawDisplay.js";
 
 // Law search hits the network per query, so wait for a typing pause before
 // firing to avoid a request per keystroke (which trips the API rate limiter).
 const LAW_SEARCH_DEBOUNCE_MS = 300;
-
-function inferOfficialReferenceFromCelex(celex) {
-  const match = String(celex || "").match(/^3(\d{4})([RLD])0*(\d{1,4})(?:\(\d+\))?$/);
-  if (!match) return null;
-
-  const actTypeMap = {
-    R: "regulation",
-    L: "directive",
-    D: "decision",
-  };
-
-  const actType = actTypeMap[match[2]] || null;
-  if (!actType) return null;
-
-  return {
-    actType,
-    year: match[1],
-    number: String(Number.parseInt(match[3], 10)),
-  };
-}
-
-function formatOfficialReference(reference) {
-  if (!reference?.actType || !reference?.year || !reference?.number) return null;
-  const actTypeLabel = reference.actType.charAt(0).toUpperCase() + reference.actType.slice(1);
-  return `${actTypeLabel} (EU) ${reference.year}/${reference.number}`;
-}
-
-function cleanLawTitle(title, referenceLabel) {
-  const raw = String(title || "").replace(/\s+/g, " ").trim();
-  if (!raw || !referenceLabel) return raw;
-  const escapedReference = referenceLabel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return raw.replace(new RegExp(`^${escapedReference}\\s+`, "i"), "").trim() || raw;
-}
-
-function extractShortLawTitle(title) {
-  const raw = String(title || "").replace(/\s+/g, " ").trim();
-  if (!raw) return "";
-
-  const matches = Array.from(raw.matchAll(/\(([^)]{5,120})\)/g));
-  for (const match of matches) {
-    const candidate = String(match[1] || "").trim();
-    if (!candidate) continue;
-    if (/text with eea relevance/i.test(candidate)) continue;
-    return candidate;
-  }
-
-  return "";
-}
 
 function getLawResultDisplay(item) {
   const officialReference = inferOfficialReferenceFromCelex(item.celex);

--- a/src/components/citedByDisplay.js
+++ b/src/components/citedByDisplay.js
@@ -65,8 +65,23 @@ export function buildCitedByDisplay(payload, {
     ...source,
     referenceChips: uniqueReferenceChips(article, source?.references, formatReference),
   }));
+  // One entry per citing law, so the (very long) law title renders once with
+  // its citing units grouped under it instead of once per unit.
+  const provisionGroups = [];
+  const groupsByCelex = new Map();
+  for (const provision of provisions) {
+    let group = groupsByCelex.get(provision.celex);
+    if (!group) {
+      group = { celex: provision.celex, title: provision.title || null, units: [] };
+      groupsByCelex.set(provision.celex, group);
+      provisionGroups.push(group);
+    }
+    group.units.push(provision);
+  }
+
   const visibleLimit = Math.max(0, Number(initialPerSection) || 0);
-  const visibleProvisions = expanded ? provisions : provisions.slice(0, visibleLimit);
+  const visibleProvisionGroups = expanded ? provisionGroups : provisionGroups.slice(0, visibleLimit);
+  const visibleProvisions = visibleProvisionGroups.flatMap((group) => group.units);
   const visibleJudgments = expanded ? judgments : judgments.slice(0, visibleLimit);
   const returnedCount = Number.isFinite(Number(payload?.pagination?.returned))
     ? Number(payload.pagination.returned)
@@ -78,6 +93,8 @@ export function buildCitedByDisplay(payload, {
   return {
     provisions,
     judgments,
+    provisionGroups,
+    visibleProvisionGroups,
     visibleProvisions,
     visibleJudgments,
     counts: {

--- a/src/components/citedByDisplay.test.js
+++ b/src/components/citedByDisplay.test.js
@@ -81,6 +81,38 @@ describe("buildCitedByDisplay", () => {
     expect(isCitedByUnavailableError({ status: 500 })).toBe(false);
   });
 
+  it("groups citing units under one entry per law, in first-seen order", () => {
+    const display = buildCitedByDisplay({
+      article: "6",
+      citingProvisions: [
+        provision("A", "article", "2"),
+        provision("B", "article", "9"),
+        provision("A", "recital", "recital_140"),
+      ],
+      counts: { provisions: 3, judgments: 0, total: 3 },
+      pagination: { returned: 3 },
+    });
+
+    expect(display.provisionGroups.map(({ celex, units }) => ({ celex, unitLabels: units.map((u) => u.unitLabel) }))).toEqual([
+      { celex: "A", unitLabels: ["Article 2", "Recital 140"] },
+      { celex: "B", unitLabels: ["Article 9"] },
+    ]);
+    expect(display.visibleProvisionGroups).toEqual(display.provisionGroups);
+  });
+
+  it("collapses to the initial number of laws, not units", () => {
+    const display = buildCitedByDisplay({
+      citingProvisions: Array.from({ length: 12 }, (_, index) => provision(`P${index % 6}`, "article", String(index + 1))),
+      counts: { provisions: 12, judgments: 0, total: 12 },
+      pagination: { returned: 12 },
+    });
+
+    expect(display.provisionGroups).toHaveLength(6);
+    expect(display.visibleProvisionGroups).toHaveLength(5);
+    expect(display.visibleProvisions).toHaveLength(10);
+    expect(display.hasHiddenResults).toBe(true);
+  });
+
   it("computes endpoint overflow separately from collapsed rows", () => {
     const display = buildCitedByDisplay({
       citingProvisions: Array.from({ length: 6 }, (_, index) => provision(`P${index}`, "article", String(index + 1))),

--- a/src/components/law-viewer/LawViewerContextRail.jsx
+++ b/src/components/law-viewer/LawViewerContextRail.jsx
@@ -1,5 +1,4 @@
 import { useMemo, useState } from "react";
-import { GeneralRecitals } from "../RelatedRecitals.jsx";
 import { RelatedCaseLaw } from "../RelatedCaseLaw.jsx";
 import { CrossReferences } from "../CrossReferences.jsx";
 import { CitedByPanel } from "../CitedByPanel.jsx";
@@ -15,10 +14,6 @@ function countReferences(crossReferences, articleNumber) {
   }
   return count;
 }
-
-// The children render with generous below-article spacing; strip the outer
-// margin/padding so they sit flush inside the narrow rail card.
-const BARE = "[&>div]:!mt-0 [&>div]:!px-0";
 
 // Everything before the recital's own words: "(39)" numbering and whitespace.
 function recitalSnippet(recital) {
@@ -64,9 +59,50 @@ function RailRecitalCards({ recitals, allRecitals, onSelectRecital, t }) {
           </button>
         );
       })}
-      <p className="px-1 pt-1 text-[10.5px] text-gray-400 dark:text-gray-500">
-        {t("lawViewer.railRecitalsHint")}
-      </p>
+    </div>
+  );
+}
+
+// Collapsed-by-default list of the law's general (unmatched) recitals, in the
+// same card style as the related-recital matches above it. The full-width
+// GeneralRecitals component renders an inline comma-separated paragraph that
+// falls apart in this narrow column.
+function RailGeneralRecitals({ recitalNumbers, allRecitals, onSelectRecital, t }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const recitals = useMemo(
+    () => (recitalNumbers || []).map((recitalNumber) => ({ recital_number: recitalNumber })),
+    [recitalNumbers]
+  );
+
+  if (recitals.length === 0) return null;
+
+  return (
+    <div className="border-t border-gray-100 pt-1 dark:border-gray-800">
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((current) => !current)}
+        className="flex w-full items-center justify-between gap-2 px-1 py-2 text-left text-xs font-semibold text-gray-700 transition hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+      >
+        <span>
+          {t("relatedRecitals.generalTitle")}
+          <span className="ml-1 font-normal text-gray-400 dark:text-gray-500">· {recitals.length}</span>
+        </span>
+        <span
+          aria-hidden="true"
+          className={`text-gray-400 transition-transform dark:text-gray-500 ${isOpen ? "rotate-90" : ""}`}
+        >
+          &gt;
+        </span>
+      </button>
+      {isOpen ? (
+        <RailRecitalCards
+          recitals={recitals}
+          allRecitals={allRecitals}
+          onSelectRecital={onSelectRecital}
+          t={t}
+        />
+      ) : null}
     </div>
   );
 }
@@ -75,7 +111,6 @@ export function LawViewerContextRail({
   relatedRecitals,
   orphanRecitalNumbers,
   allRecitals,
-  recitalTitlesLoading,
   onSelectRecital,
   celex,
   articleNumber,
@@ -127,20 +162,25 @@ export function LawViewerContextRail({
       <div className="max-h-[calc(100vh-9rem)] overflow-y-auto px-4 py-2">
         {tab === "recitals" ? (
           recitalsCount > 0 || (orphanRecitalNumbers?.length || 0) > 0 ? (
-            <div className={BARE}>
+            <div>
               {recitalsCount > 0 ? (
-                <RailRecitalCards
-                  recitals={relatedRecitals}
-                  allRecitals={allRecitals}
-                  onSelectRecital={onSelectRecital}
-                  t={t}
-                />
+                <>
+                  <RailRecitalCards
+                    recitals={relatedRecitals}
+                    allRecitals={allRecitals}
+                    onSelectRecital={onSelectRecital}
+                    t={t}
+                  />
+                  <p className="px-1 pb-2 text-[10.5px] text-gray-400 dark:text-gray-500">
+                    {t("lawViewer.railRecitalsHint")}
+                  </p>
+                </>
               ) : null}
-              <GeneralRecitals
+              <RailGeneralRecitals
                 recitalNumbers={orphanRecitalNumbers}
                 allRecitals={allRecitals}
-                recitalTitlesLoading={recitalTitlesLoading}
                 onSelectRecital={onSelectRecital}
+                t={t}
               />
             </div>
           ) : (
@@ -149,38 +189,34 @@ export function LawViewerContextRail({
         ) : null}
 
         {tab === "cases" ? (
-          <div className={BARE}>
-            <RelatedCaseLaw celex={celex} articleNumber={articleNumber} currentLang={currentLang} />
-          </div>
+          <RelatedCaseLaw celex={celex} articleNumber={articleNumber} currentLang={currentLang} compact />
         ) : null}
 
         {tab === "references" ? (
           refsCount > 0 ? (
-            <div className={BARE}>
-              <CrossReferences
-                articleNumber={articleNumber}
-                crossReferences={crossReferences}
-                articles={articles}
-                onSelectArticle={onSelectArticle}
-                currentLang={currentLang}
-                onOpenExternalReference={onOpenExternalReference}
-                isExternalReferencePending={isExternalReferencePending}
-              />
-            </div>
+            <CrossReferences
+              articleNumber={articleNumber}
+              crossReferences={crossReferences}
+              articles={articles}
+              onSelectArticle={onSelectArticle}
+              currentLang={currentLang}
+              onOpenExternalReference={onOpenExternalReference}
+              isExternalReferencePending={isExternalReferencePending}
+              compact
+            />
           ) : (
             <p className="py-6 text-center text-xs text-gray-400 dark:text-gray-500">{t("lawViewer.tabEmptyReferences")}</p>
           )
         ) : null}
 
         {tab === "citedBy" ? (
-          <div className={BARE}>
-            <CitedByPanel
-              celex={celex}
-              articleNumber={articleNumber}
-              currentLang={currentLang}
-              onOpenLaw={onOpenLaw}
-            />
-          </div>
+          <CitedByPanel
+            celex={celex}
+            articleNumber={articleNumber}
+            currentLang={currentLang}
+            onOpenLaw={onOpenLaw}
+            compact
+          />
         ) : null}
       </div>
     </div>

--- a/src/utils/lawDisplay.js
+++ b/src/utils/lawDisplay.js
@@ -1,0 +1,49 @@
+import { inferOfficialReferenceFromCelex } from "./library.js";
+
+export function formatOfficialReference(reference) {
+  if (!reference?.actType || !reference?.year || !reference?.number) return null;
+  const actTypeLabel = reference.actType.charAt(0).toUpperCase() + reference.actType.slice(1);
+  return `${actTypeLabel} (EU) ${reference.year}/${reference.number}`;
+}
+
+export function cleanLawTitle(title, referenceLabel) {
+  const raw = String(title || "").replace(/\s+/g, " ").trim();
+  if (!raw || !referenceLabel) return raw;
+  const escapedReference = referenceLabel.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return raw.replace(new RegExp(`^${escapedReference}\\s+`, "i"), "").trim() || raw;
+}
+
+// Official EU titles bury the memorable name in parentheses ("… (General Data
+// Protection Regulation)"); pull out the first parenthetical that isn't the
+// EEA-relevance boilerplate.
+export function extractShortLawTitle(title) {
+  const raw = String(title || "").replace(/\s+/g, " ").trim();
+  if (!raw) return "";
+
+  const matches = Array.from(raw.matchAll(/\(([^)]{5,120})\)/g));
+  for (const match of matches) {
+    const candidate = String(match[1] || "").trim();
+    if (!candidate) continue;
+    if (/text with eea relevance/i.test(candidate)) continue;
+    return candidate;
+  }
+
+  return "";
+}
+
+// Compact one-line label for a law where the full official title would be
+// overwhelming (e.g. list rows, the context rail). Returns the short name
+// with the official reference when both exist, and the full title separately
+// for use as a tooltip.
+export function buildLawDisplayLabel({ celex, title } = {}) {
+  const referenceLabel = formatOfficialReference(inferOfficialReferenceFromCelex(celex));
+  const shortTitle = extractShortLawTitle(title);
+  const label = shortTitle && referenceLabel
+    ? `${shortTitle} — ${referenceLabel}`
+    : shortTitle
+      || referenceLabel
+      || String(title || "").replace(/\s+/g, " ").trim()
+      || String(celex || "");
+  const fullTitle = String(title || "").replace(/\s+/g, " ").trim();
+  return { label, fullTitle: fullTitle && fullTitle !== label ? fullTitle : "" };
+}

--- a/src/utils/lawDisplay.test.js
+++ b/src/utils/lawDisplay.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildLawDisplayLabel, cleanLawTitle, extractShortLawTitle, formatOfficialReference } from "./lawDisplay.js";
+
+const GDPR_TITLE = "Regulation (EU) 2016/679 of the European Parliament and of the Council of 27 April 2016 "
+  + "on the protection of natural persons with regard to the processing of personal data and on the free "
+  + "movement of such data, and repealing Directive 95/46/EC (General Data Protection Regulation) "
+  + "(Text with EEA relevance)";
+
+describe("extractShortLawTitle", () => {
+  it("pulls the parenthesised short name, skipping EEA boilerplate", () => {
+    expect(extractShortLawTitle(GDPR_TITLE)).toBe("General Data Protection Regulation");
+  });
+
+  it("returns empty when no usable parenthetical exists", () => {
+    expect(extractShortLawTitle("Regulation (EU) 2019/817 of the European Parliament")).toBe("");
+    expect(extractShortLawTitle("")).toBe("");
+  });
+});
+
+describe("formatOfficialReference", () => {
+  it("formats a full reference and rejects partial ones", () => {
+    expect(formatOfficialReference({ actType: "regulation", year: "2016", number: "679" })).toBe("Regulation (EU) 2016/679");
+    expect(formatOfficialReference({ actType: "regulation", year: "2016" })).toBe(null);
+    expect(formatOfficialReference(null)).toBe(null);
+  });
+});
+
+describe("cleanLawTitle", () => {
+  it("strips a leading official reference", () => {
+    expect(cleanLawTitle("Regulation (EU) 2016/679 of the European Parliament", "Regulation (EU) 2016/679"))
+      .toBe("of the European Parliament");
+  });
+});
+
+describe("buildLawDisplayLabel", () => {
+  it("combines short name and CELEX-derived reference", () => {
+    const { label, fullTitle } = buildLawDisplayLabel({ celex: "32016R0679", title: GDPR_TITLE });
+    expect(label).toBe("General Data Protection Regulation — Regulation (EU) 2016/679");
+    expect(fullTitle).toBe(GDPR_TITLE.replace(/\s+/g, " ").trim());
+  });
+
+  it("falls back to the reference alone when the title has no short name", () => {
+    const { label } = buildLawDisplayLabel({
+      celex: "32019R0817",
+      title: "Regulation (EU) 2019/817 of the European Parliament and of the Council of 20 May 2019 on establishing a framework for interoperability",
+    });
+    expect(label).toBe("Regulation (EU) 2019/817");
+  });
+
+  it("falls back to title, then celex, for non-standard celexes", () => {
+    expect(buildLawDisplayLabel({ celex: "52020PC0001", title: "Some proposal title" }).label).toBe("Some proposal title");
+    expect(buildLawDisplayLabel({ celex: "52020PC0001", title: "" }).label).toBe("52020PC0001");
+  });
+});


### PR DESCRIPTION
## Problem

The context rail (right-hand tabs on wide screens) mounted the full-width below-article components as-is behind a `[&>div]:!mt-0` CSS-override hack. In a ~300px column that produced:

- **Cited by**: the full 60-word official title of every citing law, repeated once per citing unit, with reference chips squeezed alongside.
- **Recitals**: "General recitals" rendered as an inline comma-separated paragraph that wrapped into broken underlined fragments with stray commas.
- **Case law**: two cramped card columns, and duplicate headers.
- **References / Case law**: content collapsed by default, needing an unintuitive extra click inside an already-selected tab.

## Changes

- **`CitedByPanel`**: citing laws are labelled with their short name + CELEX-derived reference (e.g. "Digital Markets Act — Regulation (EU) 2022/1925"), full official title on hover. Units are grouped one entry per law with clickable chips (Article 48, Recital 36, …) instead of one row per unit; "show all" now paginates laws, not units (`citedByDisplay.js`). New `compact` prop for the rail.
- **`src/utils/lawDisplay.js`** (new): `extractShortLawTitle` / `formatOfficialReference` / `cleanLawTitle` moved out of `TopBar`, plus `buildLawDisplayLabel`; `TopBar` now imports them.
- **`CrossReferences` / `RelatedCaseLaw`**: `compact` variants — no redundant header (the tab already labels them), expanded by default, single-column judgment cards.
- **Rail recitals**: new card-style `RailGeneralRecitals` disclosure replacing the inline paragraph; the `BARE` CSS hack is removed entirely.

The full-width below-article variants (shown under 1280px) are unchanged in appearance.

## Testing

- `npm run lint`, `npm run test:web`: 344/344 passing, incl. new tests for grouping and `lawDisplay`.
- Verified in-browser (GDPR Art. 6/17): all four rail tabs, the full-width variant, and chip navigation to the citing law's article (using a local citation-graph fixture, since the real graph isn't built locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)