### PR TITLE
Add a Cited-by card with top citing laws to the law overview

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -480,10 +480,10 @@ The offline citation graph provides reverse lookups across the locally harvested
 ```bash
 npm run build:citation-graph
 curl "http://localhost:3000/api/laws/32016R0679/articles/6/cited-by?limit=50&offset=0"
-curl "http://localhost:3000/api/laws/32016R0679/cited-by"
+curl "http://localhost:3000/api/laws/32016R0679/cited-by?citingLaws=10"
 ```
 
-The article endpoint returns paginated citing provisions and judgments. The act endpoint returns aggregate counts split between act-only and article-specific citations. The MCP endpoint exposes the same data through `get_citing_provisions`; omit its `article` argument to request act-level counts. If the artifact has not been built or cannot be loaded, these queries return `503` with `code=citation_graph_unavailable`.
+The article endpoint returns paginated citing provisions and judgments. The act endpoint returns aggregate counts split between act-only and article-specific citations, plus `citingLaws` — the top citing acts (legislation only) ranked by how many distinct provisions cite the target, capped by the `citingLaws` query parameter (default 10, max 50). The MCP endpoint exposes the same data through `get_citing_provisions`; omit its `article` argument to request act-level counts. If the artifact has not been built or cannot be loaded, these queries return `503` with `code=citation_graph_unavailable`.
 
 The default artifact is `search/data/citation-graph.json`. Restart the API after rebuilding it, because it is loaded once at startup. Like the search and case-law caches, the graph is **not committed** — a fresh deploy fetches `citation-graph.json.gz` as a **GitHub Release asset** at Docker build time (see `backend/Dockerfile`, `DATA_RELEASE_TAG`); the store gunzips it at startup when the raw file is absent, and a local rebuild still wins. To publish a new build: rebuild the graph against the current corpus and case-law cache, `gzip -k` the artifact, upload `citation-graph.json.gz` to the `DATA_RELEASE_TAG` release, and redeploy.
 

--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -158,7 +158,8 @@ function registerApiRoutes(app, deps) {
       if (!validateCelex(celex)) {
         return res.status(400).json({ error: 'Invalid CELEX format', code: 'invalid_celex' });
       }
-      res.json(requireCitationGraph(citationGraphStore).getActCitations(celex));
+      const citingLawsLimit = parsePaginationValue(req.query.citingLaws, 'citingLaws', { defaultValue: 10, min: 1, max: 50 });
+      res.json(requireCitationGraph(citationGraphStore).getActCitations(celex, { citingLawsLimit }));
     } catch (err) {
       safeErrorResponse(res, err, 'Failed to fetch citation counts');
     }
