### PR TITLE
Switch default AI model to cheaper gemini-3.5-flash-lite

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -287,7 +287,7 @@ cache.
 {
   "celex": "32016R0679",
   "lang": "ENG",
-  "model": "google/gemini-2.5-pro",
+  "model": "google/gemini-3.5-flash-lite",
   "cached": true,
   "titles": {
     "1": "Protection of natural persons",
@@ -776,11 +776,11 @@ Current test coverage includes:
 | `LAW_SUMMARY_OPENROUTER_API_KEY` | Optional OpenRouter key used for law summaries and article case-law digests. Falls back to `ARTICLE_QA_OPENROUTER_API_KEY`, then `OPENROUTER_API_KEY`. |
 | `ARTICLE_QA_OPENROUTER_API_KEY` | Legacy fallback key still accepted for static summary generation. |
 | `RECITAL_TITLE_OPENROUTER_API_KEY` | Optional OpenRouter key used only for recital-title generation and `eurlex recital-titles`. Falls back to `OPENROUTER_API_KEY`. |
-| `LAW_SUMMARY_MODEL` | Model for cached law summaries. Default falls back through `ARTICLE_QA_ANSWER_MODEL`, `ARTICLE_QA_MODEL`, then `google/gemini-2.5-pro`. |
-| `ARTICLE_DIGEST_MODEL` | Model for cached article case-law digests. Default falls back through `LAW_SUMMARY_MODEL`, `ARTICLE_QA_ANSWER_MODEL`, `ARTICLE_QA_MODEL`, then `google/gemini-2.5-pro`. |
+| `LAW_SUMMARY_MODEL` | Model for cached law summaries. Default falls back through `ARTICLE_QA_ANSWER_MODEL`, `ARTICLE_QA_MODEL`, then `google/gemini-3.5-flash-lite`. |
+| `ARTICLE_DIGEST_MODEL` | Model for cached article case-law digests. Default falls back through `LAW_SUMMARY_MODEL`, `ARTICLE_QA_ANSWER_MODEL`, `ARTICLE_QA_MODEL`, then `google/gemini-3.5-flash-lite`. |
 | `ARTICLE_QA_MODEL` / `ARTICLE_QA_ANSWER_MODEL` | Legacy model fallbacks still accepted for static summary generation. |
 | `ARTICLE_QA_PLANNER_MODEL` | Legacy model fallback used only by recital-title defaults. |
-| `RECITAL_TITLE_MODEL` | Model for cached AI-generated recital titles. Default `google/gemini-2.5-pro`. |
+| `RECITAL_TITLE_MODEL` | Model for cached AI-generated recital titles. Default `google/gemini-3.5-flash-lite`. |
 | `PLAYWRIGHT_HEADLESS` / `PLAYWRIGHT_BROWSERS_PATH` / `PLAYWRIGHT_MODULE_PATH` / `LEGALVIZ_PLAYWRIGHT_MODULE_PATH` | Playwright configuration for fetching laws that require rendering. |
 
 ## Notes

--- a/backend/bin/eurlex.js
+++ b/backend/bin/eurlex.js
@@ -20,7 +20,7 @@ const EURLEX_BASE = 'https://eur-lex.europa.eu';
 const TIMEOUT_MS = parseInt(process.env.TIMEOUT_MS) || 30_000;
 const STORAGE_LIMIT_MB = parseInt(process.env.STORAGE_LIMIT_MB) || 500;
 const RESOLUTION_CACHE_MS = 24 * 60 * 60 * 1000;
-const DEFAULT_RECITAL_TITLE_MODEL = process.env.RECITAL_TITLE_MODEL || process.env.ARTICLE_QA_PLANNER_MODEL || process.env.ARTICLE_QA_MODEL || 'google/gemini-2.5-pro';
+const DEFAULT_RECITAL_TITLE_MODEL = process.env.RECITAL_TITLE_MODEL || process.env.ARTICLE_QA_PLANNER_MODEL || process.env.ARTICLE_QA_MODEL || 'google/gemini-3.5-flash-lite';
 
 function getRecitalTitleApiKey() {
   return process.env.RECITAL_TITLE_OPENROUTER_API_KEY || process.env.OPENROUTER_API_KEY;

--- a/backend/mcp/register-tools.js
+++ b/backend/mcp/register-tools.js
@@ -10,7 +10,7 @@ const DEFAULT_RECITAL_TITLE_MODEL =
   process.env.RECITAL_TITLE_MODEL
   || process.env.ARTICLE_QA_PLANNER_MODEL
   || process.env.ARTICLE_QA_MODEL
-  || 'google/gemini-2.5-pro';
+  || 'google/gemini-3.5-flash-lite';
 
 function getRecitalTitleApiKey() {
   return process.env.RECITAL_TITLE_OPENROUTER_API_KEY || process.env.OPENROUTER_API_KEY;

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,7 +23,7 @@
         "parse-fmx": "bin/parse-fmx.js"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.12"
       },
       "optionalDependencies": {
         "adm-zip": "^0.5.16"

--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -14,10 +14,10 @@ const { ensureLawSummary } = require("../shared/law-summary-service");
 const { ensureArticleDigest } = require("../shared/article-digest-service");
 const { ensureCaseLawDigest } = require("../shared/case-law-digest-service");
 
-const DEFAULT_STATIC_SUMMARY_MODEL = process.env.LAW_SUMMARY_MODEL || process.env.ARTICLE_QA_ANSWER_MODEL || process.env.ARTICLE_QA_MODEL || 'google/gemini-2.5-pro';
-const DEFAULT_ARTICLE_DIGEST_MODEL = process.env.ARTICLE_DIGEST_MODEL || process.env.LAW_SUMMARY_MODEL || process.env.ARTICLE_QA_ANSWER_MODEL || process.env.ARTICLE_QA_MODEL || 'google/gemini-2.5-pro';
-const DEFAULT_CASE_LAW_DIGEST_MODEL = process.env.CASE_LAW_DIGEST_MODEL || process.env.ARTICLE_DIGEST_MODEL || process.env.LAW_SUMMARY_MODEL || process.env.ARTICLE_QA_ANSWER_MODEL || process.env.ARTICLE_QA_MODEL || 'google/gemini-2.5-pro';
-const DEFAULT_RECITAL_TITLE_MODEL = process.env.RECITAL_TITLE_MODEL || process.env.ARTICLE_QA_PLANNER_MODEL || process.env.ARTICLE_QA_MODEL || 'google/gemini-2.5-pro';
+const DEFAULT_STATIC_SUMMARY_MODEL = process.env.LAW_SUMMARY_MODEL || process.env.ARTICLE_QA_ANSWER_MODEL || process.env.ARTICLE_QA_MODEL || 'google/gemini-3.5-flash-lite';
+const DEFAULT_ARTICLE_DIGEST_MODEL = process.env.ARTICLE_DIGEST_MODEL || process.env.LAW_SUMMARY_MODEL || process.env.ARTICLE_QA_ANSWER_MODEL || process.env.ARTICLE_QA_MODEL || 'google/gemini-3.5-flash-lite';
+const DEFAULT_CASE_LAW_DIGEST_MODEL = process.env.CASE_LAW_DIGEST_MODEL || process.env.ARTICLE_DIGEST_MODEL || process.env.LAW_SUMMARY_MODEL || process.env.ARTICLE_QA_ANSWER_MODEL || process.env.ARTICLE_QA_MODEL || 'google/gemini-3.5-flash-lite';
+const DEFAULT_RECITAL_TITLE_MODEL = process.env.RECITAL_TITLE_MODEL || process.env.ARTICLE_QA_PLANNER_MODEL || process.env.ARTICLE_QA_MODEL || 'google/gemini-3.5-flash-lite';
 
 function getStaticSummaryApiKey() {
   return process.env.LAW_SUMMARY_OPENROUTER_API_KEY


### PR DESCRIPTION
## Summary

All four AI features — recital titles, law summaries, article case-law digests, and whole-law case-law digests — defaulted to the same model, `google/gemini-2.5-pro`. That model is now a generation behind (current Gemini is 3.5/3.6) yet still priced near-flagship at **$1.25 in / $10.00 out** per million tokens.

This changes the default to **`google/gemini-3.5-flash-lite`** (**$0.30 in / $2.50 out** per M) — a current-generation model with a 1M-token context window in the same provider family, so prompt and JSON-output behaviour carry over with minimal risk. That's roughly **4x cheaper** on both input and output for these cache-miss-only generations.

Pricing checked live against the OpenRouter models API (July 2026).

## Changes

- `backend/routes/api-routes.js` — default for `DEFAULT_STATIC_SUMMARY_MODEL`, `DEFAULT_ARTICLE_DIGEST_MODEL`, `DEFAULT_CASE_LAW_DIGEST_MODEL`, `DEFAULT_RECITAL_TITLE_MODEL`.
- `backend/bin/eurlex.js` — CLI recital-title default.
- `backend/mcp/register-tools.js` — MCP recital-title default.
- `backend/README.md` — env-var defaults and the recital-titles example response.

Each feature stays independently overridable through its existing env var (`LAW_SUMMARY_MODEL`, `ARTICLE_DIGEST_MODEL`, `CASE_LAW_DIGEST_MODEL`, `RECITAL_TITLE_MODEL`).

## Cache impact

No cache-version bump required. The model id is folded into every cache key (e.g. `law-summary:${key}:${model}`) and each stored entry records the model it was produced with, so switching the default invalidates lazily and per-model: existing caches stay valid and the new default regenerates only on the next miss.

## Testing

- `npm test` (backend): 369 pass, 2 skipped (pre-existing), 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017PDv3S717dWYLiJ8gfeD6K)_