### PR TITLE
Stamp the shared parser version on HTML-parsed laws

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Nearly every expensive operation — Formex parsing, TF‑IDF recital mapping, C
 
 | When you change… | Bump | In |
 |---|---|---|
-| Parser output (fields, shape, bug fix) | `PARSER_VERSION` | `backend/shared/formex-parser/fmxParser.mjs` |
+| Parser output (fields, shape, bug fix) — **either** parser, see below | `PARSER_VERSION` | `backend/shared/formex-parser/fmxParser.mjs` |
 | Citation graph edge/artifact shape | `GRAPH_VERSION` | `backend/search/citation-graph-store.js` (shared by builder and store) |
 | Offline CJEU detail shape (declarations, `articleRefs`) | `CASE_LAW_CACHE_FILE` → `case-law-cache-vN.json` (keep the offline legacy-migration path) | `backend/shared/law-queries.js` |
 | Recital-title prompt/output format | `CACHE_VERSION` | `backend/shared/recital-title-service.js` |
@@ -69,6 +69,8 @@ Nearly every expensive operation — Formex parsing, TF‑IDF recital mapping, C
 | Precomputed data republished as a new GitHub Release (`data-vN`) | `DATA_RELEASE_TAG` → `data-vN` | `backend/Dockerfile` |
 
 The data caches are the one entry above that isn't a code constant: they ship as **GitHub Release assets** (they're far too large to commit), so republishing them means creating a new `data-vN` release **and** bumping `DATA_RELEASE_TAG` in `backend/Dockerfile` in the same commit. Skip the bump and every deploy keeps fetching the old data no matter what you rebuilt. The Dockerfile fetches **every** asset from that one tag, so a new release must carry the full set — re-upload the unchanged ones alongside the changed one, or the Docker build 404s.
+
+`PARSER_VERSION` lives in the Formex parser but versions **both** parsers' output. `eurlex-html-parser.js` reads a different document format, yet imports its cross-reference grammar (`extractCrossRefsFromText` and friends) straight from `fmxParser.mjs` — so a change there changes what HTML laws yield too, and both parsers stamp the same constant onto their result. Bump it for a fix in *either* file; there is deliberately no second constant to keep in sync.
 
 `PARSER_VERSION` is **shared with the frontend** (imported into `src/utils/formexApi.js`), so bumping it re-parses the browser IndexedDB cache too. When you bump `CASE_LAW_CACHE_FILE`, also update `CASE_LAW_CACHE_VERSION` in `article-digest-service.js` **and** `case-law-digest-service.js` — they are kept in lock-step so digests regenerate when enrichment shape changes.
 

--- a/backend/shared/eurlex-html-parser.js
+++ b/backend/shared/eurlex-html-parser.js
@@ -1055,6 +1055,10 @@ async function loadHelpers() {
         extractCrossRefsFromText: parserMod.extractCrossRefsFromText,
         repairCorroboratedTruncatedInstrumentIdentifiers: parserMod.repairCorroboratedTruncatedInstrumentIdentifiers,
         getLangConfig: langMod.getLangConfig,
+        // This parser reads a different document format, but its cross-references come
+        // from the Formex parser's grammar above — so PARSER_VERSION versions this
+        // output too, and is taken from there rather than declared a second time.
+        PARSER_VERSION: parserMod.PARSER_VERSION,
       };
     })();
   }
@@ -1071,6 +1075,7 @@ async function parseEurlexHtmlToCombined(htmlText, lang = "ENG") {
     extractCrossRefsFromText,
     repairCorroboratedTruncatedInstrumentIdentifiers,
     getLangConfig,
+    PARSER_VERSION,
   } = await loadHelpers();
   const langConfig = getLangConfig(langCode);
 
@@ -1086,6 +1091,7 @@ async function parseEurlexHtmlToCombined(htmlText, lang = "ENG") {
     });
     const checked = enforceInternalReferenceIntegrity(parsed);
     repairCorroboratedTruncatedInstrumentIdentifiers(Object.values(checked.crossReferences).flat());
+    checked.parserVersion = PARSER_VERSION;
     return checked;
   };
 
@@ -1254,6 +1260,10 @@ async function parseEurlexHtmlToCombined(htmlText, lang = "ENG") {
     definitions,
     langCode,
     crossReferences,
+    // Stamped here as well as in withCrossReferences: this oldest-era branch builds
+    // its own crossReferences (it alone passes footnotesByNumber) instead of going
+    // through that helper, so a stamp there would miss every pre-2004 OJ act.
+    parserVersion: PARSER_VERSION,
   });
   repairCorroboratedTruncatedInstrumentIdentifiers(Object.values(parsed.crossReferences).flat());
   return parsed;