@@ -685,7 +686,7 @@ function registerApiRoutes(app, deps) {
         'GET /api/laws/:celex/info': 'Get metadata only',
         'GET /api/laws/by-reference?actType=directive&year=2018&number=1972&lang=ENG': 'Resolve an official reference and fetch the matching FMX',
         'GET /api/laws/:celex/case-law': 'List CJEU judgments that interpret this law',
-        'GET /api/laws/:celex/cited-by': 'Get reverse-citation counts for an act',
+        'GET /api/laws/:celex/cited-by?citingLaws=10': 'Get reverse-citation counts and top citing laws for an act',
         'GET /api/laws/:celex/articles/:n/cited-by?limit=50&offset=0': 'List provisions and judgments citing an article',
         'GET /api/laws/:celex/recital-titles?lang=ENG': 'Get cached AI-generated short titles for recitals',
         'GET /api/laws/:celex/summary': 'Get cached static summary of what this law does (English only)',

--- a/backend/routes/api-routes.test.js
+++ b/backend/routes/api-routes.test.js
@@ -255,6 +255,30 @@ test('GET article cited-by rejects pagination outside its bounds', async () => {
   assert.equal(res.payload.code, 'invalid_pagination');
 });
 
+test('GET act cited-by passes the validated citing-laws limit to the citation graph', async () => {
+  const calls = [];
+  const { app } = registerTestRoutes({
+    citationGraphStore: {
+      isReady: () => true,
+      getActCitations: (celex, options) => {
+        calls.push({ celex, options });
+        return { celex, citingLaws: { total: 0, laws: [] }, totals: { total: 0 } };
+      },
+    },
+  });
+  const handler = app.routes.get('/api/laws/:celex/cited-by');
+  const res = createResponseRecorder();
+  await handler({ params: { celex: '32016R0679' }, query: { citingLaws: '25' } }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(calls, [{ celex: '32016R0679', options: { citingLawsLimit: 25 } }]);
+
+  const invalid = createResponseRecorder();
+  await handler({ params: { celex: '32016R0679' }, query: { citingLaws: '51' } }, invalid);
+  assert.equal(invalid.statusCode, 400);
+  assert.equal(invalid.payload.code, 'invalid_pagination');
+});
+
 test('GET act cited-by maps an unavailable graph to 503', async () => {
   const { app } = registerTestRoutes({
     citationGraphStore: { isReady: () => false, getStatus: () => ({ ready: false, reason: 'missing' }) },

--- a/backend/search/citation-graph-store.js
+++ b/backend/search/citation-graph-store.js
@@ -266,9 +266,10 @@ class CitationGraphStore {
     };
   }
 
-  getActCitations(celex) {
+  getActCitations(celex, options = {}) {
     this.assertReady();
     const targetCelex = normalize(celex);
+    const citingLawsLimit = Math.max(1, Math.min(Number.parseInt(options.citingLawsLimit, 10) || 10, 50));
     const edges = this.edgesForAct(targetCelex);
     const actOnly = edges.filter((edge) => edge.targetArticle == null || String(edge.targetArticle).trim() === "");
     const article = edges.filter((edge) => edge.targetArticle != null && String(edge.targetArticle).trim() !== "");
@@ -282,13 +283,37 @@ class CitationGraphStore {
     const articles = [...byArticle.entries()]
       .sort(([a], [b]) => a.localeCompare(b, "en", { numeric: true }))
       .map(([citedArticle, articleEdges]) => ({ article: citedArticle, ...countsFor(articleEdges) }));
+    // Top citing acts: legislation only (a judgment is a single source, so a
+    // "top" ranking is meaningless there — the case-law endpoints cover them),
+    // ranked by how many distinct provisions of the citing act reference this one.
+    const bySourceCelex = new Map();
+    for (const edge of edges) {
+      if (edge.kind !== "legislation") continue;
+      const key = normalize(edge.sourceCelex);
+      if (!key) continue;
+      const entries = bySourceCelex.get(key) || [];
+      entries.push(edge);
+      bySourceCelex.set(key, entries);
+    }
+    const rankedCitingLaws = [...bySourceCelex.entries()]
+      .map(([sourceCelex, lawEdges]) => ({
+        celex: sourceCelex,
+        title: lawEdges.find((edge) => edge.sourceTitle)?.sourceTitle || null,
+        provisions: distinctSources(lawEdges).length,
+      }))
+      .sort((a, b) => b.provisions - a.provisions
+        || a.celex.localeCompare(b.celex, "en", { numeric: true }));
+    const citingLaws = {
+      total: rankedCitingLaws.length,
+      laws: rankedCitingLaws.slice(0, citingLawsLimit),
+    };
     // `actOnly`, `article`, and `totals` each count *distinct source provisions*
     // within their own edge subset, so they intentionally do NOT sum: a single
     // provision that cites both the act generally and a specific article is
     // counted once in `actOnly` and once in `article`, but only once in
     // `totals` (which dedups across every edge). Treat `totals` as the
     // authoritative distinct-source count; do not derive it from the parts.
-    return { celex: targetCelex, actOnly: countsFor(actOnly), article: countsFor(article), articles, totals: countsFor(edges) };
+    return { celex: targetCelex, actOnly: countsFor(actOnly), article: countsFor(article), articles, citingLaws, totals: countsFor(edges) };
   }
 }
 

--- a/backend/search/citation-graph-store.test.js
+++ b/backend/search/citation-graph-store.test.js
@@ -88,8 +88,42 @@ test("act query separates act-only references from article references", () => {
     actOnly: { provisions: 1, judgments: 0, total: 1 },
     article: { provisions: 1, judgments: 1, total: 2 },
     articles: [{ article: "6", provisions: 1, judgments: 1, total: 2 }],
+    citingLaws: {
+      total: 2,
+      laws: [
+        { celex: "32024R0001", title: "A", provisions: 1 },
+        { celex: "32024R0002", title: "B", provisions: 1 },
+      ],
+    },
     totals: { provisions: 2, judgments: 1, total: 3 },
   });
+});
+
+test("act query ranks citing laws by distinct provisions and honours the limit", () => {
+  const rankedEdges = [
+    // 32024R0005 cites from two distinct provisions (article 1 twice, recital 3 once).
+    { kind: "legislation", sourceCelex: "32024R0005", sourceTitle: "Busy citer", sourceUnitType: "article", sourceUnit: "1", targetCelex: "32016R0679", targetArticle: "6", targetParagraph: null, targetPoint: null },
+    { kind: "legislation", sourceCelex: "32024R0005", sourceTitle: "Busy citer", sourceUnitType: "article", sourceUnit: "1", targetCelex: "32016R0679", targetArticle: "17", targetParagraph: null, targetPoint: null },
+    { kind: "legislation", sourceCelex: "32024R0005", sourceTitle: null, sourceUnitType: "recital", sourceUnit: "recital_3", targetCelex: "32016R0679", targetArticle: null, targetParagraph: null, targetPoint: null },
+    { kind: "legislation", sourceCelex: "32024R0004", sourceTitle: "Single citer", sourceUnitType: "article", sourceUnit: "9", targetCelex: "32016R0679", targetArticle: "6", targetParagraph: null, targetPoint: null },
+    // Judgments never appear in citingLaws.
+    { kind: "judgment", sourceCelex: "62020CJ0001", sourceTitle: "Case", sourceUnitType: "judgment", sourceUnit: "62020CJ0001", targetCelex: "32016R0679", targetArticle: "6", targetParagraph: null, targetPoint: null },
+  ];
+  const store = new CitationGraphStore(writeGraph({ graphVersion: GRAPH_VERSION, edges: rankedEdges }));
+  assert.equal(store.load(), true);
+
+  const result = store.getActCitations("32016R0679");
+  assert.deepEqual(result.citingLaws, {
+    total: 2,
+    laws: [
+      { celex: "32024R0005", title: "Busy citer", provisions: 2 },
+      { celex: "32024R0004", title: "Single citer", provisions: 1 },
+    ],
+  });
+
+  const limited = store.getActCitations("32016R0679", { citingLawsLimit: 1 });
+  assert.equal(limited.citingLaws.total, 2);
+  assert.deepEqual(limited.citingLaws.laws, [{ celex: "32024R0005", title: "Busy citer", provisions: 2 }]);
 });
 
 test("act query dedups a provision citing both the act and an article across subsets", () => {

--- a/src/components/LawViewer.jsx
+++ b/src/components/LawViewer.jsx
@@ -329,6 +329,7 @@ export function LawViewer() {
                   onPrint={() => printState.setPrintModalOpen(true)}
                   externalLawOverview={derived.externalLawOverview}
                   onOpenExternalLaw={interactions.handleOpenExternalLaw}
+                  onOpenCitedLaw={interactions.handleOpenLawByCelex}
                   isExternalReferencePending={interactions.isExternalReferencePending}
                   locale={locale}
                   t={t}

--- a/src/components/MetadataPanel.jsx
+++ b/src/components/MetadataPanel.jsx
@@ -2,9 +2,10 @@ import { useState } from "react";
 import { ExternalLink, Loader2 } from "lucide-react";
 import { buildEurlexCelexUrl } from "../utils/url.js";
 import { formatMetaDate } from "../utils/formatMetaDate.js";
+import { buildLawDisplayLabel } from "../utils/lawDisplay.js";
 import { Pill } from "./ui/Pill.jsx";
 
-function MetaCard({ title, count, emptyText, rows, cap = 4, t }) {
+function MetaCard({ title, count, subtitle, emptyText, rows, cap = 4, t }) {
   const [expanded, setExpanded] = useState(false);
   const items = rows || [];
   const visible = expanded ? items : items.slice(0, cap);
@@ -15,6 +16,9 @@ function MetaCard({ title, count, emptyText, rows, cap = 4, t }) {
         <span className="text-[13px] font-semibold text-gray-900 dark:text-gray-100">{title}</span>
         <span className="font-mono text-[11px] text-gray-400 dark:text-gray-500">{count}</span>
       </div>
+      {subtitle ? (
+        <div className="mb-1 text-[11px] text-gray-400 dark:text-gray-500">{subtitle}</div>
+      ) : null}
       {items.length === 0 ? (
         <div className="border-t border-gray-100 pt-2 text-xs italic text-gray-400 dark:border-gray-800 dark:text-gray-500">
           {emptyText}
@@ -66,17 +70,24 @@ function ActRow({ act, currentLang, locale, variant, pillLabel }) {
 }
 
 /**
- * Overview metadata cards: amendment history, implementing/delegated acts and
- * linked legislation. Consumes the shared useLawMetadata result (no fetching of
- * its own) plus the crossreference-derived linked-law overview.
+ * Overview metadata cards: amendment history, implementing/delegated acts,
+ * linked legislation and reverse citations. Consumes the shared useLawMetadata
+ * result (no fetching of its own) plus the crossreference-derived linked-law
+ * overview.
+ *
+ * `citedBy` is the act-level citation-graph payload; when it is null (graph
+ * unavailable or the fetch failed) the card is omitted entirely rather than
+ * rendered empty.
  */
 export function MetadataPanel({
   amendments,
   implementing,
   externalLawOverview = [],
+  citedBy = null,
   currentLang = "EN",
   locale = "en",
   onOpenExternalLaw,
+  onOpenCitedLaw,
   isExternalReferencePending,
   t,
 }) {
@@ -125,8 +136,33 @@ export function MetadataPanel({
     );
   });
 
+  const citingLaws = citedBy?.citingLaws?.laws || [];
+  const citedByRows = citingLaws.map((law) => {
+    const { label, fullTitle } = buildLawDisplayLabel(law);
+    return (
+      <button
+        key={law.celex}
+        type="button"
+        title={fullTitle || undefined}
+        onClick={() => onOpenCitedLaw?.(law.celex, { label: law.title })}
+        className="flex w-full items-baseline gap-2 border-t border-gray-100 py-2 text-left text-xs dark:border-gray-800"
+      >
+        <span className="min-w-0 flex-1 leading-snug text-gray-700 dark:text-gray-300">{label}</span>
+        <span className="shrink-0 whitespace-nowrap text-[11px] text-gray-400 dark:text-gray-500">
+          {t("lawOverview.citedTimes", { count: law.provisions })}
+        </span>
+      </button>
+    );
+  });
+  const citedBySubtitle = citedBy
+    ? t("lawOverview.citedByCounts", {
+        provisions: citedBy.totals?.provisions ?? 0,
+        judgments: citedBy.totals?.judgments ?? 0,
+      })
+    : null;
+
   return (
-    <div className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <div className={`mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 ${citedBy ? "lg:grid-cols-4" : "lg:grid-cols-3"}`}>
       <MetaCard
         title={t("amendmentHistory.title")}
         count={amendmentRows.length}
@@ -148,6 +184,16 @@ export function MetadataPanel({
         rows={linkedRows}
         t={t}
       />
+      {citedBy ? (
+        <MetaCard
+          title={t("citedBy.title")}
+          count={citedBy.citingLaws?.total ?? citedByRows.length}
+          subtitle={citedBySubtitle}
+          emptyText={t("citedBy.empty")}
+          rows={citedByRows}
+          t={t}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/law-viewer/LawOverviewPage.jsx
+++ b/src/components/law-viewer/LawOverviewPage.jsx
@@ -90,6 +90,7 @@ export function LawOverviewPage({
   onPrint,
   externalLawOverview = [],
   onOpenExternalLaw,
+  onOpenCitedLaw,
   isExternalReferencePending,
   locale = "en",
   t,
@@ -205,9 +206,11 @@ export function LawOverviewPage({
         amendments={meta.amendments}
         implementing={meta.implementing}
         externalLawOverview={externalLawOverview}
+        citedBy={meta.citedBy}
         currentLang={formexLang}
         locale={locale}
         onOpenExternalLaw={onOpenExternalLaw}
+        onOpenCitedLaw={onOpenCitedLaw}
         isExternalReferencePending={isExternalReferencePending}
         t={t}
       />

--- a/src/hooks/useLawMetadata.js
+++ b/src/hooks/useLawMetadata.js
@@ -1,16 +1,17 @@
 import { useState, useEffect } from "react";
-import { fetchLawMetadata, fetchAmendments, fetchImplementingActs } from "../utils/formexApi.js";
+import { fetchLawMetadata, fetchAmendments, fetchImplementingActs, fetchLawCitedBy } from "../utils/formexApi.js";
 
 // Cellar's sentinel for "open-ended" (still in force).
 const IN_FORCE_SENTINEL = "9999-12-31";
 
 /**
- * Single, error-tolerant fetch of a law's EU metadata, amendment history and
- * implementing/delegated acts, keyed by CELEX. Shared by the overview header
- * (status pill + dates) and the metadata cards so a law is only fetched once.
+ * Single, error-tolerant fetch of a law's EU metadata, amendment history,
+ * implementing/delegated acts and reverse citations, keyed by CELEX. Shared by
+ * the overview header (status pill + dates) and the metadata cards so a law is
+ * only fetched once.
  *
- * All three requests are best-effort: a failure resolves to an empty/absent
- * value rather than throwing, so the caller can simply omit whatever is missing.
+ * All requests are best-effort: a failure resolves to an empty/absent value
+ * rather than throwing, so the caller can simply omit whatever is missing.
  */
 export function useLawMetadata(celex) {
   const [metadata, setMetadata] = useState(null);
@@ -19,6 +20,8 @@ export function useLawMetadata(celex) {
   const [amendmentsLoaded, setAmendmentsLoaded] = useState(false);
   const [implementing, setImplementing] = useState(null);
   const [implementingLoaded, setImplementingLoaded] = useState(false);
+  const [citedBy, setCitedBy] = useState(null);
+  const [citedByLoaded, setCitedByLoaded] = useState(false);
 
   useEffect(() => {
     setMetadata(null);
@@ -27,6 +30,8 @@ export function useLawMetadata(celex) {
     setAmendmentsLoaded(false);
     setImplementing(null);
     setImplementingLoaded(false);
+    setCitedBy(null);
+    setCitedByLoaded(false);
     if (!celex) return;
 
     let cancelled = false;
@@ -45,6 +50,13 @@ export function useLawMetadata(celex) {
       .then((result) => { if (!cancelled) setImplementing(result.acts || []); })
       .catch(() => { if (!cancelled) setImplementing([]); })
       .finally(() => { if (!cancelled) setImplementingLoaded(true); });
+
+    // Reverse citations stay null (not empty) on failure so the overview can
+    // hide the card entirely when the citation graph is unavailable.
+    fetchLawCitedBy(celex)
+      .then((result) => { if (!cancelled) setCitedBy(result); })
+      .catch(() => { if (!cancelled) setCitedBy(null); })
+      .finally(() => { if (!cancelled) setCitedByLoaded(true); });
 
     return () => { cancelled = true; };
   }, [celex]);
@@ -69,6 +81,8 @@ export function useLawMetadata(celex) {
     amendmentsLoaded,
     implementing,
     implementingLoaded,
+    citedBy,
+    citedByLoaded,
     status,
   };
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -352,6 +352,7 @@
     "corrShort": "Corr.",
     "amendShort": "Amend.",
     "citedTimes": "cited {count}×",
+    "citedByCounts": "{provisions} provisions · {judgments} judgments",
     "amendmentsEmpty": "No amendments or corrigenda yet.",
     "implementingEmpty": "None adopted yet.",
     "linkedEmpty": "No linked legislation yet.",

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -856,6 +856,16 @@ export async function fetchArticleCitedBy(celex, articleNumber) {
   }));
 }
 
+export async function fetchLawCitedBy(celex) {
+  const key = `${celex}_cited_by_act`;
+  return getInFlightRequest(`law-cited-by:${key}`, () => fetchJsonWithCache({
+    cacheKey: key,
+    url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/cited-by?citingLaws=10`,
+    errorLabel: "Law cited-by fetch failed",
+    cacheFirst: true,
+  }));
+}
+
 export async function fetchCaseLawDigest(celex, lang = "EN") {
   const apiLang = toApiLang(lang);
   const key = `${celex}_${apiLang}_case_law_digest`;


### PR DESCRIPTION
## What

Adds a fourth card to the law-overview metadata row: **Cited by**, listing the top acts that cite the current law, ranked by how many distinct provisions reference it. Complements the existing (outgoing) "Linked legislation" card with the incoming view the citation graph was built for.

## Backend

- `getActCitations` (`backend/search/citation-graph-store.js`) additionally returns `citingLaws: { total, laws: [{ celex, title, provisions }] }` — legislation only, ranked by distinct citing provisions, ties broken by CELEX.
- `GET /api/laws/:celex/cited-by` accepts `?citingLaws=` (default 10, max 50, validated like the other pagination params). Endpoint docs updated in `backend/README.md`.
- No cache-version bumps: the stored graph artifact shape is unchanged; only the query output grew (SQLite/JSON parity test still passes byte-identical).

## Frontend

- New `fetchLawCitedBy` client (IndexedDB cache-first, like the article-level cited-by fetch) wired into `useLawMetadata` as a fourth best-effort request.
- `MetadataPanel` renders the card with a totals subtitle ("N provisions · M judgments"); rows use `buildLawDisplayLabel` short labels and open the citing law in the reader via `handleOpenLawByCelex`.
- The card is **omitted entirely** when the citation graph is unavailable (503/static mode), and the grid falls back from `lg:grid-cols-4` to the existing 3 columns.
- Judgments stay a count only — the CJEU Case Law button on the same page is the richer way to explore citing judgments (live SPARQL discovery), and per-judgment "top" ranking is meaningless since each judgment is a single source. Note the two numbers measure different things: the graph counts judgments whose parsed rulings cite the act (partial coverage, lower bound).

## Verification

Ran the app against a fixture graph (`CITATION_GRAPH_PATH`): card renders ranked laws on `/en/gdpr`, "Show all" expands, clicking a row opens the citing law in the reader, zero-citation laws show the empty state, and a 503 graph hides the card with the grid reverting to 3 columns. `npm test` (344 web + 322 api) and `npm run lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)