### PR TITLE
Fix legacy law references and headings

### DIFF
--- a/backend/shared/eurlex-html-parser.js
+++ b/backend/shared/eurlex-html-parser.js
@@ -73,8 +73,9 @@ function isLikelyArticleTitle(text) {
   if (isArticleHeading(text) || isAnnexHeading(text)) return false;
   if (/^\d+\./.test(text)) return false;
   if (/^\([a-z0-9ivxlcdm]+\)/i.test(text)) return false;
+  if (/^[-\u2010-\u2015]/.test(text)) return false;
   if (text.length > 180) return false;
-  return !/[.;!?]$/.test(text);
+  return !/[.:;!?]$/.test(text);
 }
 
 function parseDivisionMarker(text) {
@@ -549,6 +550,7 @@ function parseArticles(paragraphs) {
       currentArticle = {
         article_number: articleNumberMatch ? articleNumberMatch[1] : String(articles.length + 1),
         article_title: "",
+        titleCandidatePending: true,
         division: {
           chapter: { ...currentChapter },
           section: currentSection.number ? { ...currentSection } : null,
@@ -560,11 +562,14 @@ function parseArticles(paragraphs) {
 
     if (!currentArticle) continue;
 
-    if (!currentArticle.article_title && isLikelyArticleTitle(paragraph) && !isLikelyDivisionTitle(paragraph)) {
+    if (currentArticle.titleCandidatePending
+        && isLikelyArticleTitle(paragraph) && !isLikelyDivisionTitle(paragraph)) {
       currentArticle.article_title = paragraph;
+      currentArticle.titleCandidatePending = false;
       continue;
     }
 
+    currentArticle.titleCandidatePending = false;
     currentArticle.bodyParagraphs.push(paragraph);
   }
 

--- a/backend/shared/eurlex-html-parser.test.js
+++ b/backend/shared/eurlex-html-parser.test.js
@@ -56,6 +56,30 @@ test("parseEurlexHtmlToCombined extracts title, recitals, articles, and definiti
   assert.equal(parsed.definitions[0].sourceArticle, "2");
 });
 
+test("legacy TXT_TE parsing does not promote operative clauses to article titles", async () => {
+  const html = `<!DOCTYPE html><html lang="EN"><head>
+    <meta name="DC.description" content="Council Directive 91/271/EEC">
+  </head><body><div id="TexteOnly"><TXT_TE>
+    <p>Article 2</p>
+    <p>For the purpose of this Directive:</p>
+    <p>1. "urban waste water" means domestic waste water;</p>
+    <p>Article 3</p>
+    <p>- at the latest by 31 December 2000 for those with a p.e. of more than 15000, and</p>
+    <p>1. Member States shall ensure that all agglomerations are provided with collecting systems.</p>
+    <p>Article 4</p>
+    <p>1. Member States shall ensure that urban waste water is treated.</p>
+    <p>For the Council</p>
+  </TXT_TE></div></body></html>`;
+  const parsed = await parseEurlexHtmlToCombined(html, "ENG");
+
+  assert.equal(parsed.articles[0].article_title, "");
+  assert.match(parsed.articles[0].article_html, /For the purpose of this Directive:/);
+  assert.equal(parsed.articles[1].article_title, "");
+  assert.match(parsed.articles[1].article_html, /at the latest by 31 December 2000/);
+  assert.equal(parsed.articles[2].article_title, "");
+  assert.match(parsed.articles[2].article_html, /For the Council/);
+});
+
 test("HTML definitions retain their point and exact cross-reference provenance", async () => {
   const html = SAMPLE_HTML.replace(
     "any data processed for billing",

--- a/backend/shared/formex-parser/fmxParser.mjs
+++ b/backend/shared/formex-parser/fmxParser.mjs
@@ -33,7 +33,7 @@ import {
  * Bump this whenever the parser output changes (new fields, bug fixes, etc.)
  * so that cached parsed results are automatically re-parsed from raw XML.
  */
-export const PARSER_VERSION = 18;
+export const PARSER_VERSION = 19;
 
 // ---------------------------------------------------------------------------
 // FMX → HTML conversion helpers

--- a/backend/shared/formex-parser/fmxParser.test.js
+++ b/backend/shared/formex-parser/fmxParser.test.js
@@ -840,6 +840,16 @@ describe("injectCrossRefLinks", () => {
     expect(result).toContain('data-ref-point="g"');
   });
 
+  it("links abbreviated paragraphs through an institutional act author", () => {
+    const html = "<p>as defined in Article 2(1), (2) and (3) of Council Directive 91/271/EEC.</p>";
+    const result = injectCrossRefLinks(html, lang);
+    const linkedParagraphs = [...result.matchAll(/data-ref-paragraph="(\d+)"/g)].map((match) => match[1]);
+    expect(linkedParagraphs).toEqual(["1", "2", "3"]);
+    expect(result).not.toContain('href="#article-2"');
+    // Three provision links plus the independently clickable act name.
+    expect(result.match(/data-ref-year="1991"/g)).toHaveLength(4);
+  });
+
   it("links both coordinated internal articles (not just the first)", () => {
     const html = "<p>governed by Article 5 and Article 6 of this Regulation.</p>";
     const result = injectCrossRefLinks(html, lang);
@@ -879,6 +889,18 @@ describe("extractCrossRefsFromText — multi-article citations", () => {
     expect(refs).toHaveLength(11);
     expect(refs.map((r) => r.articleNumber)).toContain("12");
     expect(refs.map((r) => r.articleNumber)).toContain("22");
+  });
+
+  it("binds abbreviated paragraphs to a Council Directive", () => {
+    const refs = extractCrossRefsFromText(
+      "as defined in Article 2(1), (2) and (3) of Council Directive 91/271/EEC",
+      lang,
+    ).filter((ref) => ref.type === "external" && ref.actCelex === "31991L0271");
+    expect(refs.map((ref) => [ref.articleNumber, ref.paragraph])).toEqual([
+      ["2", "1"],
+      ["2", "2"],
+      ["2", "3"],
+    ]);
   });
 
   it("keeps distinct articles of the same act as separate edges (dedup key)", () => {

--- a/backend/shared/legal-reference-core.mjs
+++ b/backend/shared/legal-reference-core.mjs
@@ -363,9 +363,14 @@ function isArticleOfActBridge(gap, connectorWord = 'of') {
   // also commonly insert the closed parenthetical "as the case may be" before
   // the final "of"; accepting that phrase is still considerably narrower than
   // allowing arbitrary prose between an article and an act.
-  if (!new RegExp(`(?:^|\\W)(?:${connectorWord})(?:\\s+the)?$`, 'i').test(trimmed)) return false;
+  // Instrument names are often prefixed by their institutional author, which
+  // is not part of EXTERNAL_LAW_RE's match: "Article 2 of Council Directive
+  // 91/271/EEC" therefore leaves "of Council" in this bridge. Accept only the
+  // closed set of EU-author forms that can immediately introduce an act.
+  const issuer = '(?:Council|Commission|European\\s+Parliament(?:\\s+and\\s+(?:the\\s+)?Council)?)';
+  if (!new RegExp(`(?:^|\\W)(?:${connectorWord})(?:\\s+the)?(?:\\s+${issuer})?$`, 'i').test(trimmed)) return false;
   const body = trimmed
-    .replace(new RegExp(`(?:${connectorWord})(?:\\s+the)?$`, 'i'), ' ')
+    .replace(new RegExp(`(?:${connectorWord})(?:\\s+the)?(?:\\s+${issuer})?$`, 'i'), ' ')
     .replace(/\bas\s+the\s+case\s+may\s+be\b/gi, ' ')
     .replace(/\([^)]*\)/g, ' ')
     .replace(new RegExp(`\\b(?:${connectorWord}|and|or|to|point|points|paragraph|paragraphs|subparagraph|subparagraphs|indent|indents|thereof|Articles?|Artikels?|Art[ií]culos?|Articolo|Articoli|Artigos?|Artikelen?)\\b`, 'gi'), ' ')


### PR DESCRIPTION
## Summary

- Link coordinated paragraph citations through institutional authors, including `Article 2(1), (2) and (3) of Council Directive 91/271/EEC`.
- Preserve operative clauses in legacy EUR-Lex `<TXT_TE>` laws instead of turning them into article headings.
- Invalidate cached parser output so affected laws are reparsed.

## Root cause

The article-to-act bridge expected the external instrument to start immediately after `of`, while the legal text inserts an author such as `Council`. The legacy heading heuristic also treated any later short line without terminal punctuation as a title, allowing list items and signature text to displace article content.

## Impact

Readers now reach the cited external directive from each referenced paragraph, and legacy acts retain their original operative text without fabricated table-of-contents headings.

## Validation

- `npm test` — 367 frontend tests passed; 370 backend tests passed; 2 corpus-dependent tests skipped.
- Targeted ESLint and `git diff --check` passed.

## Follow-up prevention

The regression tests cover institutional authors and legacy dash/colon clauses. A useful next incremental hardening step is a small corpus fixture matrix that snapshots article number, title, and first body blocks across every known EUR-Lex HTML layout, then adds each newly reported law as a fixture before changing heuristics.
