### PR TITLE
Rework AI summaries: nature-and-effect line, hint-based act typing, index-only gating

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -190,7 +190,7 @@ cat input.xml | parse-fmx > output.json
 | `GET` | `/api/laws/:celex/implementing` | Implementing and delegated acts |
 | `GET` | `/api/laws/:celex/case-law?lang=ENG` | CJEU judgments citing this act, with operative parts and structured `articleRefs` |
 | `GET` | `/api/laws/:celex/recital-titles?lang=ENG` | Cached AI-generated short titles for recitals. Requires `RECITAL_TITLE_OPENROUTER_API_KEY` or `OPENROUTER_API_KEY` on cache miss. |
-| `GET` | `/api/laws/:celex/summary?lang=ENG` | Cached static law overview with article citations. Requires `LAW_SUMMARY_OPENROUTER_API_KEY`, `ARTICLE_QA_OPENROUTER_API_KEY`, or `OPENROUTER_API_KEY` on cache miss. |
+| `GET` | `/api/laws/:celex/summary?lang=ENG` | Cached static law overview with article citations. Only for acts in the search index (`404` `summary_not_indexed` otherwise). Requires `LAW_SUMMARY_OPENROUTER_API_KEY`, `ARTICLE_QA_OPENROUTER_API_KEY`, or `OPENROUTER_API_KEY` on cache miss. |
 | `GET` | `/api/laws/:celex/case-law-digest?lang=ENG` | Cached static digest of CJEU case law interpreting the whole act, grouped into doctrinal themes. Zero-case results are cached without an LLM call. |
 | `GET` | `/api/laws/:celex/articles/:n/case-law-digest?lang=ENG` | Cached static digest of CJEU case law interpreting one article. Zero-case results are cached without an LLM call. |
 | `GET` | `/api/laws/by-reference?actType=...&year=...&number=...` | Fetch law by official reference |
@@ -290,7 +290,7 @@ The backend stores titles in `recital-title-cache-v1.json` with a cache `version
 
 ### Static summary endpoints
 
-`GET /api/laws/:celex/summary?lang=ENG` returns a cached overview:
+`GET /api/laws/:celex/summary?lang=ENG` returns a cached overview. Summaries are only generated for acts present in the search index; other CELEX ids (e.g. laws opened via `/import`) get `404` with code `summary_not_indexed`.
 
 ```json
 {
@@ -298,15 +298,17 @@ The backend stores titles in `recital-title-cache-v1.json` with a cache `version
   "lang": "ENG",
   "cached": true,
   "summary": {
+    "natureAndEffect": { "text": "…", "citations": ["99"] },
     "purpose": { "text": "…", "citations": ["1"] },
     "scope": { "text": "…", "citations": ["2", "3"] },
-    "keyObligations": [
+    "keyPoints": [
       { "text": "…", "citations": ["5"] }
-    ],
-    "structure": "…"
+    ]
   }
 }
 ```
+
+`scope` is optional and may be `null` for acts without a meaningful scope provision (e.g. short amending or addressed acts).
 
 `GET /api/laws/:celex/articles/:n/case-law-digest?lang=ENG` returns a cached article-level digest:
 

--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -435,6 +435,13 @@ function registerApiRoutes(app, deps) {
       if (!validateCelex(celex)) {
         return res.status(400).json({ error: 'Invalid CELEX format' });
       }
+      // AI summaries are only offered for acts in the search index; laws
+      // loaded via /import from arbitrary CELEX ids must not trigger
+      // generation. When no search data is loaded (local dev without the
+      // built cache) the gate stands open rather than disabling the feature.
+      if (legalCacheStore.isReady() && !legalCacheStore.getByCelex(celex)) {
+        return res.status(404).json({ error: 'AI summaries are only available for laws in the search index', code: 'summary_not_indexed' });
+      }
       // Summaries are generated in English only for now; the lang query
       // parameter is ignored so other languages cannot trigger generation.
       const lang = 'ENG';

--- a/backend/routes/api-routes.test.js
+++ b/backend/routes/api-routes.test.js
@@ -584,6 +584,29 @@ test("GET /api/laws/:celex/summary falls back to HTML parsing when FMX is unavai
   });
 });
 
