### PR TITLE
Resolve implementing/delegated acts by trying all ELI subtypes

### DIFF
--- a/backend/shared/reference-utils.js
+++ b/backend/shared/reference-utils.js
@@ -207,21 +207,32 @@ function buildEliCandidates(reference) {
     );
   }
 
+  // The FMX-style reference carries no act subtype, but EUR-Lex/Cellar mint a
+  // distinct ELI per subtype: a basic act uses `reg`/`dir`/`dec`, while
+  // implementing and delegated acts use `reg_impl`/`reg_del` (etc.). These share
+  // the same year/number sequences per subtype, so a plain `reg` lookup misses
+  // e.g. Commission Implementing Regulation (EU) No 28/2014 (`reg_impl/2014/28`).
+  // Try the basic subtype first (the common case) and fall back to the others.
+  const eli = (type, num = number) =>
+    `http://publications.europa.eu/resource/eli/${type}/${reference.year}/${num}/oj`;
+
   if (reference.actType === 'directive') {
-    return [`http://publications.europa.eu/resource/eli/dir/${reference.year}/${number}/oj`];
+    return [eli('dir'), eli('dir_impl'), eli('dir_del')];
   }
 
   if (reference.actType === 'regulation') {
-    return [`http://publications.europa.eu/resource/eli/reg/${reference.year}/${number}/oj`];
+    return [eli('reg'), eli('reg_impl'), eli('reg_del')];
   }
 
   if (reference.actType === 'decision') {
     const candidates = [];
     if (reference.suffix === 'JHA') {
-      candidates.push(`http://publications.europa.eu/resource/eli/dec_framw/${reference.year}/${number}/oj`);
+      candidates.push(eli('dec_framw'));
     }
-    candidates.push(`http://publications.europa.eu/resource/eli/dec/${reference.year}/${number}/oj`);
-    candidates.push(`http://publications.europa.eu/resource/eli/dec/${reference.year}/${number}(1)/oj`);
+    candidates.push(eli('dec'));
+    candidates.push(eli('dec', `${number}(1)`));
+    candidates.push(eli('dec_impl'));
+    candidates.push(eli('dec_del'));
     return [...new Set(candidates)];
   }
 

--- a/backend/shared/reference-utils.test.js
+++ b/backend/shared/reference-utils.test.js
@@ -72,6 +72,32 @@ test('buildEliCandidates handles decision JHA suffix', () => {
   assert.ok(candidates.includes('http://publications.europa.eu/resource/eli/dec/2008/977/oj'));
 });
 
+test('buildEliCandidates includes implementing/delegated regulation subtypes', () => {
+  // CELEX 32014R0028 is Commission Implementing Regulation (EU) No 28/2014,
+  // whose ELI is reg_impl/2014/28 -- a plain reg lookup misses it.
+  const candidates = buildEliCandidates({
+    actType: 'regulation',
+    year: '2014',
+    number: '28',
+  });
+  assert.deepEqual(candidates, [
+    'http://publications.europa.eu/resource/eli/reg/2014/28/oj',
+    'http://publications.europa.eu/resource/eli/reg_impl/2014/28/oj',
+    'http://publications.europa.eu/resource/eli/reg_del/2014/28/oj',
+  ]);
+});
+
+test('buildEliCandidates includes implementing/delegated directive subtypes', () => {
+  const candidates = buildEliCandidates({
+    actType: 'directive',
+    year: '2019',
+    number: '790',
+  });
+  assert.ok(candidates.includes('http://publications.europa.eu/resource/eli/dir/2019/790/oj'));
+  assert.ok(candidates.includes('http://publications.europa.eu/resource/eli/dir_impl/2019/790/oj'));
+  assert.ok(candidates.includes('http://publications.europa.eu/resource/eli/dir_del/2019/790/oj'));
+});
+
 test('validateCelex accepts canonical CELEX format', () => {
   assert.equal(validateCelex('32016R0679'), true);
   assert.equal(validateCelex('32016R0679(01)'), true);
@@ -280,7 +306,8 @@ test('resolveEurlexUrl keeps OJ fallback path when cache cannot resolve determin
     const result = await resolver.resolveEurlexUrl('https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=OJ:L:2015:00999:TOC', 'ENG');
     assert.equal(result.resolved, null);
     assert.equal(result.fallback?.type, 'open-source-url');
-    assert.equal(fetchCalls.length, 4);
+    // 3 act types x their subtype candidates: reg(3) + dir(3) + dec(4) = 10.
+    assert.equal(fetchCalls.length, 10);
   } finally {
     restore();
   }


### PR DESCRIPTION
## Problem

Loading `https://legalviz.eu/regulation-2014-28` fails with "law load failed".

The slug `regulation-2014-28` maps to the FMX-style reference `{ actType: regulation, year: 2014, number: 28 }`. `buildEliCandidates` turned that into a single ELI, `eli/reg/2014/28/oj`, and looked it up via Cellar SPARQL. But CELEX `32014R0028` is **Commission Implementing Regulation (EU) No 28/2014**, whose real ELI subtype is `reg_impl` (`eli/reg_impl/2014/28/oj`). The `reg` lookup returns nothing, so resolution yields no CELEX and the reader shows the load-failure state.

An FMX reference carries no act subtype, yet EUR-Lex/Cellar mint a distinct ELI per subtype (`reg` vs `reg_impl` vs `reg_del`, and the directive/decision equivalents), each with its own year/number sequence. The same gap affected delegated regulations and implementing/delegated directives and decisions.

Verified against Cellar SPARQL: `eli/reg/2014/28/oj` → no bindings; `eli/reg_impl/2014/28/oj` → `celex/32014R0028`.

## Change

`buildEliCandidates` now tries the basic subtype first (the common case) and falls back to the implementing and delegated subtypes:

- regulation → `reg`, `reg_impl`, `reg_del`
- directive → `dir`, `dir_impl`, `dir_del`
- decision → `dec_framw` (JHA only), `dec`, `dec(1)`, `dec_impl`, `dec_del`

The resolver loop already returns on the first ELI that resolves, so the basic act still wins when it exists; the extra candidates only get queried on a miss.

## Tests

- New `buildEliCandidates` cases asserting the regulation and directive subtype lists.
- Updated the OJ-resolution fetch-count assertion (3 act types now expand to 10 candidate queries on a full miss).
- Full backend suite: 353 pass, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LhkiCFGQ6AicaTr9kr11um

---
_Generated by [Claude Code](https://claude.ai/code/session_01LhkiCFGQ6AicaTr9kr11um)_