### PR TITLE
Share law summary cache version with clients

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Nearly every expensive operation — Formex parsing, TF‑IDF recital mapping, C
 | Citation graph edge/artifact shape | `GRAPH_VERSION` | `backend/search/citation-graph-store.js` (shared by builder and store) |
 | Offline CJEU detail shape (declarations, `articleRefs`) | `CASE_LAW_CACHE_FILE` → `case-law-cache-vN.json` (keep the offline legacy-migration path) | `backend/shared/law-queries.js` |
 | Recital-title prompt/output format | `CACHE_VERSION` | `backend/shared/recital-title-service.js` |
-| Law-summary JSON schema / prompt | `SCHEMA_VERSION` / `PROMPT_VERSION` | `backend/shared/law-summary-service.js` |
+| Law-summary cache / JSON schema / prompt | `cacheVersion` / `schemaVersion` / `promptVersion` | `backend/shared/law-summary-cache-version.json` (shared by backend and frontend) |
 | Article-digest JSON schema / prompt | `SCHEMA_VERSION` / `PROMPT_VERSION` | `backend/shared/article-digest-service.js` |
 | Whole-law digest JSON schema / prompt | `SCHEMA_VERSION` / `PROMPT_VERSION` | `backend/shared/case-law-digest-service.js` |
 | Persisted analytics shape (`analytics.json` fields) | `ANALYTICS_SCHEMA_VERSION` | `backend/shared/analytics.js` |
@@ -74,6 +74,8 @@ The data caches are the one entry above that isn't a code constant: they ship as
 
 `PARSER_VERSION` is **shared with the frontend** (imported into `src/utils/formexApi.js`), so bumping it re-parses the browser IndexedDB cache too. When you bump `CASE_LAW_CACHE_FILE`, also update `CASE_LAW_CACHE_VERSION` in `article-digest-service.js` **and** `case-law-digest-service.js` — they are kept in lock-step so digests regenerate when enrichment shape changes.
 
+The law-summary cache versions are also shared with the frontend through `backend/shared/law-summary-cache-version.json`. `fetchLawSummary` includes all three values in its IndexedDB key, so bumping any backend summary cache/schema/prompt version makes browsers fetch the regenerated summary immediately after loading the updated frontend.
+
 **Frontend, browser** (`src/`):
 
 | When you change… | Bump | In |
@@ -82,4 +84,5 @@ The data caches are the one entry above that isn't a code constant: they ship as
 | IndexedDB store shape (DB `formex-cache`) | `CACHE_VERSION` | `src/utils/formexApi.js` |
 | Cached recital-title envelope shape | `RECITAL_TITLE_CACHE_VERSION` | `src/utils/formexApi.js` |
 | Cached API-JSON payload shape | `API_JSON_CACHE_VERSION` | `src/utils/formexApi.js` |
+| Cached law-summary output | Shared law-summary versions | `backend/shared/law-summary-cache-version.json` |
 | Force every client to wipe local data once | `CURRENT_MIGRATION_VERSION` | `src/utils/resetApp.js` |

--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -9,7 +9,12 @@ const { createTopicsHandler } = require("../search/topics-route");
 const { fetchMetadata, fetchAmendments, fetchImplementing, fetchCaseLaw } = require("../shared/law-queries");
 const { ChatProviderError } = require("../shared/openrouter-chat");
 const { ensureRecitalTitles } = require("../shared/recital-title-service");
-const { ensureLawSummary } = require("../shared/law-summary-service");
+const {
+  CACHE_VERSION: LAW_SUMMARY_CACHE_VERSION,
+  PROMPT_VERSION: LAW_SUMMARY_PROMPT_VERSION,
+  SCHEMA_VERSION: LAW_SUMMARY_SCHEMA_VERSION,
+  ensureLawSummary,
+} = require("../shared/law-summary-service");
 const { ensureArticleDigest } = require("../shared/article-digest-service");
 const { ensureCaseLawDigest } = require("../shared/case-law-digest-service");
 
