### PR TITLE
Drop "Related instruments" from the AI law summary

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -303,10 +303,7 @@ The backend stores titles in `recital-title-cache-v1.json` with a cache `version
     "keyObligations": [
       { "text": "…", "citations": ["5"] }
     ],
-    "structure": "…",
-    "relatedInstruments": [
-      { "label": "Directive 95/46/EC", "celex": "31995L0046", "relationship": "…" }
-    ]
+    "structure": "…"
   }
 }
 ```

--- a/backend/shared/law-summary-service.js
+++ b/backend/shared/law-summary-service.js
@@ -2,7 +2,6 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const { chatComplete } = require('./openrouter-chat');
-const { ACT_CELEX_MAP } = require('./law-queries');
 const { inferTypeFromCelex } = require('../search/search-ranking');
 const {
   stripTags,
@@ -15,12 +14,11 @@ const {
 
 const CACHE_FILE = 'law-summary-cache-v1.json';
 const CACHE_VERSION = 1;
-const SCHEMA_VERSION = 2;
-const PROMPT_VERSION = 2;
+const SCHEMA_VERSION = 3;
+const PROMPT_VERSION = 3;
 const MAX_ARTICLE_TEXT_CHARS = 6000;
 const MAX_RECITAL_COUNT = 60;
 const MAX_RECITAL_TEXT_CHARS = 700;
-const MAX_RELATED_CANDIDATES = 12;
 const MAX_ARTICLE_TEXT_BUDGET_CHARS = 500000;
 
 const ACT_TYPE_GUIDANCE = {
@@ -45,18 +43,15 @@ Return ONLY a JSON object with this exact shape:
   "keyPoints": [
     { "text": "one concrete obligation, right, power, or prohibition", "citations": ["5"] }
   ],
-  "structure": "short narrative of how the chapters/sections are organised",
-  "relatedInstruments": [
-    { "label": "instrument name or reference from the candidates", "celex": "optional CELEX from candidates", "relationship": "why it is related" }
-  ]
+  "structure": "short narrative of how the chapters/sections are organised"
 }
 
 Rules:
-- Use only the provided law input and related-instrument candidates.
+- Use only the provided law input.
 - Every scope and key-point item must cite existing article numbers from the provided article list.
 - Prefer 3-6 key points.
 - Keep the whole output under about 400 words.
-- Do not invent article numbers, CELEX identifiers, instruments, obligations, or legal effects.`;
+- Do not invent article numbers, obligations, or legal effects.`;
 }
 
 // Sentence-boundary-aware truncation, specific to the summary feature (the
@@ -118,53 +113,6 @@ function cachedResult(entry) {
   };
 }
 
