### PR TITLE
Deploy definition index data release

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -39,7 +39,7 @@ COPY search/build-sqlite-data.js search/search-ranking.js ./search/
 # Placed before `COPY . .` so this (large) layer stays cached across code
 # changes and only re-runs when DATA_RELEASE_TAG is bumped for a new data build.
 ARG DATA_RELEASE_REPO=maastrichtlawtech/legalviz.eu
-ARG DATA_RELEASE_TAG=data-v10
+ARG DATA_RELEASE_TAG=data-v11
 # Every asset comes from this one tag, so a new release must carry the full set —
 # re-upload the unchanged ones alongside the changed one or this fetch 404s.
 # citation-graph.json.gz is a *build input* like the others: it is folded into


### PR DESCRIPTION
## What changed\n\n- bumps the backend Docker build from immutable data release `data-v10` to `data-v11`\n- `data-v11` carries forward the validated search, case-law, and citation-graph assets unchanged\n- adds the generated `definitions.json.gz` asset\n\n## Why\n\nProduction reports `Definition index is not available` because `data-v10` does not contain the optional definitions asset. The Docker build therefore disables the definition tables.\n\n## Data validation\n\n- 80,465 laws parsed\n- 21,861 definition occurrences across 11,986 terms\n- 7,513 usage edges\n- zero parse failures and zero duplicate occurrence IDs\n- all four gzip assets pass integrity checks\n- carried-forward asset SHA-256 digests match `data-v10`\n- published `definitions.json.gz` SHA-256: `6b18d0f54e79acfe7081605315f45906ee3a68c088fe7d6b30be1e7fb1410269`\n\nRelease: https://github.com/maastrichtlawtech/legalviz.eu/releases/tag/data-v11