@@ -100,6 +105,7 @@ function registerApiRoutes(app, deps) {
     legalCacheStore,
     resolveEurlexUrl,
     resolveParsedLaw,
+    ensureLawSummary: ensureLawSummaryImpl = ensureLawSummary,
     resolveReference,
     runSparqlQuery,
     safeErrorResponse,
@@ -445,7 +451,7 @@ function registerApiRoutes(app, deps) {
       }
 
       const skipFmxProbe = req.query.skipFmxProbe === '1';
-      const result = await ensureLawSummary({
+      const result = await ensureLawSummaryImpl({
         celex,
         lang,
         cacheDir: FMX_DIR,
@@ -489,6 +495,9 @@ function registerApiRoutes(app, deps) {
       res.json({
         celex,
         lang,
+        cacheVersion: LAW_SUMMARY_CACHE_VERSION,
+        schemaVersion: LAW_SUMMARY_SCHEMA_VERSION,
+        promptVersion: LAW_SUMMARY_PROMPT_VERSION,
         model: result.model,
         cached: result.cached,
         generatedAt: result.generatedAt,

--- a/backend/routes/api-routes.test.js
+++ b/backend/routes/api-routes.test.js
@@ -10,6 +10,11 @@ const { createReferenceResolver } = require("../shared/reference-utils");
 const { ClientError, cacheGet, cacheSet, safeErrorResponse, toSearchLang } = require("../shared/api-utils");
 const { CitationGraphStore, GRAPH_VERSION } = require("../search/citation-graph-store");
 const { JsonLegalCacheStore } = require("../search/legal-cache-store");
+const {
+  CACHE_VERSION: LAW_SUMMARY_CACHE_VERSION,
+  PROMPT_VERSION: LAW_SUMMARY_PROMPT_VERSION,
+  SCHEMA_VERSION: LAW_SUMMARY_SCHEMA_VERSION,
+} = require("../shared/law-summary-service");
 
 const fixturePath = path.join(__dirname, "..", "search", "__fixtures__", "search-fixture.json");
 const gdprFmxPath = path.join(__dirname, "..", "..", "src", "__fixtures__", "gdpr.fmx.xml");
@@ -481,6 +486,31 @@ test("AI-backed static routes require their own OpenRouter key or the shared fal
     assert.equal(res.payload.code, "openrouter_unconfigured");
     assert.match(res.payload.error, /OpenRouter API key/);
     assert.equal(resolveParsedLawCalled, false);
+  });
+});
+
+test("GET /api/laws/:celex/summary returns the cache version contract", async () => {
+  await withOpenRouterEnv({ LAW_SUMMARY_OPENROUTER_API_KEY: "test-key" }, async () => {
+    const { app } = registerTestRoutes({
+      ensureLawSummary: async () => ({
+        model: "test-model",
+        cached: true,
+        generatedAt: "2026-07-16T00:00:00.000Z",
+        summary: { purpose: { text: "Test", citations: [] } },
+      }),
+    });
+    const handler = app.routes.get("/api/laws/:celex/summary");
+    const res = createResponseRecorder();
+
+    await handler({
+      params: { celex: "32016R0679" },
+      query: { lang: "ENG" },
+    }, res);
+
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.payload.cacheVersion, LAW_SUMMARY_CACHE_VERSION);
+    assert.equal(res.payload.schemaVersion, LAW_SUMMARY_SCHEMA_VERSION);
+    assert.equal(res.payload.promptVersion, LAW_SUMMARY_PROMPT_VERSION);
   });
 });
 

--- a/backend/shared/law-summary-cache-version.json
+++ b/backend/shared/law-summary-cache-version.json
@@ -1,0 +1,5 @@
+{
+  "cacheVersion": 1,
+  "schemaVersion": 3,
+  "promptVersion": 3
+}

--- a/backend/shared/law-summary-cache-version.json
+++ b/backend/shared/law-summary-cache-version.json
@@ -1,5 +1,5 @@
 {
-  "cacheVersion": 1,
+  "cacheVersion": 2,
   "schemaVersion": 3,
   "promptVersion": 3
 }

--- a/backend/shared/law-summary-service.js
+++ b/backend/shared/law-summary-service.js
@@ -4,6 +4,11 @@ const path = require('path');
 const { chatComplete } = require('./openrouter-chat');
 const { inferTypeFromCelex } = require('../search/search-ranking');
 const {
+  cacheVersion: CACHE_VERSION,
+  schemaVersion: SCHEMA_VERSION,
+  promptVersion: PROMPT_VERSION,
+} = require('./law-summary-cache-version.json');
+const {
   stripTags,
   normalizeText,
   stableHash,
@@ -13,9 +18,6 @@ const {
 } = require('./ai-digest-utils');
 
 const CACHE_FILE = 'law-summary-cache-v1.json';
-const CACHE_VERSION = 1;
-const SCHEMA_VERSION = 3;
-const PROMPT_VERSION = 3;
 const MAX_ARTICLE_TEXT_CHARS = 6000;
 const MAX_RECITAL_COUNT = 60;
 const MAX_RECITAL_TEXT_CHARS = 700;

--- a/src/utils/formexApi.indexedDb.test.js
+++ b/src/utils/formexApi.indexedDb.test.js
@@ -73,6 +73,26 @@ describe("law summary cache versioning", () => {
     const { makeLawSummaryCacheKey } = await importFormexApi();
 
     expect(makeLawSummaryCacheKey("32016R0679"))
-      .toBe("32016R0679_ENG_summary_v1_schema3_prompt3");
+      .toBe("32016R0679_ENG_summary_v2_schema3_prompt3");
+  });
+
+  it("does not cache a response from a mismatched backend version", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        celex: "32016R0679",
+        lang: "ENG",
+        cacheVersion: 1,
+        schemaVersion: 3,
+        promptVersion: 3,
+        summary: { purpose: { text: "stale", citations: [] } },
+      }),
+    }));
+
+    const { fetchLawSummary } = await importFormexApi();
+    await expect(fetchLawSummary("32016R0679")).rejects.toMatchObject({
+      code: "cache_version_mismatch",
+      status: 409,
+    });
   });
 });

