### PR TITLE
Serialize GitHub Pages deployments with a concurrency group

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,6 +8,11 @@ permissions:
   contents: read
   pages: write
   id-token: write
+# Serialize Pages deployments: allow an in-progress deploy to finish and queue
+# newer ones, so concurrent pushes to main don't collide at the Pages API.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What

Adds a `pages` concurrency group (with `cancel-in-progress: false`) to `.github/workflows/pages.yml`.

## Why

The "Deploy Vite to GitHub Pages" workflow failed on the latest `main` commit ([`cf096af`](https://github.com/maastrichtlawtech/legalviz.eu/commit/cf096af4)):

```
HttpError: Deployment request failed for cf096af4… due to in progress deployment.
Please cancel ba308f88… first or wait for it to complete.
Error: Failed to create deployment (status: 400)
```

Two commits landed on `main` within seconds of each other (`ba308f88` → #129, `cf096af4` → #131). Each triggered its own `pages.yml` run, and with no concurrency control the two `deploy` jobs raced to call the GitHub Pages deployment API. The Pages API only permits one in-progress deployment per environment, so the second run got a `400`.

This is an infrastructure race, not a code defect — the build, lint, and tests all passed.

## Fix

```yaml
concurrency:
  group: pages
  cancel-in-progress: false
```

With `cancel-in-progress: false`, overlapping runs queue instead of running in parallel, so a newer deploy waits for the in-progress one to finish rather than colliding at the API. This matches GitHub's [recommended configuration](https://github.com/actions/deploy-pages#usage) for the Pages deploy action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQbVpjUY8sTnUsPYr6g8rX)_