### PR TITLE
Drop phantom recitals from acts with a CONSID lead-in

### DIFF
--- a/backend/shared/formex-parser/fmxParser.mjs
+++ b/backend/shared/formex-parser/fmxParser.mjs
@@ -33,7 +33,7 @@ import {
  * Bump this whenever the parser output changes (new fields, bug fixes, etc.)
  * so that cached parsed results are automatically re-parsed from raw XML.
  */
-export const PARSER_VERSION = 19;
+export const PARSER_VERSION = 20;
 
 // ---------------------------------------------------------------------------
 // FMX → HTML conversion helpers
@@ -1528,10 +1528,19 @@ export function parseFmxToCombined(xmlText) {
   // --- Recitals ---
   const recitals = [];
   for (const consid of root.querySelectorAll("GR\\.CONSID > CONSID")) {
-    const noP = consid.querySelector("NP > NO\\.P");
-    const num = noP ? allText(noP).replace(/[()]/g, "").trim() : String(recitals.length + 1);
     const txtEl = consid.querySelector("NP > TXT") || consid.querySelector("NP");
     const recitalText = txtEl ? allText(txtEl) : "";
+    // Not every CONSID is a recital. Some acts (the Data Act, 32023R2854) wrap
+    // the "Whereas:" lead-in in its own <CONSID><P>Whereas:</P></CONSID> with
+    // no NP, which yielded a text-less recital that consumed number 1 and
+    // pushed the real recital 1 into a duplicate — 120 entries numbered only
+    // to 119. An entry with no text is never worth keeping, and skipping it
+    // before the number is assigned also keeps the index fallback below
+    // counting only real recitals.
+    if (!recitalText.trim()) continue;
+
+    const noP = consid.querySelector("NP > NO\\.P");
+    const num = noP ? allText(noP).replace(/[()]/g, "").trim() : String(recitals.length + 1);
     const recitalHtmlRaw = txtEl ? renderWithFootnotes(txtEl, `recital-${num}`) : "";
     recitals.push({
       recital_number: num,

--- a/backend/shared/formex-parser/fmxParser.test.js
+++ b/backend/shared/formex-parser/fmxParser.test.js
@@ -1196,3 +1196,69 @@ describe("extractCrossRefsFromText — multi-article citations", () => {
     expect(boundTo1725).toBeFalsy();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Recital extraction: not every CONSID is a recital
+// ---------------------------------------------------------------------------
+
+describe("recital extraction", () => {
+  /** Mirrors the Data Act (32023R2854) preamble shape. */
+  function buildAct(considXml) {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<COMBINED.FMX>
+  <ACT>
+    <TITLE><TI><P>Regulation (EU) 2020/1 of the European Parliament</P></TI></TITLE>
+    <PREAMBLE>
+      <GR.CONSID>
+        <GR.CONSID.INIT>Acting in accordance with the ordinary legislative procedure</GR.CONSID.INIT>
+        ${considXml}
+      </GR.CONSID>
+    </PREAMBLE>
+    <ENACTING.TERMS>
+      <ARTICLE IDENTIFIER="001">
+        <TI.ART>Article 1</TI.ART>
+        <ALINEA><P>This Regulation lays down rules.</P></ALINEA>
+      </ARTICLE>
+    </ENACTING.TERMS>
+  </ACT>
+</COMBINED.FMX>`;
+  }
+
+  const numbered = (n, text) => `<CONSID><NP><NO.P>(${n})</NO.P><TXT>${text}</TXT></NP></CONSID>`;
+
+  it("skips a 'Whereas:' lead-in wrapped in its own CONSID", () => {
+    // The Data Act puts the lead-in in <CONSID><P>Whereas:</P></CONSID> rather
+    // than in GR.CONSID.INIT. That used to parse as a text-less recital which
+    // took number 1, leaving the real recital 1 as a duplicate and the act
+    // with one more entry than its highest number (120 entries, numbered to
+    // 119) — which in turn produced a prerendered page for a recital that
+    // does not exist.
+    const result = parseFmxToCombined(buildAct(
+      `<CONSID><P>Whereas:</P></CONSID>${numbered(1, "First recital.")}${numbered(2, "Second recital.")}`,
+    ));
+
+    expect(result.recitals).toHaveLength(2);
+    expect(result.recitals.map((r) => r.recital_number)).toEqual(["1", "2"]);
+    expect(result.recitals[0].recital_text).toBe("First recital.");
+    expect(new Set(result.recitals.map((r) => r.recital_number)).size).toBe(result.recitals.length);
+  });
+
+  it("keeps recitals whose CONSID carries no number, counting only real ones", () => {
+    const result = parseFmxToCombined(buildAct(
+      `<CONSID><P>Whereas:</P></CONSID>`
+      + `<CONSID><NP><TXT>Unnumbered recital text.</TXT></NP></CONSID>`
+      + `<CONSID><NP><TXT>Another unnumbered recital.</TXT></NP></CONSID>`,
+    ));
+
+    // The positional fallback must not count the skipped lead-in, or every
+    // unnumbered recital in the act shifts by one.
+    expect(result.recitals.map((r) => r.recital_number)).toEqual(["1", "2"]);
+    expect(result.recitals[0].recital_text).toBe("Unnumbered recital text.");
+  });
+
+  it("still extracts an ordinary numbered preamble unchanged", () => {
+    const result = parseFmxToCombined(buildAct(numbered(1, "Only recital.")));
+    expect(result.recitals).toHaveLength(1);
+    expect(result.recitals[0]).toMatchObject({ recital_number: "1", recital_text: "Only recital." });
+  });
+});


### PR DESCRIPTION
Found while working on #136: the Data Act parses to **120 recitals numbered only up to 119**, with recital 1 appearing twice.

## Cause

`32023R2854` wraps its "Whereas:" lead-in in its own element instead of putting it in `GR.CONSID.INIT`:

```xml
<GR.CONSID.INIT>Acting in accordance with the ordinary legislative procedure…</GR.CONSID.INIT>
<CONSID><P>Whereas:</P></CONSID>          <!-- the lead-in, not a recital -->
<CONSID><NP><NO.P>(1)</NO.P><TXT>In recent years, data-driven technologies…</TXT></NP></CONSID>
```

The recital loop treats every `GR.CONSID > CONSID` as a recital and reads text only from `NP`/`TXT`. That lead-in has neither, so it parsed as a **text-less recital at index 0** and took number `1` from the positional fallback — pushing the real recital 1 into a duplicate.

Downstream, the count (120) was used as the highest number, so the prerender generated `/data-act/recital/120` — a page, and a sitemap entry, for a recital that does not exist. (#139 stops the prerender trusting counts; this PR fixes the parse the count came from. They're independent.)

## Fix

Skip a `CONSID` that yields no text, **before** the number is assigned so the positional fallback keeps counting only real recitals — otherwise every unnumbered recital in such an act shifts by one.

## Blast radius

Checked all flagship laws against the live API: only the Data Act is affected.

| Law | Recitals | Empty |
|---|---|---|
| GDPR | 173 | 0 |
| AI Act | 180 | 0 |
| DSA | 156 | 0 |
| DMA | 109 | 0 |
| DGA | 63 | 0 |
| **Data Act** | **120** | **1 (index 0)** |

An entry with no text was never useful — it rendered as a blank recital — so nothing that previously carried content is dropped.

## Version bump

Bumps `PARSER_VERSION` 19 → 20, per the cache-version table in `CLAUDE.md`. Without it, backend disk caches and browser IndexedDB parses keep serving the phantom recital indefinitely. This bump also covers #128's unbumped cross-reference and title-heuristic changes, which is why #139 no longer carries one.

## Testing

Three tests added to `fmxParser.test.js`, using a synthetic act that mirrors the Data Act preamble shape rather than adding a ~350 KB fixture: the lead-in is skipped with no duplicate number, unnumbered recitals still get positional numbers counted from the first real one, and an ordinary numbered preamble is unchanged.

Verified the first two **fail without the fix** (`expected length 2 but got 3`; `expected ['1','2','3'] to equal ['1','2']`) and pass with it. Full suite green: 406 frontend + 377 backend, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H82VPVqW4C4hb2mhx3LAzj

---
_Generated by [Claude Code](https://claude.ai/code/session_01H82VPVqW4C4hb2mhx3LAzj)_