### PR TITLE
Replace native title tooltips for definitions with a portal popup

### DIFF
--- a/src/components/LawViewer.jsx
+++ b/src/components/LawViewer.jsx
@@ -41,6 +41,7 @@ import { LawViewerLoadingState } from "./law-viewer/LawViewerLoadingState.jsx";
 import { LawViewerErrorState } from "./law-viewer/LawViewerErrorState.jsx";
 import { LawViewerSidebar } from "./law-viewer/LawViewerSidebar.jsx";
 import { LawViewerSideBySide } from "./law-viewer/LawViewerSideBySide.jsx";
+import { DefinitionTooltip } from "./law-viewer/DefinitionTooltip.jsx";
 import { LawViewerReadingFooter } from "./law-viewer/LawViewerReadingFooter.jsx";
 import { LawViewerContextRail } from "./law-viewer/LawViewerContextRail.jsx";
 import { LawOverviewPage } from "./law-viewer/LawOverviewPage.jsx";
@@ -388,6 +389,8 @@ export function LawViewer() {
                     onTouchEnd={interactions.onTouchEnd}
                     t={t}
                   />
+
+                  <DefinitionTooltip t={t} />
 
                   <LawViewerReadingFooter
                     selected={selection.selected}

--- a/src/components/law-viewer/DefinitionTooltip.jsx
+++ b/src/components/law-viewer/DefinitionTooltip.jsx
@@ -1,0 +1,216 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+
+const VIEWPORT_MARGIN = 8;
+const ANCHOR_GAP = 8;
+const CLOSE_DELAY_MS = 150;
+// Below this width an anchored popup has nowhere sensible to go, so we
+// render a bottom sheet instead.
+const SHEET_MEDIA_QUERY = "(max-width: 640px)";
+
+function matchesSheetQuery() {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia(SHEET_MEDIA_QUERY).matches
+    : false;
+}
+
+/**
+ * Single shared popup for the `.defined-term` spans that
+ * injectDefinitionTooltips() plants inside the EUR-Lex HTML.
+ *
+ * The law text is injected via dangerouslySetInnerHTML, so nothing React can
+ * live inside it: this component listens for hover/click on document and
+ * renders exactly one popup through a portal on document.body. Rendering
+ * outside the EUR-Lex DOM keeps its tables, overflow rules, and stacking
+ * contexts from clipping or restyling the popup.
+ */
+export function DefinitionTooltip({ t }) {
+  // { term, definition, anchor } — anchor is the hovered/tapped span.
+  const [active, setActive] = useState(null);
+  const [isSheet, setIsSheet] = useState(matchesSheetQuery);
+  const [position, setPosition] = useState(null);
+  const tooltipRef = useRef(null);
+  const closeTimerRef = useRef(null);
+
+  const cancelScheduledClose = useCallback(() => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const close = useCallback(() => {
+    cancelScheduledClose();
+    setActive(null);
+  }, [cancelScheduledClose]);
+
+  // Grace period on mouse-out so the pointer can travel into the popup
+  // (e.g. to select the definition text) without it vanishing.
+  const scheduleClose = useCallback(() => {
+    cancelScheduledClose();
+    closeTimerRef.current = setTimeout(() => setActive(null), CLOSE_DELAY_MS);
+  }, [cancelScheduledClose]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return undefined;
+    const query = window.matchMedia(SHEET_MEDIA_QUERY);
+    const handleChange = (event) => setIsSheet(event.matches);
+    query.addEventListener("change", handleChange);
+    return () => query.removeEventListener("change", handleChange);
+  }, []);
+
+  useEffect(() => {
+    const openFromElement = (el) => {
+      cancelScheduledClose();
+      setActive({
+        term: el.getAttribute("data-term") || el.textContent,
+        definition: el.getAttribute("data-definition") || "",
+        anchor: el,
+      });
+    };
+
+    const findTerm = (eventTarget) => {
+      if (!(eventTarget instanceof Element)) return null;
+      // Terms inside cross-reference links stay links: navigation wins.
+      if (eventTarget.closest("a")) return null;
+      return eventTarget.closest(".defined-term");
+    };
+
+    const handleMouseOver = (event) => {
+      if (isSheet) return; // sheet mode is tap-to-open only
+      const el = findTerm(event.target);
+      if (el) openFromElement(el);
+    };
+
+    const handleMouseOut = (event) => {
+      if (isSheet) return;
+      if (findTerm(event.target)) scheduleClose();
+    };
+
+    // Explicit tap-to-open: synthetic mouseover on touch devices is too
+    // unreliable to be the only way in.
+    const handleClick = (event) => {
+      const el = findTerm(event.target);
+      if (el) {
+        openFromElement(el);
+        return;
+      }
+      if (tooltipRef.current?.contains(event.target)) return;
+      close();
+    };
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") close();
+    };
+
+    // Any scroll invalidates the anchored position; the sheet is
+    // viewport-fixed, so only close when the popup itself isn't scrolling.
+    const handleScroll = (event) => {
+      if (isSheet && event.target instanceof Node && tooltipRef.current?.contains(event.target)) return;
+      if (!isSheet) close();
+    };
+
+    document.addEventListener("mouseover", handleMouseOver);
+    document.addEventListener("mouseout", handleMouseOut);
+    document.addEventListener("click", handleClick);
+    document.addEventListener("keydown", handleKeyDown);
+    window.addEventListener("scroll", handleScroll, { capture: true, passive: true });
+    window.addEventListener("resize", close);
+    return () => {
+      document.removeEventListener("mouseover", handleMouseOver);
+      document.removeEventListener("mouseout", handleMouseOut);
+      document.removeEventListener("click", handleClick);
+      document.removeEventListener("keydown", handleKeyDown);
+      window.removeEventListener("scroll", handleScroll, { capture: true });
+      window.removeEventListener("resize", close);
+      cancelScheduledClose();
+    };
+  }, [cancelScheduledClose, close, isSheet, scheduleClose]);
+
+  // Anchored placement: measure the rendered popup, center it on the term,
+  // clamp to the viewport, and flip below when there is no room above.
+  useLayoutEffect(() => {
+    if (!active || isSheet) {
+      setPosition(null);
+      return;
+    }
+    if (!active.anchor.isConnected) {
+      setActive(null);
+      return;
+    }
+    const el = tooltipRef.current;
+    if (!el) return;
+
+    const anchorRect = active.anchor.getBoundingClientRect();
+    const { offsetWidth: width, offsetHeight: height } = el;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let left = anchorRect.left + anchorRect.width / 2 - width / 2;
+    left = Math.max(VIEWPORT_MARGIN, Math.min(left, viewportWidth - width - VIEWPORT_MARGIN));
+
+    let top = anchorRect.top - height - ANCHOR_GAP;
+    if (top < VIEWPORT_MARGIN) {
+      top = anchorRect.bottom + ANCHOR_GAP;
+    }
+    top = Math.max(VIEWPORT_MARGIN, Math.min(top, viewportHeight - height - VIEWPORT_MARGIN));
+
+    setPosition({ left, top });
+  }, [active, isSheet]);
+
+  if (!active || typeof document === "undefined") return null;
+
+  if (isSheet) {
+    return createPortal(
+      <div
+        ref={tooltipRef}
+        role="dialog"
+        aria-label={active.term}
+        className="fixed inset-x-0 bottom-0 z-50 rounded-t-2xl border-t border-gray-200 bg-white px-5 pt-4 shadow-[0_-8px_30px_rgba(0,0,0,0.15)] dark:border-gray-700 dark:bg-gray-900"
+        style={{ paddingBottom: "calc(1.25rem + env(safe-area-inset-bottom))" }}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="pt-1.5 text-sm font-semibold text-blue-600 dark:text-blue-400">
+            {active.term}
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            aria-label={t("common.close")}
+            className="-mr-2 rounded-lg p-2 text-gray-400 transition hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+          >
+            <X size={18} />
+          </button>
+        </div>
+        <div className="mt-1 max-h-[45vh] overflow-y-auto text-sm leading-6 text-gray-700 dark:text-gray-300">
+          {active.definition}
+        </div>
+      </div>,
+      document.body
+    );
+  }
+
+  return createPortal(
+    <div
+      ref={tooltipRef}
+      role="tooltip"
+      className="fixed z-50 w-max max-w-sm rounded-xl border border-gray-200 bg-white px-4 py-3 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+      style={{
+        left: position?.left ?? 0,
+        top: position?.top ?? 0,
+        visibility: position ? "visible" : "hidden",
+      }}
+      onMouseEnter={cancelScheduledClose}
+      onMouseLeave={scheduleClose}
+    >
+      <div className="text-xs font-semibold uppercase tracking-wide text-blue-600 dark:text-blue-400">
+        {active.term}
+      </div>
+      <div className="mt-1 max-h-60 overflow-y-auto text-sm leading-6 text-gray-700 dark:text-gray-300">
+        {active.definition}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/utils/definitions.js
+++ b/src/utils/definitions.js
@@ -1,6 +1,7 @@
 /**
- * Inject definition tooltips into HTML content.
- * Wraps occurrences of defined terms with span elements that show the definition on hover.
+ * Inject definition markers into HTML content.
+ * Wraps occurrences of defined terms with span elements carrying data-term /
+ * data-definition attributes; DefinitionTooltip renders the actual popup.
  */
 
 /**
@@ -101,10 +102,13 @@ export function injectDefinitionTooltips(html, definitions, options = {}) {
             }
             if (insideDefinedTerm) continue;
 
-            // Replace occurrences in text nodes
+            // Replace occurrences in text nodes. The span is a pure data
+            // marker: the popup itself is rendered by <DefinitionTooltip />
+            // outside this HTML, so no title attribute here.
             parts[i] = part.replace(termPattern, (match) => {
                 const escapedDef = escapeHtml(definition);
-                return `<span class="defined-term" data-definition="${escapedDef}" title="${escapedDef}">${match}</span>`;
+                const escapedTerm = escapeHtml(term);
+                return `<span class="defined-term" data-term="${escapedTerm}" data-definition="${escapedDef}">${match}</span>`;
             });
         }
 

--- a/src/utils/definitions.test.js
+++ b/src/utils/definitions.test.js
@@ -21,6 +21,13 @@ describe("injectDefinitionTooltips", () => {
     expect(result).toContain('data-definition="');
   });
 
+  it("includes the canonical term in data-term and no native title attribute", () => {
+    const html = "<p>The CONTROLLER processes data.</p>";
+    const result = injectDefinitionTooltips(html, DEFINITIONS);
+    expect(result).toContain('data-term="controller"');
+    expect(result).not.toContain("title=");
+  });
+
   it("returns html unchanged when definitions array is empty", () => {
     const html = "<p>Some text.</p>";
     expect(injectDefinitionTooltips(html, [])).toBe(html);


### PR DESCRIPTION
## Problem

Defined terms in the law text used the browser's native `title` attribute: tiny, unstyled, slow to appear — and on mobile they didn't appear at all, since there is no hover. Earlier attempts at proper React popups failed because the popup was mounted inside the injected EUR-Lex HTML, where its table layouts, overflow rules, and stacking contexts clipped and misaligned it (popups frequently drew outside the window).

## Approach

The popup never lives inside the EUR-Lex DOM:

- `injectDefinitionTooltips()` now plants **pure data markers** — `<span class="defined-term" data-term="…" data-definition="…">` — with the native `title` attribute removed.
- A new **`DefinitionTooltip`** component renders a single shared popup through a `createPortal` on `document.body`, driven by document-level event delegation (`closest(".defined-term")`, same pattern as the existing cross-ref link handling). It therefore works across the single pane, both side-by-side panes, and aligned rows without prop threading.

## Behavior

- **Desktop:** hover (or click) opens a styled popup with the term header and full definition. Position comes from the term's viewport rect — centered, clamped to the viewport with an 8px margin, flipped below the term when there's no room above. Scroll/resize close it, so it can never drift out of alignment. A 150ms mouse-out grace period lets the pointer travel into the popup to select/copy text.
- **Mobile (<640px):** anchored popups are hopeless on small screens, so terms open a tap-to-open **bottom sheet** (term header, scrollable definition, close button, safe-area padding). Closes via ✕, tap outside, or Escape. This gives mobile users definitions for the first time.
- Terms inside cross-reference links defer to navigation; long definitions scroll inside the popup; dark mode styled.

## Verification

- Exercised in the browser against GDPR Article 6: hover popup, flip-below near the viewport top, mobile sheet open/close at 375×812, dark mode. No console errors.
- `npm run lint` and `npm run test:web` pass (353 tests); added a test pinning the new marker contract (`data-term` present, no `title`).
- No cache-version bumps needed: injection happens at render time in `useProcessedLawHtml`; no persisted payload shape changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)