### PR TITLE
Add mini citation graph preview

### DIFF
--- a/src/components/MetadataPanel.jsx
+++ b/src/components/MetadataPanel.jsx
@@ -3,6 +3,7 @@ import { ExternalLink, Loader2 } from "lucide-react";
 import { buildEurlexCelexUrl } from "../utils/url.js";
 import { formatMetaDate } from "../utils/formatMetaDate.js";
 import { buildLawDisplayLabel } from "../utils/lawDisplay.js";
+import { MiniCitationGraph } from "./MiniCitationGraph.jsx";
 
 const ROW_DIVIDERS = "divide-y divide-gray-100 dark:divide-gray-800";
 
@@ -91,6 +92,7 @@ export function MetadataPanel({
   implementing,
   externalLawOverview = [],
   citedBy = null,
+  centreLabel = "",
   currentLang = "EN",
   locale = "en",
   onOpenExternalLaw,
@@ -186,6 +188,7 @@ export function MetadataPanel({
   // yet re-derives the default as citedBy loads in asynchronously.
   const defaultTab = citedBy ? "citedBy" : "cites";
   const effectiveTab = activeTab && tabs.some((entry) => entry.id === activeTab) ? activeTab : defaultTab;
+  const showCitationGraph = effectiveTab === "citedBy" && citingLaws.length > 0;
 
   const sections = {
     citedBy: { rows: citedByRows, emptyText: t("citedBy.empty"), footer: citedByFooter },
@@ -255,15 +258,36 @@ export function MetadataPanel({
         role="tabpanel"
         id="metadata-tabpanel"
         aria-labelledby={`metadata-tab-${effectiveTab}`}
-        className="px-4 py-2"
+        className={showCitationGraph ? "p-0" : "px-4 py-2"}
       >
-        <SectionList
-          key={effectiveTab}
-          rows={active.rows}
-          emptyText={active.emptyText}
-          footer={active.footer}
-          t={t}
-        />
+        {showCitationGraph ? (
+          <div className="grid md:grid-cols-[minmax(0,1fr)_minmax(18rem,1fr)]">
+            <div className="px-4 py-2">
+              <SectionList
+                key={effectiveTab}
+                rows={active.rows}
+                emptyText={active.emptyText}
+                footer={active.footer}
+                t={t}
+              />
+            </div>
+            <MiniCitationGraph
+              laws={citingLaws}
+              total={citedBy?.citingLaws?.total ?? citingLaws.length}
+              centreLabel={centreLabel || citedBy?.celex}
+              ariaLabel={t("citedBy.title")}
+              formatMore={(count) => t("citedBy.andMore", { count })}
+            />
+          </div>
+        ) : (
+          <SectionList
+            key={effectiveTab}
+            rows={active.rows}
+            emptyText={active.emptyText}
+            footer={active.footer}
+            t={t}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/MetadataPanel.tabs.test.jsx
+++ b/src/components/MetadataPanel.tabs.test.jsx
@@ -18,7 +18,7 @@ function t(key, vars = {}) {
 
 const citedBy = {
   citingLaws: {
-    total: 2,
+    total: 12,
     laws: [
       { celex: "32022R1925", title: "Regulation (Digital Markets Act)", provisions: 5 },
       { celex: "32022R2065", title: "Regulation (Digital Services Act)", provisions: 3 },
@@ -58,6 +58,7 @@ function render(props) {
         implementing,
         externalLawOverview,
         currentLang: "EN",
+        centreLabel: "GDPR",
         locale: "en",
         onOpenExternalLaw: () => {},
         onOpenCitedLaw: () => {},
@@ -88,6 +89,9 @@ describe("MetadataPanel tabs", () => {
     // The active panel lists the citing laws + totals footer.
     expect(container.textContent).toContain("Digital Markets Act");
     expect(container.textContent).toContain("8 provisions");
+    expect(container.querySelector('svg[role="img"]')).not.toBeNull();
+    expect(container.querySelector("svg").textContent).toContain("GDPR");
+    expect(container.textContent).toContain("And 10 more not shown.");
   });
 
   it("omits the Cited by tab and defaults to Cites when citedBy is null", () => {
@@ -97,6 +101,7 @@ describe("MetadataPanel tabs", () => {
     expect(labels).toHaveLength(3);
     expect(activeTab().textContent).toContain("Cites");
     expect(container.textContent).toContain("E-Commerce Directive");
+    expect(container.querySelector('svg[role="img"]')).toBeNull();
   });
 
   it("switches to the Amendments tab and humanises the row", () => {
@@ -109,5 +114,6 @@ describe("MetadataPanel tabs", () => {
     expect(container.textContent).toContain("32016R0679R(01)");
     // The cited-by laws are no longer visible once the tab changes.
     expect(container.textContent).not.toContain("Digital Markets Act");
+    expect(container.querySelector('svg[role="img"]')).toBeNull();
   });
 });

--- a/src/components/MiniCitationGraph.jsx
+++ b/src/components/MiniCitationGraph.jsx
@@ -1,0 +1,107 @@
+import { buildLawDisplayLabel } from "../utils/lawDisplay.js";
+
+const CENTRE = { x: 180, y: 108 };
+const NODE_POSITIONS = [
+  { x: 112, y: 34 },
+  { x: 198, y: 27 },
+  { x: 267, y: 52 },
+  { x: 294, y: 112 },
+  { x: 250, y: 169 },
+  { x: 158, y: 188 },
+  { x: 76, y: 153 },
+  { x: 58, y: 91 },
+];
+
+function compactLawLabel(law) {
+  const { label } = buildLawDisplayLabel(law);
+  const [shortTitle, reference] = label.split(" — ");
+  if (reference) return shortTitle.length <= 18 ? shortTitle : reference.replace(/^[^(]+\(EU\)\s*/i, "");
+  return label.replace(/^(Regulation|Directive|Decision)\s*\(EU\)\s*/i, "");
+}
+
+function nodeRadius(provisions) {
+  return Math.max(5, Math.min(10, 4 + Math.sqrt(Number(provisions) || 1)));
+}
+
+/**
+ * A deliberately static citation preview: the API has already ranked the
+ * laws, so fixed positions are clearer and cheaper than a force simulation.
+ * Navigation remains in the adjacent list to avoid duplicate keyboard stops.
+ */
+export function MiniCitationGraph({ laws = [], total = 0, centreLabel, ariaLabel, formatMore }) {
+  const visible = laws.slice(0, NODE_POSITIONS.length);
+  const hiddenCount = Math.max(0, total - visible.length);
+  const centreText = String(centreLabel || "EU law").trim().slice(0, 12);
+
+  if (!visible.length) return null;
+
+  return (
+    <figure className="flex min-h-64 flex-col justify-center border-t border-gray-100 px-3 py-4 dark:border-gray-800 md:border-l md:border-t-0">
+      <svg
+        viewBox="0 0 360 216"
+        role="img"
+        aria-label={ariaLabel}
+        className="mx-auto block h-auto w-full max-w-[390px]"
+      >
+        <g className="stroke-eu-blue/35 dark:stroke-eu-blue-bright/40" strokeWidth="1.5">
+          {visible.map((law, index) => {
+            const position = NODE_POSITIONS[index];
+            return (
+              <line
+                key={`line-${law.celex}`}
+                x1={CENTRE.x}
+                y1={CENTRE.y}
+                x2={position.x}
+                y2={position.y}
+              />
+            );
+          })}
+        </g>
+
+        {visible.map((law, index) => {
+          const position = NODE_POSITIONS[index];
+          const onLeft = position.x < CENTRE.x;
+          const radius = nodeRadius(law.provisions);
+          return (
+            <g key={law.celex}>
+              <circle
+                cx={position.x}
+                cy={position.y}
+                r={radius}
+                className="fill-eu-blue dark:fill-eu-blue-bright"
+              />
+              <text
+                x={position.x + (onLeft ? -radius - 5 : radius + 5)}
+                y={position.y + 3}
+                textAnchor={onLeft ? "end" : "start"}
+                className="fill-gray-500 text-[8.5px] dark:fill-gray-400"
+              >
+                {compactLawLabel(law)}
+              </text>
+            </g>
+          );
+        })}
+
+        <circle
+          cx={CENTRE.x}
+          cy={CENTRE.y}
+          r="19"
+          className="fill-eu-navy dark:fill-gray-100"
+        />
+        <text
+          x={CENTRE.x}
+          y={CENTRE.y + 3}
+          textAnchor="middle"
+          className="fill-white text-[8px] font-semibold dark:fill-eu-navy"
+        >
+          {centreText}
+        </text>
+      </svg>
+      {hiddenCount > 0 ? (
+        <figcaption className="text-center text-[11px] text-gray-400 dark:text-gray-500">
+          {formatMore?.(hiddenCount) || `+${hiddenCount}`}
+        </figcaption>
+      ) : null}
+    </figure>
+  );
+}

--- a/src/components/law-viewer/LawOverviewPage.jsx
+++ b/src/components/law-viewer/LawOverviewPage.jsx
@@ -207,6 +207,7 @@ export function LawOverviewPage({
         implementing={meta.implementing}
         externalLawOverview={externalLawOverview}
         citedBy={meta.citedBy}
+        centreLabel={currentLaw?.label || title}
         currentLang={formexLang}
         locale={locale}
         onOpenExternalLaw={onOpenExternalLaw}


### PR DESCRIPTION
## What changed

- add a compact, fixed-position SVG constellation to the existing **Cited by** tab
- reuse the already-fetched top citing laws and citation counts
- show the current law at the centre and the remaining citing-law count below the preview
- stack the preview below the list on narrow screens and place it beside the list on wider screens
- preserve the existing list as the interactive navigation surface

## Why

The cited-by list already exposes the graph data, but the relationship is easy to miss. This adds a lightweight visual on-ramp without introducing a graph dependency, force simulation, animation loop, new API request, or expanded graph view.

## User impact

Users get an immediate visual summary of the strongest incoming citation relationships while retaining the current tab and list behavior. The preview supports light and dark themes and disappears cleanly when no citing laws are available.

## Validation

- `npm run test:web` — 28 files, 353 tests passed
- `npm run lint`
- `npm run build` — passed (existing bundle-size and offline prerender warnings only)
- `git diff --check`