--- a/src/utils/formexApi.indexedDb.test.js
+++ b/src/utils/formexApi.indexedDb.test.js
@@ -67,3 +67,12 @@ describe("Formex IndexedDB connection lifecycle", () => {
     expect(lateDb.close).toHaveBeenCalledOnce();
   });
 });
+
+describe("law summary cache versioning", () => {
+  it("uses the backend cache, schema, and prompt versions in the browser key", async () => {
+    const { makeLawSummaryCacheKey } = await importFormexApi();
+
+    expect(makeLawSummaryCacheKey("32016R0679"))
+      .toBe("32016R0679_ENG_summary_v1_schema3_prompt3");
+  });
+});

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -6,6 +6,7 @@
  */
 
 import { PARSER_VERSION, parseFmxToCombined, isFmxDocument } from "./fmxParser.js";
+import lawSummaryCacheVersion from "../../backend/shared/law-summary-cache-version.json";
 
 export const API_BASE = (() => {
   if (typeof import.meta !== "undefined" && import.meta.env?.VITE_FORMEX_API_BASE) {
@@ -825,8 +826,13 @@ export async function fetchRecitalTitles(celex, lang = "EN") {
 
 // Law summaries are generated in English only for now, regardless of the
 // reading language.
+export function makeLawSummaryCacheKey(celex) {
+  const { cacheVersion, schemaVersion, promptVersion } = lawSummaryCacheVersion;
+  return `${celex}_ENG_summary_v${cacheVersion}_schema${schemaVersion}_prompt${promptVersion}`;
+}
+
 export async function fetchLawSummary(celex) {
-  const key = `${celex}_ENG_summary`;
+  const key = makeLawSummaryCacheKey(celex);
   return getInFlightRequest(`law-summary:${key}`, () => fetchJsonWithCache({
     cacheKey: key,
     url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/summary?lang=ENG`,

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -6,7 +6,7 @@
  */
 
 import { PARSER_VERSION, parseFmxToCombined, isFmxDocument } from "./fmxParser.js";
-import lawSummaryCacheVersion from "../../backend/shared/law-summary-cache-version.json";
+import lawSummaryCacheVersion from "../../backend/shared/law-summary-cache-version.json" with { type: "json" };
 
 export const API_BASE = (() => {
   if (typeof import.meta !== "undefined" && import.meta.env?.VITE_FORMEX_API_BASE) {
@@ -240,6 +240,7 @@ async function fetchJsonWithCache({
   errorLabel,
   cacheFirst = false,
   maxAgeMs = API_JSON_CACHE_MAX_AGE_MS,
+  validatePayload = null,
 }) {
   const cached = await cacheGet(cacheKey);
   const envelope = isApiJsonEnvelope(cached) ? cached : null;
@@ -255,6 +256,12 @@ async function fetchJsonWithCache({
       await readApiError(res, `${errorLabel} (${res.status})`);
     }
     const payload = await res.json();
+    if (typeof validatePayload === "function" && !validatePayload(payload)) {
+      throw new FormexApiError(`${errorLabel} returned an incompatible version`, {
+        status: 409,
+        code: "cache_version_mismatch",
+      });
+    }
     await cacheSet(cacheKey, createApiJsonEnvelope(payload));
     return payload;
   } catch (error) {
@@ -831,6 +838,12 @@ export function makeLawSummaryCacheKey(celex) {
   return `${celex}_ENG_summary_v${cacheVersion}_schema${schemaVersion}_prompt${promptVersion}`;
 }
 
+function isCurrentLawSummaryPayload(payload) {
+  return payload?.cacheVersion === lawSummaryCacheVersion.cacheVersion
+    && payload?.schemaVersion === lawSummaryCacheVersion.schemaVersion
+    && payload?.promptVersion === lawSummaryCacheVersion.promptVersion;
+}
+
 export async function fetchLawSummary(celex) {
   const key = makeLawSummaryCacheKey(celex);
   return getInFlightRequest(`law-summary:${key}`, () => fetchJsonWithCache({
@@ -838,6 +851,7 @@ export async function fetchLawSummary(celex) {
     url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/summary?lang=ENG`,
     errorLabel: "Law summary fetch failed",
     cacheFirst: true,
+    validatePayload: isCurrentLawSummaryPayload,
   }));
 }
 


### PR DESCRIPTION
## What changed

- move the law-summary cache, schema, and prompt versions into a browser-safe shared manifest
- make the backend consume that shared version metadata
- include all three versions in the frontend IndexedDB summary cache key
- add regression coverage and document the cross-layer cache contract

## Why

The backend correctly rejected summaries generated with an old prompt, but clients that had already cached the API response used the browser's cache-first seven-day TTL. As a result, they could continue seeing an old AI summary for up to seven days after a prompt deployment.

Versioning the frontend key with the same metadata used by the backend makes old browser entries unreachable once clients load the updated frontend. Future prompt or schema bumps now invalidate both layers together.

## Validation

- `npm run test:web -- --run src/utils/formexApi.indexedDb.test.js` — 3 passed
- `node --test shared/law-summary-service.test.js` — 7 passed
- `npx vite build` — passed
- `git diff --check` — passed