-function findKnownCelex(label, actCelexMap = ACT_CELEX_MAP) {
-  const text = String(label || '');
-  if (!text) return null;
-  for (const [alias, celex] of Object.entries(actCelexMap || {})) {
-    if (!celex) continue;
-    if (alias.includes('/') && text.toLowerCase().includes(alias.toLowerCase())) {
-      return celex;
-    }
-    const escaped = alias.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    if (new RegExp(`(^|[^A-Za-z0-9/])${escaped}([^A-Za-z0-9/]|$)`, 'i').test(text)) {
-      return celex;
-    }
-  }
-  return null;
-}
-
-function buildRelatedInstrumentCandidates(crossReferences, actCelexMap = ACT_CELEX_MAP) {
-  const candidates = new Map();
-  for (const refs of Object.values(crossReferences || {})) {
-    for (const ref of refs || []) {
-      if (ref?.type !== 'external' && ref?.type !== 'oj_ref') continue;
-      const label = ref.raw || ref.target;
-      if (!label) continue;
-      const key = ref.type === 'oj_ref'
-        ? `oj:${ref.ojColl || ''}:${ref.ojYear || ''}:${ref.ojNo || ''}`
-        : `external:${ref.target || label}`;
-      const celex = ref.celex || ref.actCelex || findKnownCelex(label, actCelexMap);
-      const existing = candidates.get(key);
-      if (existing) {
-        existing.count += 1;
-      } else {
-        candidates.set(key, {
-          key,
-          label,
-          celex,
-          type: ref.type,
-          count: 1,
-        });
-      }
-    }
-  }
-
-  return Array.from(candidates.values())
-    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label))
-    .slice(0, MAX_RELATED_CANDIDATES);
-}
-
 function buildSkeleton(articles) {
   return (articles || []).map((article) => ({
     number: String(article.article_number || '').trim(),
@@ -174,7 +122,7 @@ function buildSkeleton(articles) {
   })).filter((article) => article.number);
 }
 
-function buildLawSummaryInput(parsedLaw, { actCelexMap = ACT_CELEX_MAP } = {}) {
+function buildLawSummaryInput(parsedLaw) {
   let articleTextBudgetUsed = 0;
   const articles = (parsedLaw.articles || [])
     .map((article) => {
@@ -212,7 +160,6 @@ function buildLawSummaryInput(parsedLaw, { actCelexMap = ACT_CELEX_MAP } = {}) {
       text: clip(recital.recital_text || recital.recital_html || '', MAX_RECITAL_TEXT_CHARS),
     })).filter((recital) => recital.number && recital.text),
     articles,
-    relatedInstrumentCandidates: buildRelatedInstrumentCandidates(parsedLaw.crossReferences || {}, actCelexMap),
   };
 }
 
@@ -244,33 +191,6 @@ function normalizeCitedBlock(value, validArticles, { requireCitation = false } =
   return { text, citations };
 }
 
-function normalizeRelatedInstruments(value, candidates) {
-  const candidateByCelex = new Map();
-  const candidateByLabel = new Map();
-  for (const candidate of candidates || []) {
-    if (candidate.celex) candidateByCelex.set(candidate.celex, candidate);
-    candidateByLabel.set(String(candidate.label).toLowerCase(), candidate);
-  }
-
-  return (Array.isArray(value) ? value : [])
-    .map((entry) => {
-      if (!entry || typeof entry !== 'object') return null;
-      const label = normalizeText(entry.label, 220);
-      const celex = normalizeText(entry.celex, 40) || null;
-      const relationship = normalizeText(entry.relationship, 320);
-      const candidate = (celex && candidateByCelex.get(celex))
-        || candidateByLabel.get(label.toLowerCase());
-      if (!label || !relationship || !candidate) return null;
-      return {
-        label: candidate.label,
-        celex: candidate.celex || celex || null,
-        relationship,
-      };
-    })
-    .filter(Boolean)
-    .slice(0, 6);
-}
-
 function parseLawSummaryJson(text, input) {
   const parsed = extractJsonObject(text);
   const validArticles = new Set([
@@ -284,7 +204,6 @@ function parseLawSummaryJson(text, input) {
     .filter(Boolean)
     .slice(0, 8);
   const structure = normalizeText(parsed.structure, 1000);
-  const relatedInstruments = normalizeRelatedInstruments(parsed.relatedInstruments, input.relatedInstrumentCandidates || []);
 
   if (!purpose?.text) throw new Error('Summary is missing purpose');
   if (!scope?.text) throw new Error('Summary is missing cited scope');
@@ -296,7 +215,6 @@ function parseLawSummaryJson(text, input) {
     scope,
     keyPoints,
     structure,
-    relatedInstruments,
   };
 }
 
@@ -314,7 +232,6 @@ function buildUserPrompt(input) {
     definitions: input.definitions,
     openingRecitals: input.recitals,
     articles: input.articles,
-    relatedInstrumentCandidates: input.relatedInstrumentCandidates,
   }, null, 2);
 }
 

--- a/backend/shared/law-summary-service.test.js
+++ b/backend/shared/law-summary-service.test.js
@@ -32,13 +32,10 @@ function sampleParsedLaw() {
     ],
     recitals: [{ recital_number: '1', recital_text: 'Protection of natural persons.' }],
     definitions: [{ term: 'personal data', sourceArticle: '4' }],
-    crossReferences: {
-      1: [{ type: 'external', raw: 'Directive 95/46/EC', target: 'Directive 95/46/EC' }],
-    },
   };
 }
 
-test('parseLawSummaryJson keeps only valid article citations and related instruments', () => {
+test('parseLawSummaryJson keeps only valid article citations', () => {
   const input = buildLawSummaryInput(sampleParsedLaw());
   const summary = parseLawSummaryJson(JSON.stringify({
     purpose: { text: 'It protects personal data.', citations: ['1', '999'] },
@@ -48,16 +45,10 @@ test('parseLawSummaryJson keeps only valid article citations and related instrum
       { text: 'Invalid point is dropped.', citations: ['999'] },
     ],
     structure: 'It starts with general provisions and then sets principles.',
-    relatedInstruments: [
-      { label: 'Directive 95/46/EC', celex: '31995L0046', relationship: 'Predecessor data-protection framework.' },
-      { label: 'Invented Act', celex: '39999X0000', relationship: 'Should be rejected.' },
-    ],
   }), input);
 
   assert.deepEqual(summary.purpose.citations, ['1']);
   assert.deepEqual(summary.keyPoints.map((item) => item.citations), [['5']]);
-  assert.equal(summary.relatedInstruments.length, 1);
-  assert.equal(summary.relatedInstruments[0].celex, '31995L0046');
 });
 
 test('ensureLawSummary caches validated summaries', async () => {
@@ -73,7 +64,6 @@ test('ensureLawSummary caches validated summaries', async () => {
         scope: { text: 'It applies to personal data processing.', citations: ['1'] },
         keyPoints: [{ text: 'Data must be processed lawfully.', citations: ['5'] }],
         structure: 'It starts with general provisions and then sets principles.',
-        relatedInstruments: [{ label: 'Directive 95/46/EC', celex: '31995L0046', relationship: 'Predecessor framework.' }],
       }),
     };
   };
@@ -147,7 +137,6 @@ test('overall article budget drops bodies but keeps every article number citable
     scope: { text: 'It applies broadly.', citations: [droppedArticle.number] },
     keyPoints: [{ text: 'A rule still cites a body-trimmed article.', citations: [droppedArticle.number] }],
     structure: 'It is organised into many articles.',
-    relatedInstruments: [],
   }), input);
 
   assert.deepEqual(summary.scope.citations, [droppedArticle.number]);