--- a/backend/shared/eurlex-html-parser.test.js
+++ b/backend/shared/eurlex-html-parser.test.js
@@ -490,6 +490,31 @@ test("parseEurlexHtmlToCombined captures annexes from the older XHTML layout", a
   assert.match(parsed.annexes[0].annex_html, /legal liability of a seller or supplier/i);
 });
 
+// This parser reads a different document format from the Formex one, but it imports that
+// parser's cross-reference grammar, so a single PARSER_VERSION versions both outputs — and
+// the citation-graph builder reads this field off every parsed law to decide whether a
+// published artifact predates a parser fix. An unstamped layout reports `null` there and
+// silently exempts itself from staleness detection.
+//
+// Asserted per layout, not once: the oldest TXT_TE branch builds its own crossReferences
+// (it alone needs footnotesByNumber) rather than going through withCrossReferences, so it
+// carries a second, separate stamp. That branch is the one every pre-2004 OJ act takes —
+// the bulk of the HTML corpus — so a single-layout test would pass while it returned null.
+test("parseEurlexHtmlToCombined stamps the shared parser version on every layout", async () => {
+  const { PARSER_VERSION } = await import("./formex-parser/fmxParser.mjs");
+  const layouts = [
+    ["TXT_TE fallback", SAMPLE_HTML],
+    ["structured", STRUCTURED_HTML],
+    ["legacy XHTML", LEGACY_XHTML_HTML],
+    ["LegisWrite", LEGISWRITE_COM_HTML],
+  ];
+
+  for (const [layout, html] of layouts) {
+    const parsed = await parseEurlexHtmlToCombined(html, "ENG");
+    assert.equal(parsed.parserVersion, PARSER_VERSION, `${layout} layout must report the shared parser version`);
+  }
+});
+
 test("fetchAndParseEurlexHtmlLaw always fetches and parses the English fallback", async () => {
   const originalFetch = global.fetch;
   let requestedUrl = null;


### PR DESCRIPTION
Follow-up from the citation-graph rebuild: per-year shards for HTML-only years reported `parserVersion=null`, which turned out to be an omission rather than a design choice.

## The version already applies

`parseEurlexHtmlToCombined` returned no `parserVersion`, so every law parsed from EUR-Lex HTML reported `null` to the citation-graph builder — which reads that field off each parsed law to record which parser produced an artifact.

But the constant does govern this parser. It reads a different document *format*, yet imports its cross-reference grammar straight from `fmxParser.mjs`:

```js
const [parserMod, langMod] = await Promise.all([import("./formex-parser/fmxParser.mjs"), ...]);
return { extractCrossRefsFromText: parserMod.extractCrossRefsFromText, ... };
```

and the citation graph is built from exactly those references. #106 is the precedent: it bumped `PARSER_VERSION` **14 → 16** while changing `fmxParser.mjs` (190 lines) and `eurlex-html-parser.js` (16 lines) in the same commit. The constant was already the pipeline's version; the HTML parser just wasn't signing its work.

## Why it matters

**52,523 of 80,439 corpus laws (65%) were exempt from parser staleness detection.** A fix to the shared grammar could change what the entire HTML corpus yields while the published artifact's `parserVersion` sat still — and `GRAPH_VERSION` wouldn't move either, since it only tracks envelope shape. This is the failure mode the cache-version table exists to prevent.

## Stamped twice, deliberately

Of the four layout branches, three funnel through `withCrossReferences` — but the oldest `TXT_TE` fallback builds its own `crossReferences` (it alone passes `footnotesByNumber`) and returns directly. **That branch is the one every pre-2004 OJ act takes**, so stamping only the helper would have left the bulk of the HTML corpus reporting `null` — a fix whose symptom never changes.

## Verification

- **Mutation-tested**: removing either stamp fails a different layout (`TXT_TE fallback` / `structured`).
- **Against the corpus**: the four 1953 acts that reported `null` now report 16. All four take the fallback branch, confirmed by their layout markers.
- Checked `enforceInternalReferenceIntegrity` mutates and returns its argument rather than rebuilding it from a whitelist, so the field survives — the silent-drop class we hit in #113.
- Backend suite: 319 passing, 0 failing, 2 skipped. Lint clean.

The test asserts each layout against `fmxParser`'s constant rather than a literal, so it survives the next bump and pins the invariant instead: one version, one pipeline.

No artifact impact: FMX years already contribute 16, so a merged graph's version is 16 either way. This only makes per-law reporting honest going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)