### PR TITLE
Fix definition popup flashing shut on mobile tap

### DIFF
--- a/src/components/law-viewer/DefinitionTooltip.jsx
+++ b/src/components/law-viewer/DefinitionTooltip.jsx
@@ -5,6 +5,11 @@ import { GitCompare, X } from "lucide-react";
 const VIEWPORT_MARGIN = 8;
 const ANCHOR_GAP = 8;
 const CLOSE_DELAY_MS = 150;
+// Tapping a term focuses its tabindex=0 span, so the browser scrolls it into
+// view and (on mobile) toggles the URL bar, firing scroll/resize right after
+// open. Ignore those for a beat so the popup isn't dismissed by the very
+// gesture that opened it.
+const OPEN_SETTLE_MS = 350;
 // Below this width an anchored popup has nowhere sensible to go, so we
 // render a bottom sheet instead.
 const SHEET_MEDIA_QUERY = "(max-width: 640px)";
@@ -35,6 +40,7 @@ export function DefinitionTooltip({ t, onCompareDefinition }) {
   const closeTimerRef = useRef(null);
   const focusCompareOnOpenRef = useRef(false);
   const returnFocusRef = useRef(null);
+  const openedAtRef = useRef(0);
 
   const cancelScheduledClose = useCallback(() => {
     if (closeTimerRef.current) {
@@ -66,6 +72,7 @@ export function DefinitionTooltip({ t, onCompareDefinition }) {
   useEffect(() => {
     const openFromElement = (el) => {
       cancelScheduledClose();
+      openedAtRef.current = Date.now();
       setActive({
         term: el.getAttribute("data-term") || el.textContent,
         definition: el.getAttribute("data-definition") || "",
@@ -124,11 +131,24 @@ export function DefinitionTooltip({ t, onCompareDefinition }) {
       if (el) openFromElement(el);
     };
 
-    // Any scroll invalidates the anchored position; the sheet is
-    // viewport-fixed, so only close when the popup itself isn't scrolling.
-    const handleScroll = (event) => {
-      if (isSheet && event.target instanceof Node && tooltipRef.current?.contains(event.target)) return;
-      if (!isSheet) close();
+    // The sheet is viewport-fixed, so it never needs to close on scroll.
+    // The anchored popup's position is tied to the term's viewport rect, so a
+    // real scroll invalidates it — but ignore the scroll-into-view the browser
+    // fires right after tapping the (focusable) term, which would otherwise
+    // dismiss the popup the same tap just opened.
+    const handleScroll = () => {
+      if (isSheet) return;
+      if (Date.now() - openedAtRef.current < OPEN_SETTLE_MS) return;
+      close();
+    };
+
+    // A genuine resize invalidates the anchored position, but the sheet is
+    // pinned to the viewport and must survive the URL-bar show/hide that mobile
+    // browsers report as a resize when a tap scrolls the focused term into view.
+    const handleResize = () => {
+      if (isSheet) return;
+      if (Date.now() - openedAtRef.current < OPEN_SETTLE_MS) return;
+      close();
     };
 
     document.addEventListener("mouseover", handleMouseOver);
@@ -137,7 +157,7 @@ export function DefinitionTooltip({ t, onCompareDefinition }) {
     document.addEventListener("keydown", handleKeyDown);
     document.addEventListener("focusin", handleFocusIn);
     window.addEventListener("scroll", handleScroll, { capture: true, passive: true });
-    window.addEventListener("resize", close);
+    window.addEventListener("resize", handleResize);
     return () => {
       document.removeEventListener("mouseover", handleMouseOver);
       document.removeEventListener("mouseout", handleMouseOut);
@@ -145,7 +165,7 @@ export function DefinitionTooltip({ t, onCompareDefinition }) {
       document.removeEventListener("keydown", handleKeyDown);
       document.removeEventListener("focusin", handleFocusIn);
       window.removeEventListener("scroll", handleScroll, { capture: true });
-      window.removeEventListener("resize", close);
+      window.removeEventListener("resize", handleResize);
       cancelScheduledClose();
     };
   }, [cancelScheduledClose, close, isSheet, scheduleClose]);

--- a/src/components/law-viewer/DefinitionTooltip.test.jsx
+++ b/src/components/law-viewer/DefinitionTooltip.test.jsx
@@ -1,0 +1,101 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DefinitionTooltip } from "./DefinitionTooltip.jsx";
+
+let container;
+let root;
+let term;
+
+function t(key) {
+  return key;
+}
+
+// jsdom has no matchMedia; fake it so the component can pick sheet vs anchored.
+function mockMatchMedia(matches) {
+  window.matchMedia = vi.fn().mockImplementation((query) => ({
+    matches,
+    media: query,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }));
+}
+
+function renderTooltip(props = {}) {
+  act(() => {
+    root.render(<DefinitionTooltip t={t} {...props} />);
+  });
+}
+
+function tapTerm() {
+  // Mirror the mobile order: the tabindex=0 span focuses, then click fires.
+  act(() => {
+    term.dispatchEvent(new FocusEvent("focusin", { bubbles: true }));
+    term.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+
+  term = document.createElement("span");
+  term.className = "defined-term";
+  term.setAttribute("tabindex", "0");
+  term.setAttribute("data-term", "personal data");
+  term.setAttribute("data-definition", "information relating to an identified person");
+  term.textContent = "personal data";
+  document.body.appendChild(term);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  term.remove();
+  vi.restoreAllMocks();
+});
+
+describe("DefinitionTooltip on mobile (sheet mode)", () => {
+  beforeEach(() => mockMatchMedia(true));
+
+  it("opens a bottom sheet when a defined term is tapped", () => {
+    renderTooltip();
+    tapTerm();
+
+    const sheet = document.querySelector('[role="dialog"]');
+    expect(sheet).not.toBeNull();
+    expect(sheet.textContent).toContain("personal data");
+  });
+
+  it("stays open when the mobile URL bar fires a resize right after opening", () => {
+    renderTooltip();
+    tapTerm();
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+
+    // Tapping the focusable term makes the browser scroll it into view and
+    // toggle the URL bar, firing scroll + resize. The sheet must survive both.
+    act(() => {
+      window.dispatchEvent(new Event("scroll"));
+      window.dispatchEvent(new Event("resize"));
+    });
+
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+  });
+});
+
+describe("DefinitionTooltip on desktop (anchored mode)", () => {
+  beforeEach(() => mockMatchMedia(false));
+
+  it("renders an anchored tooltip on hover", () => {
+    renderTooltip();
+    act(() => {
+      term.dispatchEvent(new MouseEvent("mouseover", { bubbles: true }));
+    });
+
+    const tip = document.querySelector('[role="tooltip"]');
+    expect(tip).not.toBeNull();
+    expect(tip.textContent).toContain("personal data");
+  });
+});


### PR DESCRIPTION
## Problem

Tapping a defined term on mobile opened the definition popup and then immediately closed it — a quick flash with nothing left on screen.

## Root cause

The `.defined-term` spans are rendered with `tabindex="0"` (they're keyboard-activatable buttons). On a mobile tap the browser **focuses** the span, scrolls it into view, and toggles the URL bar — which fires a `resize` event. `DefinitionTooltip` listened for `resize` and called `close()` **unconditionally**, dismissing the bottom sheet the same tap had just opened.

In sheet mode `scroll` was already ignored, but `resize` was not — so the sheet never had a chance to stay open.

## Fix

- **Sheet (mobile):** the bottom sheet is viewport-fixed, so it never needs to close on `resize` or `scroll` — both are now ignored in sheet mode.
- **Anchored (desktop):** a genuine scroll/resize still closes the popup, but the scroll-into-view/resize that the *opening focus itself* induces is ignored for a short settle window (`OPEN_SETTLE_MS`), so tapping a focusable term can't dismiss the popup it just opened.

## Testing

- Added `DefinitionTooltip.test.jsx` covering: sheet opens on tap, **sheet survives a post-open `scroll`/`resize`** (the regression), and the desktop anchored tooltip still opens on hover.
- `npx vitest run` — all 34 files / 393 tests pass.
- `npx eslint` clean on the changed files.

No cache-version bump needed: this is an interaction-only change (no parser output, cached payload shape, or NLP algorithm touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkB4r1CbupNwWGcN9sjNZk

---
_Generated by [Claude Code](https://claude.ai/code/session_01VkB4r1CbupNwWGcN9sjNZk)_