@@ -174,7 +163,6 @@ function stubChatComplete(counter) {
         scope: { text: 'It applies to personal data processing.', citations: ['1'] },
         keyPoints: [{ text: 'Data must be processed lawfully.', citations: ['5'] }],
         structure: 'It starts with general provisions and then sets principles.',
-        relatedInstruments: [],
       }),
     };
   };

--- a/scripts/generate-prerendered-law-pages.js
+++ b/scripts/generate-prerendered-law-pages.js
@@ -141,14 +141,6 @@ function buildLawSummarySection(law, summaryPayload) {
   const keyPointsHtml = (summary.keyPoints || [])
     .map((item) => `<li>${citedText(law, item)}</li>`)
     .join("");
-  const relatedInstrumentsHtml = (summary.relatedInstruments || [])
-    .map((item) => {
-      const celexSuffix = item.celex ? ` (${escapeHtml(item.celex)})` : "";
-      const relationship = item.relationship ? ` — ${escapeHtml(item.relationship)}` : "";
-      return `<li>${escapeHtml(item.label || "")}${celexSuffix}${relationship}</li>`;
-    })
-    .join("");
-
   return `
     <section class="lv-summary">
       <h2>Overview</h2>
@@ -156,7 +148,6 @@ function buildLawSummarySection(law, summaryPayload) {
       ${scopeHtml ? `<p>${scopeHtml}</p>` : ""}
       ${keyPointsHtml ? `<h3>Key points</h3><ul>${keyPointsHtml}</ul>` : ""}
       ${summary.structure ? `<h3>Structure</h3><p>${escapeHtml(summary.structure)}</p>` : ""}
-      ${relatedInstrumentsHtml ? `<h3>Related instruments</h3><ul>${relatedInstrumentsHtml}</ul>` : ""}
     </section>
   `;
 }

--- a/src/components/LawSummary.jsx
+++ b/src/components/LawSummary.jsx
@@ -140,21 +140,6 @@ export function LawSummary({ celex, lang = "EN", onArticleClick, className = "ro
                 </div>
               ) : null}
 
-              {summary.relatedInstruments?.length ? (
-                <div>
-                  <SectionLabel>{t("lawSummary.relatedInstruments")}</SectionLabel>
-                  <ul className="space-y-1.5">
-                    {summary.relatedInstruments.map((item, index) => (
-                      <li key={`${item.label}-${index}`}>
-                        <span className="font-medium text-gray-900 dark:text-gray-100">{item.label}</span>
-                        {item.celex ? <span className="ml-1 font-mono text-xs text-gray-500 dark:text-gray-400">{item.celex}</span> : null}
-                        {item.relationship ? <span> — {item.relationship}</span> : null}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-              ) : null}
-
               {metadata?.generatedAt ? (
                 <div className="pt-1 text-[11px] text-gray-400 dark:text-gray-500">
                   {t("lawSummary.generatedOn", {

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -377,7 +377,6 @@
     "scope": "Scope",
     "keyPoints": "Key points",
     "structure": "Structure",
-    "relatedInstruments": "Related instruments",
     "generatedOn": "Static summary generated {date}"
   }
 }


### PR DESCRIPTION
Closes #117, taking option 1 from the issue: the Cites tab owns cited legislation, and the summary stops duplicating it.

Since #116, the law overview has a "Cites" tab listing the legislation a law cites, ranked by citation count. The AI summary's "Related instruments" section substantially overlapped it — on the GDPR page, Directive 95/46/EC and Directive 2002/58/EC appeared both in the summary prose and in the Cites tab directly below, with different affordances (plain text plus a EUR-Lex link vs. in-app open).

## What changed

- **`backend/shared/law-summary-service.js`** — removed `relatedInstruments` from the prompt's JSON schema, the two rules referencing instrument candidates, the `relatedInstrumentCandidates` payload in the user prompt, and the now-dead helpers that built and grounded them (`buildRelatedInstrumentCandidates`, `findKnownCelex`, `normalizeRelatedInstruments`, the `ACT_CELEX_MAP` import, `MAX_RELATED_CANDIDATES`). `SCHEMA_VERSION` and `PROMPT_VERSION` both go 2 → 3 per the cache-version table in CLAUDE.md, so cached summaries regenerate.
- **`src/components/LawSummary.jsx`** and the `lawSummary.relatedInstruments` string in `en.json` — removed the rendered section.
- **`scripts/generate-prerendered-law-pages.js`** — removed the matching section from prerendered static HTML.
- **`backend/README.md`** — dropped the field from the documented `/api/laws/:celex/summary` response shape; updated the service test fixture and assertions.

## Note

The `PROMPT_VERSION` bump means every law summary regenerates on next request, so the first hit per law pays an OpenRouter call. That's inherent to any prompt change.

## Testing

`npm run lint`, `npm run test:web` (352 passed), and the backend `law-summary-service` tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)