+test("GET /api/laws/:celex/summary returns 404 for laws outside the search index", async () => {
+  // No API key in the environment: the not-indexed gate must answer before
+  // the key check (404, not 503) and before any law resolution.
+  await withOpenRouterEnv({}, async () => {
+    let prepared = false;
+    const { app } = registerTestRoutes({
+      prepareLawPayload: async () => {
+        prepared = true;
+        throw new Error("prepareLawPayload should not be called for a non-indexed law");
+      },
+    });
+    const handler = app.routes.get("/api/laws/:celex/summary");
+    const res = createResponseRecorder();
+
+    // Valid CELEX format, but not part of the search fixture.
+    await handler({ params: { celex: "31995L0046" }, query: { lang: "ENG" } }, res);
+
+    assert.equal(res.statusCode, 404);
+    assert.equal(res.payload.code, "summary_not_indexed");
+    assert.equal(prepared, false);
+  });
+});
+
 test("Case-law-digest routes fail fast without an OpenRouter key, before resolving/parsing the law", async () => {
   await withOpenRouterEnv({}, async () => {
     let resolveParsedLawCalled = false;

--- a/backend/shared/law-summary-service.js
+++ b/backend/shared/law-summary-service.js
@@ -14,42 +14,73 @@ const {
 
 const CACHE_FILE = 'law-summary-cache-v1.json';
 const CACHE_VERSION = 1;
-const SCHEMA_VERSION = 3;
-const PROMPT_VERSION = 3;
+const SCHEMA_VERSION = 4;
+const PROMPT_VERSION = 4;
 const MAX_ARTICLE_TEXT_CHARS = 6000;
 const MAX_RECITAL_COUNT = 60;
 const MAX_RECITAL_TEXT_CHARS = 700;
 const MAX_ARTICLE_TEXT_BUDGET_CHARS = 500000;
 
-const ACT_TYPE_GUIDANCE = {
-  regulation: 'This is a regulation: frame key points as directly-applicable obligations, rights, and prohibitions binding on the addressees themselves.',
-  directive: 'This is a directive: frame key points as duties on Member States, i.e. what must be transposed into national law and by when if a deadline is stated, not direct obligations on private parties.',
-  decision: 'This is a decision or establishing act: frame key points around the addressees, the body or authority it creates, and that body\'s powers and mandate.',
-  unknown: 'The act type could not be determined: frame key points generically as obligations, rights, powers, or prohibitions as best supported by the text.',
+// The CELEX descriptor letter and the official title are hints, not verdicts:
+// legal form is a weak proxy for how an act functions (a sui generis decision
+// can operate like a regulation; an adequacy decision addresses Member
+// States; a "regulation" may only amend another act). The prompt passes these
+// to the model and asks it to verify against the text itself.
+const CELEX_TYPE_HINTS = {
+  regulation: 'a regulation',
+  directive: 'a directive',
+  decision: 'a decision',
 };
+
+function detectTitleHints(title) {
+  const text = String(title || '').toLowerCase();
+  const hints = [];
+  if (/\bamending\b/.test(text)) hints.push('the title says it amends other acts');
+  if (/\brepealing\b/.test(text)) hints.push('the title says it repeals other acts');
+  if (/\bimplementing\b/.test(text)) hints.push('the title marks it as an implementing act');
+  if (/\bdelegated\b/.test(text)) hints.push('the title marks it as a delegated act');
+  if (/\bframework decision\b/.test(text)) hints.push('the title marks it as a framework decision');
+  if (/\brecommendation\b/.test(text)) hints.push('the title marks it as a recommendation');
+  return hints;
+}
 
 const withSingleFlight = makeSingleFlight();
 
-function buildSystemPrompt(actType) {
-  const guidance = ACT_TYPE_GUIDANCE[actType] || ACT_TYPE_GUIDANCE.unknown;
+function buildSystemPrompt(input) {
+  const hints = [];
+  const celexHint = CELEX_TYPE_HINTS[input.actType];
+  if (celexHint) hints.push(`the CELEX descriptor suggests ${celexHint}`);
+  hints.push(...(input.titleHints || []));
+  const hintSentence = hints.length
+    ? `Metadata hints, to verify against the text rather than assume: ${hints.join('; ')}.`
+    : 'No act-type metadata is available; rely on the text alone.';
+
   return `You write concise, grounded summaries of EU legal acts for a legal research reader.
 
-${guidance}
+Before summarising, determine from the text itself what kind of act this is and how it takes legal effect: read the enacting formula, the addressee clause and the final articles, and check whether the act mainly amends other acts. ${hintSentence}
+
+Frame the key points to match how the act actually operates:
+- directly applicable acts: the obligations, rights, powers, and prohibitions binding on the persons covered;
+- acts requiring national transposition (directives and similar): duties on Member States, with the transposition deadline if stated, not direct obligations on private parties;
+- addressed or establishing acts: the addressees, the body or scheme created, and its powers and mandate;
+- acts that mainly amend other acts: the concrete changes made to the amended acts;
+- non-binding acts (recommendations, opinions): what is recommended — never present these as imposing obligations.
 
 Return ONLY a JSON object with this exact shape:
 {
+  "natureAndEffect": { "text": "1-2 sentences: what kind of act this is, who it binds or addresses, and how it takes effect (directly applicable, requires transposition with any deadline, addressed to named parties, or non-binding)", "citations": ["99"] },
   "purpose": { "text": "1-2 sentences", "citations": ["1", "2"] },
   "scope": { "text": "who or what the law applies to", "citations": ["2", "3"] },
   "keyPoints": [
-    { "text": "one concrete obligation, right, power, or prohibition", "citations": ["5"] }
-  ],
-  "structure": "short narrative of how the chapters/sections are organised"
+    { "text": "one concrete obligation, right, power, prohibition, or change made to another act", "citations": ["5"] }
+  ]
 }
 
 Rules:
 - Use only the provided law input.
-- Every scope and key-point item must cite existing article numbers from the provided article list.
-- Prefer 3-6 key points.
+- Every scope and key-point item must cite existing article numbers from the provided article list; cite natureAndEffect where the text supports it (an addressee or transposition article), else leave its citations empty.
+- Omit "scope" entirely rather than padding it — include it only when the text supports it.
+- Prefer 3-6 key points for substantial acts; 1-3 are enough for short or narrow ones.
 - Keep the whole output under about 400 words.
 - Do not invent article numbers, obligations, or legal effects.`;
 }
@@ -148,6 +179,7 @@ function buildLawSummaryInput(parsedLaw) {
     eli: parsedLaw.eli || null,
     source: parsedLaw.source || null,
     actType: inferTypeFromCelex(parsedLaw.celex),
+    titleHints: detectTitleHints(parsedLaw.title || parsedLaw.doc_title || parsedLaw.name || null),
     skeleton: buildSkeleton(parsedLaw.articles || []),
     definitions: (parsedLaw.definitions || [])
       .map((definition) => ({
@@ -197,24 +229,26 @@ function parseLawSummaryJson(text, input) {
     ...(input.articles || []).map((article) => String(article.number)),
     ...(input.skeleton || []).map((article) => String(article.number)),
   ]);
+  const natureAndEffect = normalizeCitedBlock(parsed.natureAndEffect, validArticles);
   const purpose = normalizeCitedBlock(parsed.purpose, validArticles);
+  // Scope is optional: for acts without a meaningful scope provision (a
+  // one-article amending act, an addressed decision) omitting the section
+  // beats forcing the model to pad it. An uncited scope is dropped, not fatal.
   const scope = normalizeCitedBlock(parsed.scope, validArticles, { requireCitation: true });
   const keyPoints = (Array.isArray(parsed.keyPoints) ? parsed.keyPoints : [])
     .map((item) => normalizeCitedBlock(item, validArticles, { requireCitation: true }))
     .filter(Boolean)
     .slice(0, 8);
-  const structure = normalizeText(parsed.structure, 1000);
 
+  if (!natureAndEffect?.text) throw new Error('Summary is missing natureAndEffect');
   if (!purpose?.text) throw new Error('Summary is missing purpose');
-  if (!scope?.text) throw new Error('Summary is missing cited scope');
   if (keyPoints.length === 0) throw new Error('Summary is missing cited key points');
-  if (!structure) throw new Error('Summary is missing structure');
 
   return {
+    natureAndEffect,
     purpose,
     scope,
     keyPoints,
-    structure,
   };
 }
 
@@ -248,7 +282,7 @@ async function generateLawSummary(input, {
     responseFormat: 'json_object',
     reasoning: { max_tokens: 256, exclude: true },
     messages: [
-      { role: 'system', content: buildSystemPrompt(input.actType) },
+      { role: 'system', content: buildSystemPrompt(input) },
       { role: 'user', content: buildUserPrompt(input) },
     ],
   });
@@ -369,6 +403,7 @@ module.exports = {
   PROMPT_VERSION,
   SCHEMA_VERSION,
   buildLawSummaryInput,
+  buildSystemPrompt,
   ensureLawSummary,
   generateLawSummary,
   parseLawSummaryJson,

--- a/backend/shared/law-summary-service.test.js
+++ b/backend/shared/law-summary-service.test.js
@@ -6,6 +6,7 @@ const path = require('node:path');
 
 const {
   buildLawSummaryInput,
+  buildSystemPrompt,
   ensureLawSummary,
   parseLawSummaryJson,
 } = require('./law-summary-service');
@@ -38,17 +39,43 @@ function sampleParsedLaw() {
 test('parseLawSummaryJson keeps only valid article citations', () => {
   const input = buildLawSummaryInput(sampleParsedLaw());
   const summary = parseLawSummaryJson(JSON.stringify({
+    natureAndEffect: { text: 'A directly applicable regulation binding on controllers and processors.', citations: ['1', '999'] },
     purpose: { text: 'It protects personal data.', citations: ['1', '999'] },
     scope: { text: 'It applies to personal data processing.', citations: ['1'] },
     keyPoints: [
       { text: 'Data must be processed lawfully.', citations: ['5'] },
       { text: 'Invalid point is dropped.', citations: ['999'] },
     ],
-    structure: 'It starts with general provisions and then sets principles.',
   }), input);
 
+  assert.deepEqual(summary.natureAndEffect.citations, ['1']);
   assert.deepEqual(summary.purpose.citations, ['1']);
   assert.deepEqual(summary.keyPoints.map((item) => item.citations), [['5']]);
+});
+
+test('scope is optional but natureAndEffect is required', () => {
+  const input = buildLawSummaryInput(sampleParsedLaw());
+
+  const withoutScope = parseLawSummaryJson(JSON.stringify({
+    natureAndEffect: { text: 'A short addressed decision.', citations: [] },
+    purpose: { text: 'It protects personal data.', citations: ['1'] },
+    keyPoints: [{ text: 'Data must be processed lawfully.', citations: ['5'] }],
+  }), input);
+  assert.equal(withoutScope.scope, null);
+
+  // An uncited scope is dropped rather than fatal.
+  const uncitedScope = parseLawSummaryJson(JSON.stringify({
+    natureAndEffect: { text: 'A short addressed decision.', citations: [] },
+    purpose: { text: 'It protects personal data.', citations: ['1'] },
+    scope: { text: 'It applies to everything.', citations: ['999'] },
+    keyPoints: [{ text: 'Data must be processed lawfully.', citations: ['5'] }],
+  }), input);
+  assert.equal(uncitedScope.scope, null);
+
+  assert.throws(() => parseLawSummaryJson(JSON.stringify({
+    purpose: { text: 'It protects personal data.', citations: ['1'] },
+    keyPoints: [{ text: 'Data must be processed lawfully.', citations: ['5'] }],
+  }), input), /natureAndEffect/);
 });
 
 test('ensureLawSummary caches validated summaries', async () => {
@@ -60,10 +87,10 @@ test('ensureLawSummary caches validated summaries', async () => {
       model: 'test-model',
       usage: { total_tokens: 10 },
       text: JSON.stringify({
+        natureAndEffect: { text: 'A directly applicable regulation.', citations: [] },
         purpose: { text: 'It protects personal data.', citations: ['1'] },
         scope: { text: 'It applies to personal data processing.', citations: ['1'] },
         keyPoints: [{ text: 'Data must be processed lawfully.', citations: ['5'] }],
-        structure: 'It starts with general provisions and then sets principles.',
       }),
     };
   };
@@ -133,10 +160,10 @@ test('overall article budget drops bodies but keeps every article number citable
   assert.ok(droppedArticle, 'expected at least one article whose body was trimmed away');
 
   const summary = parseLawSummaryJson(JSON.stringify({
+    natureAndEffect: { text: 'A directly applicable regulation.', citations: [] },
     purpose: { text: 'It protects personal data.', citations: [droppedArticle.number] },
     scope: { text: 'It applies broadly.', citations: [droppedArticle.number] },
     keyPoints: [{ text: 'A rule still cites a body-trimmed article.', citations: [droppedArticle.number] }],
-    structure: 'It is organised into many articles.',
   }), input);
 
   assert.deepEqual(summary.scope.citations, [droppedArticle.number]);
@@ -152,6 +179,40 @@ test('actType is derived from the CELEX descriptor letter', () => {
   assert.equal(buildLawSummaryInput({ ...base, celex: null }).actType, 'unknown');
 });
 
+test('title-based hints flag amending and implementing acts', () => {
+  const base = sampleParsedLaw();
+
+  const amending = buildLawSummaryInput({
+    ...base,
+    title: 'Regulation (EU) 2024/900 amending Regulation (EU) 2016/679',
+  });
+  assert.ok(amending.titleHints.some((hint) => hint.includes('amends other acts')));
+
+  const implementing = buildLawSummaryInput({
+    ...base,
+    title: 'Commission Implementing Decision (EU) 2021/914',
+  });
+  assert.ok(implementing.titleHints.some((hint) => hint.includes('implementing act')));
+
+  assert.deepEqual(buildLawSummaryInput({ ...base, title: 'Regulation (EU) 2016/679' }).titleHints, []);
+});
+
+test('buildSystemPrompt passes metadata as hints to verify, not verdicts', () => {
+  const input = buildLawSummaryInput({
+    ...sampleParsedLaw(),
+    title: 'Regulation (EU) 2024/900 amending Regulation (EU) 2016/679',
+  });
+  const prompt = buildSystemPrompt(input);
+
+  assert.match(prompt, /verify against the text rather than assume/);
+  assert.match(prompt, /the CELEX descriptor suggests a regulation/);
+  assert.match(prompt, /the title says it amends other acts/);
+  assert.match(prompt, /concrete changes made to the amended acts/);
+
+  const bare = buildSystemPrompt(buildLawSummaryInput({ ...sampleParsedLaw(), celex: null, title: null }));
+  assert.match(bare, /No act-type metadata is available/);
+});
+
 function stubChatComplete(counter) {
   return async () => {
     counter.calls++;
@@ -159,10 +220,10 @@ function stubChatComplete(counter) {
       model: 'test-model',
       usage: { total_tokens: 10 },
       text: JSON.stringify({
+        natureAndEffect: { text: 'A directly applicable regulation.', citations: [] },
         purpose: { text: 'It protects personal data.', citations: ['1'] },
         scope: { text: 'It applies to personal data processing.', citations: ['1'] },
         keyPoints: [{ text: 'Data must be processed lawfully.', citations: ['5'] }],
-        structure: 'It starts with general provisions and then sets principles.',
       }),
     };
   };

--- a/scripts/generate-prerendered-law-pages.js
+++ b/scripts/generate-prerendered-law-pages.js
@@ -136,6 +136,7 @@ function buildLawSummarySection(law, summaryPayload) {
   const summary = summaryPayload?.summary;
   if (!summary) return "";
 
+  const natureHtml = citedText(law, summary.natureAndEffect);
   const purposeHtml = citedText(law, summary.purpose);
   const scopeHtml = citedText(law, summary.scope);
   const keyPointsHtml = (summary.keyPoints || [])
@@ -144,10 +145,10 @@ function buildLawSummarySection(law, summaryPayload) {
   return `
     <section class="lv-summary">
       <h2>Overview</h2>
+      ${natureHtml ? `<p>${natureHtml}</p>` : ""}
       ${purposeHtml ? `<p>${purposeHtml}</p>` : ""}
       ${scopeHtml ? `<p>${scopeHtml}</p>` : ""}
       ${keyPointsHtml ? `<h3>Key points</h3><ul>${keyPointsHtml}</ul>` : ""}
-      ${summary.structure ? `<h3>Structure</h3><p>${escapeHtml(summary.structure)}</p>` : ""}
     </section>
   `;
 }

--- a/src/components/LawSummary.jsx
+++ b/src/components/LawSummary.jsx
@@ -51,6 +51,9 @@ export function LawSummary({ celex, lang = "EN", onArticleClick, className = "ro
   const showEnglishOnlyNote = (lang || "EN").toUpperCase() !== "EN";
 
   if (!celex) return null;
+  // Imported laws outside the search index have summaries deliberately
+  // disabled server-side; hide the panel instead of offering a retry.
+  if (error?.code === "summary_not_indexed") return null;
 
   return (
     <div className={className}>
@@ -96,15 +99,24 @@ export function LawSummary({ celex, lang = "EN", onArticleClick, className = "ro
 
           {summary ? (
             <>
+              {summary.natureAndEffect?.text ? (
+                <div>
+                  <SectionLabel>{t("lawSummary.natureAndEffect")}</SectionLabel>
+                  <p><CitedText block={summary.natureAndEffect} onArticleClick={onArticleClick} t={t} /></p>
+                </div>
+              ) : null}
+
               <div>
                 <SectionLabel>{t("lawSummary.purpose")}</SectionLabel>
                 <p><CitedText block={summary.purpose} onArticleClick={onArticleClick} t={t} /></p>
               </div>
 
-              <div>
-                <SectionLabel>{t("lawSummary.scope")}</SectionLabel>
-                <p><CitedText block={summary.scope} onArticleClick={onArticleClick} t={t} /></p>
-              </div>
+              {summary.scope?.text ? (
+                <div>
+                  <SectionLabel>{t("lawSummary.scope")}</SectionLabel>
+                  <p><CitedText block={summary.scope} onArticleClick={onArticleClick} t={t} /></p>
+                </div>
+              ) : null}
 
               {summary.keyPoints?.length ? (
                 <div>
@@ -130,13 +142,6 @@ export function LawSummary({ celex, lang = "EN", onArticleClick, className = "ro
                       </li>
                     ))}
                   </ul>
-                </div>
-              ) : null}
-
-              {summary.structure ? (
-                <div>
-                  <SectionLabel>{t("lawSummary.structure")}</SectionLabel>
-                  <p>{summary.structure}</p>
                 </div>
               ) : null}
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -373,10 +373,10 @@
     "englishOnly": "English only",
     "generating": "Generating overview",
     "unavailable": "Overview is not available for this law yet.",
+    "natureAndEffect": "Nature & legal effect",
     "purpose": "Purpose",
     "scope": "Scope",
     "keyPoints": "Key points",
-    "structure": "Structure",
     "generatedOn": "Static summary generated {date}"
   }
 }

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -194,7 +194,7 @@ function createCombinedLawEnvelope(payload, rawXml = null) {
 // Bump whenever the shape of a cached API payload changes (e.g. renaming a
 // summary field) so stale cache-first entries are invalidated rather than
 // served for up to API_JSON_CACHE_MAX_AGE_MS under the old shape.
-const API_JSON_CACHE_VERSION = 4;
+const API_JSON_CACHE_VERSION = 5;
 // After this age, cache-first entries are revalidated against the network
 // (still served from cache if the network is unavailable).
 const API_JSON_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;


### PR DESCRIPTION
Stacked on #119 (base is its branch; retarget to `main` once #119 merges).

The AI summary assumed every act looks like the GDPR: a mandatory Structure section narrating chapters, and prompt guidance that treated the CELEX descriptor letter as a verdict on how the act operates. This reworks the summary for the heterogeneous corpus (amending acts, implementing/delegated acts, addressed decisions, framework decisions), and disables summaries for laws outside the search index.

## Summary schema (`SCHEMA_VERSION`/`PROMPT_VERSION` 3 → 4)

- **Structure is gone.** It restated the chapter skeleton the reader's own navigation shows, was the only field with no citation grounding, and was mandatory — for acts without chapters the model had to pad or fail.
- **New required `natureAndEffect` block** (with optional article citations): what kind of act this is, who it binds or addresses, and how it takes effect — directly applicable, requires transposition (with deadline), addressed, or non-binding. This is orientation the table of contents *cannot* provide, unlike the old Structure prose.
- **`scope` is now optional** and may be `null`: short amending or addressed acts omit it rather than pad it. An uncited scope is dropped, not fatal.
- **Key-point count scales**: 3–6 for substantial acts, 1–3 for short or narrow ones.

## Prompt: metadata as hints, not verdicts

`ACT_TYPE_GUIDANCE` ("This is a decision: frame key points around the addressees…") is replaced. The CELEX letter and title-derived signals (*amending, repealing, implementing, delegated, framework decision, recommendation*) are passed as "hints to verify against the text rather than assume", and the model is told to determine the act's nature from the enacting formula, addressee clause, and final articles. Framing rules are keyed to function, not form — notably, acts that mainly amend other acts are summarised as the concrete changes they make, and non-binding acts are never presented as imposing obligations.

## Index-only gating

`GET /api/laws/:celex/summary` now returns `404` `{ code: "summary_not_indexed" }` for CELEX ids not in the search index, before the API-key check and before any law resolution — laws opened via `/import` no longer trigger generation. When no search data is loaded (local dev without the built cache) the gate stands open. The frontend hides the AI overview panel entirely on that code instead of showing an error with retry.

## Other changes

- `src/components/LawSummary.jsx` renders the nature line first and guards scope; `en.json` swaps the `structure` label for `natureAndEffect` (only en.json carries these keys).
- `API_JSON_CACHE_VERSION` 4 → 5 so cache-first clients don't serve the old payload shape for up to 7 days.
- Prerendered law pages render the nature line and drop the Structure block.
- `backend/README.md`: updated response shape (also fixes the stale `keyObligations` field name — the API has always returned `keyPoints`), documents the 404.

## Testing

`npm run lint`, `npm run test:web` (352 passed), backend `npm test` (348 passed) — including new tests for optional scope / required natureAndEffect, title-hint detection, hint-based prompt content, and the not-indexed 404 (asserted to fire before key check and law resolution). Also verified against a running server with a fixture search cache: non-indexed CELEX → `404 summary_not_indexed`, indexed CELEX → passes the gate to the key check.

Like #119, the version bumps regenerate every cached summary on next request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)