### PR TITLE
docs: note the live API at api.legalviz.eu in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ The fmxParser.test.js is a vitest test (not part of the backend node:test glob).
 
 Backend CLI (`eurlex`) commands are documented in [backend/README.md](backend/README.md); run via `npx eurlex <command>` from `backend/` after `npm install`.
 
+The production API is live at `https://api.legalviz.eu` — useful for checking what the deployed parser/search actually returns without building the local data caches, e.g. `curl -s https://api.legalviz.eu/api/laws/32016R0679/parsed`. Routes are defined in [backend/routes/api-routes.js](backend/routes/api-routes.js). It is read-only from your side: never treat it as a place to write or mutate state, and remember it serves *deployed* code and *published* caches, so it can lag local changes (see [Cache & version invalidation](#cache--version-invalidation)).
+
 Requires Node.js v22.12+ (`engines` in root and backend `package.json`; the backend needs require(esm), unflagged since 22.12).
 
 Subtree-specific guidance lives in nested memory files that Claude Code loads on demand when you work in them: [backend/CLAUDE.md](backend/CLAUDE.md) (API, CLI, MCP, AI services) and [src/CLAUDE.md](src/CLAUDE.md) (React frontend). Keep this root file for cross-cutting concerns; push backend-only or frontend-only detail down into those.


### PR DESCRIPTION
Adds a short note to `CLAUDE.md` recording that a deployed API exists at `https://api.legalviz.eu`, so it can be used to check what the parser and search endpoints actually return without building the local data caches first.

The note also flags two things that are easy to get wrong: it is read-only, and it serves deployed code plus published caches, so it can lag local changes (linking to the existing Cache & version invalidation section).

Docs only — no code changes. The definitions-parsing work that briefly sat on this branch has moved to #141, stacked on #140.