### PR TITLE
Warn when a law has been amended since adoption

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -195,6 +195,7 @@ cat input.xml | parse-fmx > output.json
 | `GET` | `/api/laws/:celex/info?lang=ENG` | Law type and format metadata |
 | `GET` | `/api/laws/:celex/metadata` | SPARQL metadata (entry into force, ELI, etc.) |
 | `GET` | `/api/laws/:celex/amendments` | Amendment and corrigendum history |
+| `GET` | `/api/laws/:celex/consolidated` | Consolidated ("as amended") versions EUR-Lex publishes for the act, oldest first. Future-dated versions are included — the caller decides which one is current. |
 | `GET` | `/api/laws/:celex/implementing` | Implementing and delegated acts |
 | `GET` | `/api/laws/:celex/case-law?lang=ENG` | CJEU judgments citing this act, with operative parts and structured `articleRefs` |
 | `GET` | `/api/laws/:celex/recital-titles?lang=ENG` | Cached AI-generated short titles for recitals. Requires `RECITAL_TITLE_OPENROUTER_API_KEY` or `OPENROUTER_API_KEY` on cache miss. |

--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -8,7 +8,7 @@ const { createSearchHandler } = require("../search/search-route");
 const { createFulltextSearchHandler } = require("../search/fulltext-route");
 const { createTopicsHandler } = require("../search/topics-route");
 const { createDefinitionCompareHandler, createDefinitionSearchHandler } = require("../search/definitions-route");
-const { fetchMetadata, fetchAmendments, fetchImplementing, fetchCaseLaw } = require("../shared/law-queries");
+const { fetchMetadata, fetchAmendments, fetchConsolidatedVersions, fetchImplementing, fetchCaseLaw } = require("../shared/law-queries");
 const { ChatProviderError } = require("../shared/openrouter-chat");
 const { ensureRecitalTitles } = require("../shared/recital-title-service");
 const {
@@ -377,6 +377,28 @@ function registerApiRoutes(app, deps) {
       res.json(payload);
     } catch (err) {
       safeErrorResponse(res, err, 'Failed to fetch amendment history');
+    }
+  });
+
+  app.get('/api/laws/:celex/consolidated', rateLimitMiddleware, async (req, res) => {
+    try {
+      const { celex } = req.params;
+
+      if (!validateCelex(celex)) {
+        return res.status(400).json({ error: 'Invalid CELEX format' });
+      }
+
+      const cacheKey = `consolidated:${celex}`;
+      const cached = cacheGet(resolutionCache, cacheKey);
+      if (cached) {
+        return res.json(cached);
+      }
+
+      const payload = await fetchConsolidatedVersions(celex, runSparqlQuery);
+      cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+      res.json(payload);
+    } catch (err) {
+      safeErrorResponse(res, err, 'Failed to fetch consolidated versions');
     }
   });
 

--- a/backend/shared/law-queries.js
+++ b/backend/shared/law-queries.js
@@ -55,6 +55,13 @@ LIMIT 10`;
   };
 }
 
+// Some acts (e.g. heavily-amended directives/regulations) have far more than a
+// handful of amendments — 233 is the highest observed count in production.
+// The cap must stay comfortably above that, and rows must survive ordered by
+// newest first, or a truncated result silently drops the most recent
+// amendments instead of the oldest ones (see `truncated` below).
+const AMENDMENTS_LIMIT = 300;
+
 async function fetchAmendments(celex, runSparqlQuery) {
   const celexUri = `http://publications.europa.eu/resource/celex/${celex}`;
   const query = `
@@ -71,11 +78,12 @@ SELECT DISTINCT ?type ?sourceCelex ?date WHERE {
   FILTER(STRSTARTS(STR(?sourceCelex), "http://publications.europa.eu/resource/celex/"))
   OPTIONAL { ?sourceWork cdm:work_date_document ?date }
 }
-ORDER BY ?date
-LIMIT 50`;
+ORDER BY DESC(?date)
+LIMIT ${AMENDMENTS_LIMIT}`;
 
   const data = await runSparqlQuery(query);
-  const amendments = (data.results?.bindings || []).map((b) => {
+  const bindings = data.results?.bindings || [];
+  const amendments = bindings.map((b) => {
     const raw = b.sourceCelex?.value?.split('/').pop() || null;
     return {
       celex: raw ? decodeURIComponent(raw) : null,
@@ -84,18 +92,32 @@ LIMIT 50`;
     };
   }).filter((a) => a.celex);
 
-  return { celex, amendments };
+  // Hitting the cap means older rows were left out (newest survive, per the
+  // DESC order above), so the count callers derive from `amendments` is only
+  // a lower bound — they must say "at least N", never a precise number.
+  return { celex, amendments, truncated: bindings.length >= AMENDMENTS_LIMIT };
 }
 
 // Consolidated ("as amended") versions live in CELEX sector 0 under a
-// point-in-time id: 32013R0575 -> 02013R0575-20260626. Only sector-3 acts have
-// them, so anything else short-circuits without a SPARQL round trip.
-const SECTOR_3_CELEX = /^3\d{4}[A-Z]{1,2}\d{4}$/;
-const CONSOLIDATED_CELEX = /^(0\d{4}[A-Z]{1,2}\d{4})-(\d{4})(\d{2})(\d{2})$/;
+// point-in-time id: 32013R0575 -> 02013R0575-20260626. A suffixed original
+// keeps its suffix: 31999F0130(06) -> 01999F0130(06)-20021220. Acts from any
+// sector can have one — sector-2 international agreements (e.g. the EEA
+// Agreement, 21994A0103(01) -> 01994A0103(01)-20160519) do too, not just
+// sector-3 legislation — so this only rejects CELEX ids that aren't shaped
+// like an original act to begin with (already a point-in-time id, malformed,
+// etc.), short-circuiting those without a SPARQL round trip. The pattern
+// mirrors validateCelex's domain (reference-utils.js) so nothing admitted by
+// the route falls through here unchecked.
+const ORIGINAL_ACT_CELEX = /^\d{5}[A-Z]{1,2}\d{4}(\(\d+\))?$/;
+const CONSOLIDATED_CELEX = /^(0\d{4}[A-Z]{1,2}\d{4}(?:\(\d+\))?)-(\d{4})(\d{2})(\d{2})$/;
 
 function consolidatedBaseCelex(celex) {
   const normalized = String(celex || '').toUpperCase();
-  return SECTOR_3_CELEX.test(normalized) ? `0${normalized.slice(1)}` : null;
+  // `normalized` only reaches the interpolated SPARQL FILTER in
+  // fetchConsolidatedVersions once it has passed this strict regex, whose
+  // character class is limited to digits, A-Z, and literal parentheses — so
+  // no quote, backslash, or brace can ever be smuggled into the query string.
+  return ORIGINAL_ACT_CELEX.test(normalized) ? `0${normalized.slice(1)}` : null;
 }
 
 /**

--- a/backend/shared/law-queries.js
+++ b/backend/shared/law-queries.js
@@ -87,6 +87,53 @@ LIMIT 50`;
   return { celex, amendments };
 }
 
+// Consolidated ("as amended") versions live in CELEX sector 0 under a
+// point-in-time id: 32013R0575 -> 02013R0575-20260626. Only sector-3 acts have
+// them, so anything else short-circuits without a SPARQL round trip.
+const SECTOR_3_CELEX = /^3\d{4}[A-Z]{1,2}\d{4}$/;
+const CONSOLIDATED_CELEX = /^(0\d{4}[A-Z]{1,2}\d{4})-(\d{4})(\d{2})(\d{2})$/;
+
+function consolidatedBaseCelex(celex) {
+  const normalized = String(celex || '').toUpperCase();
+  return SECTOR_3_CELEX.test(normalized) ? `0${normalized.slice(1)}` : null;
+}
+
+/**
+ * List the consolidated versions EUR-Lex publishes for an act, oldest first.
+ *
+ * Cellar has no "consolidated version of" predicate that resolves from the base
+ * act, so this matches on the point-in-time CELEX id instead. Consolidations can
+ * be dated in the future (a version prepared for an amendment that has not yet
+ * applied); the whole list is returned unfiltered and callers decide which one
+ * is current, so the payload stays cacheable without a "today" baked into it.
+ */
+async function fetchConsolidatedVersions(celex, runSparqlQuery) {
+  const base = consolidatedBaseCelex(celex);
+  if (!base) return { celex, base: null, versions: [] };
+
+  const query = `
+PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
+SELECT DISTINCT ?id WHERE {
+  ?work cdm:resource_legal_id_celex ?id .
+  FILTER(STRSTARTS(STR(?id), "${base}-"))
+}
+ORDER BY ?id
+LIMIT 200`;
+
+  const data = await runSparqlQuery(query);
+  const versions = (data.results?.bindings || [])
+    .map((binding) => {
+      const id = String(binding.id?.value || '').toUpperCase();
+      const match = CONSOLIDATED_CELEX.exec(id);
+      if (!match || match[1] !== base) return null;
+      return { celex: id, date: `${match[2]}-${match[3]}-${match[4]}` };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  return { celex, base, versions };
+}
+
 async function fetchImplementing(celex, runSparqlQuery) {
   const celexUri = `http://publications.europa.eu/resource/celex/${celex}`;
   const query = `
@@ -627,6 +674,7 @@ module.exports = {
   ACT_CELEX_MAP,
   fetchMetadata,
   fetchAmendments,
+  fetchConsolidatedVersions,
   fetchImplementing,
   fetchCaseLaw,
   parseCitationsToRefs,

--- a/backend/shared/law-queries.test.js
+++ b/backend/shared/law-queries.test.js
@@ -4,7 +4,7 @@ const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
-const { fetchCaseLaw, parseCitationsToRefs } = require("./law-queries");
+const { fetchCaseLaw, fetchConsolidatedVersions, parseCitationsToRefs } = require("./law-queries");
 
 test("fetchCaseLaw reads precomputed details from the data store and never writes", async () => {
   const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "case-law-cache-"));
@@ -173,4 +173,42 @@ test('fetchCaseLaw includes and formats General Court judgments', async () => {
 
   assert.match(query, /\(CJ\|TJ\)/);
   assert.equal(payload.cases[0].caseNumber, 'T-123/25');
+});
+
+test('fetchConsolidatedVersions maps point-in-time CELEX ids to dated versions', async () => {
+  let query = '';
+  const payload = await fetchConsolidatedVersions('32013R0575', async (value) => {
+    query = value;
+    return {
+      results: {
+        bindings: [
+          { id: { value: '02013R0575-20260626' } },
+          { id: { value: '02013R0575-20130628' } },
+          // Neighbouring acts share the id prefix up to the separator; the
+          // base must match exactly or 32013R0575 would absorb 32013R05750.
+          { id: { value: '02013R05750-20200101' } },
+          { id: { value: 'not-a-celex' } },
+        ],
+      },
+    };
+  });
+
+  assert.match(query, /STRSTARTS\(STR\(\?id\), "02013R0575-"\)/);
+  assert.equal(payload.base, '02013R0575');
+  assert.deepEqual(payload.versions, [
+    { celex: '02013R0575-20130628', date: '2013-06-28' },
+    { celex: '02013R0575-20260626', date: '2026-06-26' },
+  ]);
+});
+
+test('fetchConsolidatedVersions skips SPARQL for CELEX ids that cannot be consolidated', async () => {
+  let called = false;
+  const payload = await fetchConsolidatedVersions('62025TJ0123', async () => {
+    called = true;
+    return { results: { bindings: [] } };
+  });
+
+  assert.equal(called, false);
+  assert.equal(payload.base, null);
+  assert.deepEqual(payload.versions, []);
 });

--- a/backend/shared/law-queries.test.js
+++ b/backend/shared/law-queries.test.js
@@ -203,7 +203,9 @@ test('fetchConsolidatedVersions maps point-in-time CELEX ids to dated versions',
 
 test('fetchConsolidatedVersions skips SPARQL for CELEX ids that cannot be consolidated', async () => {
   let called = false;
-  const payload = await fetchConsolidatedVersions('62025TJ0123', async () => {
+  // Already a point-in-time consolidated id itself (sector 0 + trailing
+  // date) — not shaped like an original act, so it must not be re-consolidated.
+  const payload = await fetchConsolidatedVersions('02013R0575-20260626', async () => {
     called = true;
     return { results: { bindings: [] } };
   });
@@ -211,4 +213,39 @@ test('fetchConsolidatedVersions skips SPARQL for CELEX ids that cannot be consol
   assert.equal(called, false);
   assert.equal(payload.base, null);
   assert.deepEqual(payload.versions, []);
+});
+
+test('fetchConsolidatedVersions matches a suffixed original act, not just sector 3', async () => {
+  let query = '';
+  const payload = await fetchConsolidatedVersions('31999F0130(06)', async (value) => {
+    query = value;
+    return {
+      results: {
+        bindings: [
+          { id: { value: '01999F0130(06)-20021220' } },
+        ],
+      },
+    };
+  });
+
+  assert.match(query, /STRSTARTS\(STR\(\?id\), "01999F0130\(06\)-"\)/);
+  assert.equal(payload.base, '01999F0130(06)');
+  assert.deepEqual(payload.versions, [
+    { celex: '01999F0130(06)-20021220', date: '2002-12-20' },
+  ]);
+});
+
+test('fetchConsolidatedVersions matches a sector-2 international agreement', async () => {
+  const payload = await fetchConsolidatedVersions('21994A0103(01)', async () => ({
+    results: {
+      bindings: [
+        { id: { value: '01994A0103(01)-20160519' } },
+      ],
+    },
+  }));
+
+  assert.equal(payload.base, '01994A0103(01)');
+  assert.deepEqual(payload.versions, [
+    { celex: '01994A0103(01)-20160519', date: '2016-05-19' },
+  ]);
 });

--- a/src/components/ConsolidationNotice.jsx
+++ b/src/components/ConsolidationNotice.jsx
@@ -31,10 +31,17 @@ export function ConsolidationNotice({ celex, currentLang = "EN", locale = "en", 
     : null;
 
   // The catalog carries no plural machinery, so the singular is its own key.
-  const once = status.amendmentCount === 1;
+  // A truncated amendment count is a lower bound, never an exact number (see
+  // `truncated` in fetchAmendments), so it gets its own "at least N" copy
+  // rather than risk stating a precise-looking figure that is provably wrong.
+  const once = status.amendmentCount === 1 && status.amendmentCountExact;
   const summaryKey = amendedOn
-    ? (once ? "consolidation.amendedOnceWithDate" : "consolidation.amendedWithDate")
-    : (once ? "consolidation.amendedOnce" : "consolidation.amended");
+    ? (status.amendmentCountExact
+      ? (once ? "consolidation.amendedOnceWithDate" : "consolidation.amendedWithDate")
+      : "consolidation.amendedAtLeastWithDate")
+    : (status.amendmentCountExact
+      ? (once ? "consolidation.amendedOnce" : "consolidation.amended")
+      : "consolidation.amendedAtLeast");
   const summary = t(summaryKey, { count: status.amendmentCount, date: amendedOn });
 
   const link = consolidatedUrl ? (
@@ -48,6 +55,20 @@ export function ConsolidationNotice({ celex, currentLang = "EN", locale = "en", 
       <ExternalLink size={13} aria-hidden="true" />
     </a>
   ) : null;
+
+  // No link means either: no consolidated version has ever been published
+  // (say so), only future-dated ones exist (say that instead, honestly), or
+  // the /consolidated fetch itself failed (say nothing — we don't know).
+  let noVersionMessage = null;
+  if (!link) {
+    if (status.consolidatedStatusUnknown) {
+      noVersionMessage = null;
+    } else if (status.hasUpcomingConsolidation) {
+      noVersionMessage = t("consolidation.consolidatedVersionPending");
+    } else {
+      noVersionMessage = t("consolidation.noConsolidatedVersion");
+    }
+  }
 
   if (variant === "inline") {
     return (
@@ -68,7 +89,7 @@ export function ConsolidationNotice({ celex, currentLang = "EN", locale = "en", 
       </div>
       <p className="mt-1 leading-6">
         {summary}
-        {link ? <> {link}</> : <> {t("consolidation.noConsolidatedVersion")}</>}
+        {link ? <> {link}</> : (noVersionMessage ? <> {noVersionMessage}</> : null)}
       </p>
     </div>
   );

--- a/src/components/ConsolidationNotice.jsx
+++ b/src/components/ConsolidationNotice.jsx
@@ -1,0 +1,75 @@
+import { ExternalLink, History } from "lucide-react";
+
+import { useI18n } from "../i18n/useI18n.js";
+import { useConsolidationStatus } from "../hooks/useConsolidationStatus.js";
+import { formatMetaDate } from "../utils/formatMetaDate.js";
+import { buildEurlexCelexUrl } from "../utils/url.js";
+
+/**
+ * Tells the reader that the text on screen is the act as adopted, and that it
+ * has since been amended.
+ *
+ * Everything LegalViz renders is the original published text; for a heavily
+ * amended act that is the wrong answer to most practical questions, and nothing
+ * in the reader said so. The consolidated text itself is not rendered here (it
+ * is a different Formex schema, and EUR-Lex strips the recitals this app is
+ * built around) — so the notice links out to it rather than pretending.
+ *
+ * Renders nothing at all when the act has never been amended, which is the
+ * common case, and while the amendment history is still loading.
+ */
+export function ConsolidationNotice({ celex, currentLang = "EN", locale = "en", variant = "banner" }) {
+  const { t } = useI18n();
+  const status = useConsolidationStatus(celex);
+
+  if (!status.isOutdated) return null;
+
+  const amendedOn = formatMetaDate(status.latestAmendmentDate, locale);
+  const consolidatedOn = formatMetaDate(status.consolidated?.date, locale);
+  const consolidatedUrl = status.consolidated
+    ? buildEurlexCelexUrl(status.consolidated.celex, currentLang)
+    : null;
+
+  // The catalog carries no plural machinery, so the singular is its own key.
+  const once = status.amendmentCount === 1;
+  const summaryKey = amendedOn
+    ? (once ? "consolidation.amendedOnceWithDate" : "consolidation.amendedWithDate")
+    : (once ? "consolidation.amendedOnce" : "consolidation.amended");
+  const summary = t(summaryKey, { count: status.amendmentCount, date: amendedOn });
+
+  const link = consolidatedUrl ? (
+    <a
+      href={consolidatedUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 font-medium underline underline-offset-2 hover:no-underline"
+    >
+      {t("consolidation.readConsolidated", { date: consolidatedOn })}
+      <ExternalLink size={13} aria-hidden="true" />
+    </a>
+  ) : null;
+
+  if (variant === "inline") {
+    return (
+      <p className="mb-4 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-xs text-amber-800 dark:text-amber-300">
+        <History size={13} className="translate-y-px" aria-hidden="true" />
+        <span>{t("consolidation.asAdopted")}</span>
+        <span className="text-amber-700/80 dark:text-amber-300/70">{summary}</span>
+        {link}
+      </p>
+    );
+  }
+
+  return (
+    <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-100">
+      <div className="flex items-center gap-2 font-medium">
+        <History size={15} aria-hidden="true" />
+        {t("consolidation.asAdopted")}
+      </div>
+      <p className="mt-1 leading-6">
+        {summary}
+        {link ? <> {link}</> : <> {t("consolidation.noConsolidatedVersion")}</>}
+      </p>
+    </div>
+  );
+}

--- a/src/components/ConsolidationNotice.test.jsx
+++ b/src/components/ConsolidationNotice.test.jsx
@@ -110,7 +110,7 @@ describe("ConsolidationNotice", () => {
     expect(container.textContent).toBe("");
   });
 
-  it("ignores a consolidated version that has not applied yet", async () => {
+  it("says a consolidated version is pending when only future-dated ones exist", async () => {
     vi.setSystemTime(new Date("2026-08-12T00:00:00Z"));
     fetchAmendments.mockResolvedValue({
       amendments: [{ celex: "32026R0001", date: "2026-01-01", type: "amendment" }],
@@ -121,7 +121,38 @@ describe("ConsolidationNotice", () => {
 
     await render();
 
-    expect(container.textContent).toContain("has not published a consolidated version");
+    expect(container.textContent).toContain("has been prepared but is not yet in force");
+    expect(container.textContent).not.toContain("has not published a consolidated version");
     vi.useRealTimers();
+  });
+
+  it("does not claim no consolidated version exists when the /consolidated fetch fails", async () => {
+    fetchAmendments.mockResolvedValue({
+      amendments: [{ celex: "32020R0001", date: "2020-01-01", type: "amendment" }],
+    });
+    fetchConsolidatedVersions.mockRejectedValue(new Error("cellar timeout"));
+
+    await render();
+
+    expect(container.textContent).toContain("amended once");
+    expect(container.textContent).not.toContain("has not published a consolidated version");
+    expect(container.querySelector("a")).toBe(null);
+  });
+
+  it("says 'at least N times' when the amendment count was truncated", async () => {
+    fetchAmendments.mockResolvedValue({
+      amendments: [
+        { celex: "32019R0876", date: "2019-05-20", type: "amendment" },
+        { celex: "32024R1623", date: "2024-05-31", type: "amendment" },
+      ],
+      truncated: true,
+    });
+    fetchConsolidatedVersions.mockResolvedValue({
+      versions: [{ celex: "02013R0575-20260626", date: "2026-06-26" }],
+    });
+
+    await render();
+
+    expect(container.textContent).toContain("amended at least 2 times");
   });
 });

--- a/src/components/ConsolidationNotice.test.jsx
+++ b/src/components/ConsolidationNotice.test.jsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+
+const fetchAmendments = vi.fn();
+const fetchConsolidatedVersions = vi.fn();
+
+vi.mock("../utils/formexApi.js", () => ({
+  fetchAmendments: (...args) => fetchAmendments(...args),
+  fetchConsolidatedVersions: (...args) => fetchConsolidatedVersions(...args),
+}));
+
+const { ConsolidationNotice } = await import("./ConsolidationNotice.jsx");
+const { I18nProvider } = await import("../i18n/I18nProvider.jsx");
+
+let container;
+let root;
+
+async function render(props = {}) {
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      createElement(
+        MemoryRouter,
+        null,
+        createElement(
+          I18nProvider,
+          null,
+          createElement(ConsolidationNotice, { celex: "32013R0575", ...props })
+        )
+      )
+    );
+  });
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  fetchAmendments.mockReset();
+  fetchConsolidatedVersions.mockReset();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  document.body.innerHTML = "";
+});
+
+describe("ConsolidationNotice", () => {
+  it("warns that the text is as adopted and links the consolidated version", async () => {
+    fetchAmendments.mockResolvedValue({
+      amendments: [
+        { celex: "32019R0876", date: "2019-05-20", type: "amendment" },
+        { celex: "32024R1623", date: "2024-05-31", type: "amendment" },
+      ],
+    });
+    fetchConsolidatedVersions.mockResolvedValue({
+      versions: [
+        { celex: "02013R0575-20130628", date: "2013-06-28" },
+        { celex: "02013R0575-20260626", date: "2026-06-26" },
+      ],
+    });
+
+    await render();
+
+    expect(container.textContent).toContain("You are reading this law as adopted.");
+    expect(container.textContent).toContain("amended 2 times");
+    const link = container.querySelector("a");
+    expect(link.getAttribute("href")).toBe(
+      "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02013R0575-20260626"
+    );
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("renders nothing for a law that only ever had corrigenda", async () => {
+    fetchAmendments.mockResolvedValue({
+      amendments: [{ celex: "32016R0679R(01)", date: "2018-05-23", type: "corrigendum" }],
+    });
+    fetchConsolidatedVersions.mockResolvedValue({
+      versions: [{ celex: "02016R0679-20160504", date: "2016-05-04" }],
+    });
+
+    await render({ celex: "32016R0679" });
+
+    expect(container.textContent).toBe("");
+  });
+
+  it("says so when the act is amended but has no consolidated version", async () => {
+    fetchAmendments.mockResolvedValue({
+      amendments: [{ celex: "32020R0001", date: "2020-01-01", type: "amendment" }],
+    });
+    fetchConsolidatedVersions.mockResolvedValue({ versions: [] });
+
+    await render();
+
+    expect(container.textContent).toContain("amended once");
+    expect(container.textContent).toContain("has not published a consolidated version");
+    expect(container.querySelector("a")).toBe(null);
+  });
+
+  it("stays silent when the amendment history cannot be fetched", async () => {
+    fetchAmendments.mockRejectedValue(new Error("cellar down"));
+    fetchConsolidatedVersions.mockRejectedValue(new Error("cellar down"));
+
+    await render();
+
+    expect(container.textContent).toBe("");
+  });
+
+  it("ignores a consolidated version that has not applied yet", async () => {
+    vi.setSystemTime(new Date("2026-08-12T00:00:00Z"));
+    fetchAmendments.mockResolvedValue({
+      amendments: [{ celex: "32026R0001", date: "2026-01-01", type: "amendment" }],
+    });
+    fetchConsolidatedVersions.mockResolvedValue({
+      versions: [{ celex: "02013R0575-20270101", date: "2027-01-01" }],
+    });
+
+    await render();
+
+    expect(container.textContent).toContain("has not published a consolidated version");
+    vi.useRealTimers();
+  });
+});

--- a/src/components/LawViewer.jsx
+++ b/src/components/LawViewer.jsx
@@ -48,6 +48,7 @@ import { LawViewerReadingFooter } from "./law-viewer/LawViewerReadingFooter.jsx"
 import { LawViewerContextRail } from "./law-viewer/LawViewerContextRail.jsx";
 import { LawOverviewPage } from "./law-viewer/LawOverviewPage.jsx";
 import { DefinitionComparisonSheet } from "./law-viewer/DefinitionComparisonSheet.jsx";
+import { ConsolidationNotice } from "./ConsolidationNotice.jsx";
 
 export function LawViewer() {
   const { locale: routeLocale, slug, key, kind, id } = useParams();
@@ -405,6 +406,13 @@ export function LawViewer() {
                       {getSelectionTitle(selection.selected, t)}
                     </h2>
                   </div>
+
+                  <ConsolidationNotice
+                    celex={source.effectiveCelex}
+                    currentLang={displayedFormexLang}
+                    locale={locale}
+                    variant="inline"
+                  />
 
                   {interactions.isResolvingExternalLaw ? (
                     <div className="mb-4 flex items-center gap-2 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-900/60 dark:bg-blue-950/30 dark:text-blue-200">

--- a/src/components/law-viewer/LawOverviewPage.jsx
+++ b/src/components/law-viewer/LawOverviewPage.jsx
@@ -3,6 +3,7 @@ import { Loader2, Printer, Scale } from "lucide-react";
 import { LawSummary } from "../LawSummary.jsx";
 import { MetadataPanel } from "../MetadataPanel.jsx";
 import { CaseLawModal } from "../CaseLawModal.jsx";
+import { ConsolidationNotice } from "../ConsolidationNotice.jsx";
 import { formatMetaDate } from "../../utils/formatMetaDate.js";
 import { Pill } from "../ui/Pill.jsx";
 import { useLawMetadata } from "../../hooks/useLawMetadata.js";
@@ -176,6 +177,12 @@ export function LawOverviewPage({
           </a>
         ) : null}
       </div>
+
+      <ConsolidationNotice
+        celex={effectiveCelex}
+        currentLang={formexLang}
+        locale={locale}
+      />
 
       {/* Actions */}
       <div className="mb-8 flex flex-wrap gap-3">

--- a/src/hooks/useConsolidationStatus.js
+++ b/src/hooks/useConsolidationStatus.js
@@ -1,0 +1,50 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { fetchAmendments, fetchConsolidatedVersions } from "../utils/formexApi.js";
+import { selectConsolidatedVersions, summarizeAmendments } from "../utils/consolidatedVersions.js";
+
+/**
+ * Whether the act being read is still the current text, and where to find the
+ * current one if it isn't.
+ *
+ * Both requests are best-effort and resolve to an absent value on failure: a
+ * Cellar outage must not put a "this may be outdated" warning on a law we know
+ * nothing about, so `isOutdated` stays false until the amendment history says
+ * otherwise. Both endpoints are already IndexedDB-cached and de-duplicated in
+ * flight, so sharing them with the metadata panel costs nothing.
+ */
+export function useConsolidationStatus(celex) {
+  const [amendments, setAmendments] = useState(null);
+  const [versions, setVersions] = useState(null);
+
+  useEffect(() => {
+    setAmendments(null);
+    setVersions(null);
+    if (!celex) return undefined;
+
+    let cancelled = false;
+
+    fetchAmendments(celex)
+      .then((result) => { if (!cancelled) setAmendments(result.amendments || []); })
+      .catch(() => { if (!cancelled) setAmendments([]); });
+
+    fetchConsolidatedVersions(celex)
+      .then((result) => { if (!cancelled) setVersions(result.versions || []); })
+      .catch(() => { if (!cancelled) setVersions([]); });
+
+    return () => { cancelled = true; };
+  }, [celex]);
+
+  return useMemo(() => {
+    const { count, latestDate } = summarizeAmendments(amendments);
+    const { current, upcoming } = selectConsolidatedVersions(versions);
+
+    return {
+      isOutdated: count > 0,
+      amendmentCount: count,
+      latestAmendmentDate: latestDate,
+      consolidated: current,
+      hasUpcomingConsolidation: upcoming.length > 0,
+    };
+  }, [amendments, versions]);
+}

--- a/src/hooks/useConsolidationStatus.js
+++ b/src/hooks/useConsolidationStatus.js
@@ -7,30 +7,50 @@ import { selectConsolidatedVersions, summarizeAmendments } from "../utils/consol
  * Whether the act being read is still the current text, and where to find the
  * current one if it isn't.
  *
- * Both requests are best-effort and resolve to an absent value on failure: a
- * Cellar outage must not put a "this may be outdated" warning on a law we know
- * nothing about, so `isOutdated` stays false until the amendment history says
- * otherwise. Both endpoints are already IndexedDB-cached and de-duplicated in
- * flight, so sharing them with the metadata panel costs nothing.
+ * Both requests are best-effort: a Cellar outage must not put a "this may be
+ * outdated" warning on a law we know nothing about, so `isOutdated` stays
+ * false until the amendment history says otherwise. But a failed
+ * `/consolidated` fetch is kept distinct from a genuine empty result — the
+ * consolidated-version query is the slower of the two, so it is the one most
+ * likely to time out, and reporting "no consolidated version exists" when we
+ * simply don't know would be a falsehood. `consolidatedStatusUnknown` carries
+ * that distinction to the caller instead of silently collapsing to `[]`.
+ * Both endpoints are already IndexedDB-cached and de-duplicated in flight, so
+ * sharing them with the metadata panel costs nothing.
  */
 export function useConsolidationStatus(celex) {
   const [amendments, setAmendments] = useState(null);
+  const [amendmentsTruncated, setAmendmentsTruncated] = useState(false);
   const [versions, setVersions] = useState(null);
+  const [consolidatedStatusUnknown, setConsolidatedStatusUnknown] = useState(false);
 
   useEffect(() => {
     setAmendments(null);
+    setAmendmentsTruncated(false);
     setVersions(null);
+    setConsolidatedStatusUnknown(false);
     if (!celex) return undefined;
 
     let cancelled = false;
 
     fetchAmendments(celex)
-      .then((result) => { if (!cancelled) setAmendments(result.amendments || []); })
+      .then((result) => {
+        if (cancelled) return;
+        setAmendments(result.amendments || []);
+        setAmendmentsTruncated(Boolean(result.truncated));
+      })
       .catch(() => { if (!cancelled) setAmendments([]); });
 
     fetchConsolidatedVersions(celex)
       .then((result) => { if (!cancelled) setVersions(result.versions || []); })
-      .catch(() => { if (!cancelled) setVersions([]); });
+      .catch(() => {
+        if (cancelled) return;
+        // Unlike the amendments failure above, this must not be treated as
+        // "no consolidated version" — render `[]` for `selectConsolidatedVersions`
+        // to work with, but flag it so the caller can tell the two apart.
+        setVersions([]);
+        setConsolidatedStatusUnknown(true);
+      });
 
     return () => { cancelled = true; };
   }, [celex]);
@@ -42,9 +62,11 @@ export function useConsolidationStatus(celex) {
     return {
       isOutdated: count > 0,
       amendmentCount: count,
+      amendmentCountExact: !amendmentsTruncated,
       latestAmendmentDate: latestDate,
       consolidated: current,
       hasUpcomingConsolidation: upcoming.length > 0,
+      consolidatedStatusUnknown,
     };
-  }, [amendments, versions]);
+  }, [amendments, amendmentsTruncated, versions, consolidatedStatusUnknown]);
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -451,5 +451,14 @@
     "keyPoints": "Key points",
     "structure": "Structure",
     "generatedOn": "Static summary generated {date}"
+  },
+  "consolidation": {
+    "asAdopted": "You are reading this law as adopted.",
+    "amendedWithDate": "It has been amended {count} times since, most recently on {date}.",
+    "amendedOnceWithDate": "It has been amended once since, on {date}.",
+    "amended": "It has been amended {count} times since.",
+    "amendedOnce": "It has been amended once since.",
+    "readConsolidated": "Read the consolidated text as of {date} on EUR-Lex",
+    "noConsolidatedVersion": "EUR-Lex has not published a consolidated version."
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -458,7 +458,10 @@
     "amendedOnceWithDate": "It has been amended once since, on {date}.",
     "amended": "It has been amended {count} times since.",
     "amendedOnce": "It has been amended once since.",
+    "amendedAtLeastWithDate": "It has been amended at least {count} times since, most recently on {date}.",
+    "amendedAtLeast": "It has been amended at least {count} times since.",
     "readConsolidated": "Read the consolidated text as of {date} on EUR-Lex",
-    "noConsolidatedVersion": "EUR-Lex has not published a consolidated version."
+    "noConsolidatedVersion": "EUR-Lex has not published a consolidated version.",
+    "consolidatedVersionPending": "A consolidated version has been prepared but is not yet in force."
   }
 }

--- a/src/utils/consolidatedVersions.js
+++ b/src/utils/consolidatedVersions.js
@@ -1,0 +1,61 @@
+/**
+ * Pure helpers behind the "you are reading the text as adopted" notice.
+ *
+ * Two independent facts drive it. *Was the text changed?* comes from the
+ * amendment history — corrigenda are excluded, since they correct the published
+ * text rather than amend the law, and a corrigendum-only act (the GDPR, for
+ * one) is still readable as adopted. *Can the reader see the current text?*
+ * comes from the consolidated-version list.
+ *
+ * The API returns every consolidated version, including ones dated in the
+ * future — EUR-Lex prepares a consolidation as soon as an amending act is
+ * published, sometimes months before it applies. Choosing between them needs
+ * today's date, which deliberately stays out of the cached payload.
+ */
+
+/** ISO `YYYY-MM-DD` for the local calendar day, so comparisons are string-safe. */
+export function todayIso(now = new Date()) {
+  const pad = (value) => String(value).padStart(2, "0");
+  return `${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}`;
+}
+
+/**
+ * Split a version list into the one in force today and the ones not yet applied.
+ *
+ * `current` is the newest version dated on or before today. A law whose only
+ * consolidations are future-dated has no current version — presenting an
+ * upcoming one as the text in force would be worse than saying nothing.
+ */
+export function selectConsolidatedVersions(versions, today = todayIso()) {
+  const sorted = (Array.isArray(versions) ? versions : [])
+    .filter((version) => version && version.celex && version.date)
+    .slice()
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  const applied = sorted.filter((version) => version.date <= today);
+  const upcoming = sorted.filter((version) => version.date > today);
+
+  return {
+    current: applied.length ? applied[applied.length - 1] : null,
+    upcoming,
+    all: sorted,
+  };
+}
+
+/**
+ * Count the entries that actually changed the law's text, and date the newest.
+ *
+ * Amendment dates are the amending act's own document date, which is why they
+ * are only ever shown as "most recently amended in <month year>" rather than
+ * used to reason about what the current text says.
+ */
+export function summarizeAmendments(amendments) {
+  const changes = (Array.isArray(amendments) ? amendments : [])
+    .filter((entry) => entry && entry.type === "amendment");
+  const dates = changes.map((entry) => entry.date).filter(Boolean).sort();
+
+  return {
+    count: changes.length,
+    latestDate: dates.length ? dates[dates.length - 1] : null,
+  };
+}

--- a/src/utils/consolidatedVersions.test.js
+++ b/src/utils/consolidatedVersions.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  selectConsolidatedVersions,
+  summarizeAmendments,
+  todayIso,
+} from "./consolidatedVersions.js";
+
+const VERSIONS = [
+  { celex: "02013R0575-20260626", date: "2026-06-26" },
+  { celex: "02013R0575-20130628", date: "2013-06-28" },
+  { celex: "02013R0575-20270101", date: "2027-01-01" },
+];
+
+describe("selectConsolidatedVersions", () => {
+  it("picks the newest version already in force and lists the rest as upcoming", () => {
+    const { current, upcoming, all } = selectConsolidatedVersions(VERSIONS, "2026-08-12");
+
+    expect(current.celex).toBe("02013R0575-20260626");
+    expect(upcoming.map((v) => v.date)).toEqual(["2027-01-01"]);
+    expect(all.map((v) => v.date)).toEqual(["2013-06-28", "2026-06-26", "2027-01-01"]);
+  });
+
+  it("treats a version dated today as in force", () => {
+    expect(selectConsolidatedVersions(VERSIONS, "2026-06-26").current.date).toBe("2026-06-26");
+  });
+
+  it("reports no current version when every consolidation is still ahead", () => {
+    const { current, upcoming } = selectConsolidatedVersions(VERSIONS, "2012-01-01");
+
+    expect(current).toBe(null);
+    expect(upcoming).toHaveLength(3);
+  });
+
+  it("survives missing, malformed and absent input", () => {
+    expect(selectConsolidatedVersions(undefined).current).toBe(null);
+    expect(selectConsolidatedVersions([{ celex: "x" }, null, { date: "2020-01-01" }]).all).toEqual([]);
+  });
+});
+
+describe("summarizeAmendments", () => {
+  it("counts only entries that amended the text", () => {
+    const summary = summarizeAmendments([
+      { type: "corrigendum", date: "2018-05-23" },
+      { type: "amendment", date: "2019-06-07" },
+      { type: "amendment", date: "2024-03-01" },
+    ]);
+
+    expect(summary.count).toBe(2);
+    expect(summary.latestDate).toBe("2024-03-01");
+  });
+
+  it("reports nothing for a corrigendum-only act, so the GDPR gets no warning", () => {
+    const summary = summarizeAmendments([
+      { type: "corrigendum", date: "2018-05-23" },
+      { type: "corrigendum", date: "2021-03-04" },
+    ]);
+
+    expect(summary.count).toBe(0);
+    expect(summary.latestDate).toBe(null);
+  });
+
+  it("counts undated amendments without inventing a date", () => {
+    const summary = summarizeAmendments([{ type: "amendment", date: null }]);
+
+    expect(summary.count).toBe(1);
+    expect(summary.latestDate).toBe(null);
+  });
+});
+
+describe("todayIso", () => {
+  it("formats the local calendar day, zero-padded", () => {
+    expect(todayIso(new Date(2026, 0, 5))).toBe("2026-01-05");
+  });
+});

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -935,6 +935,14 @@ export async function fetchAmendments(celex) {
   }));
 }
 
+export async function fetchConsolidatedVersions(celex) {
+  return getInFlightRequest(`consolidated:${celex}`, () => fetchJsonWithCache({
+    cacheKey: `${celex}_consolidated`,
+    url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/consolidated`,
+    errorLabel: "Consolidated version lookup failed",
+  }));
+}
+
 export async function fetchLawMetadata(celex) {
   return getInFlightRequest(`metadata:${celex}`, () => fetchJsonWithCache({
     cacheKey: `${celex}_metadata`,


### PR DESCRIPTION
Out of the discussion on #135: rather than building consolidated-text rendering (item 1), this does the cheap part of the same job — telling the reader that what's on screen is the text *as adopted*, and where the current text lives.

Everything LegalViz renders is the original published text, and nothing said so. The amendment count existed only behind a collapsed sidebar accordion. For a heavily amended act that silence is the actual harm item 1 was aimed at.

The follow-up spike is stacked on this branch in #145, and its measurements back the "link out for now" decision below.

## What this adds

**Reader-facing.** A notice on the law overview and a compact one above each article:

> ⟲ You are reading this law as adopted.
> It has been amended 4 times since, most recently on 28 Feb 2024.
> [Read the consolidated text as of 28 May 2022 on EUR-Lex ↗](https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:02011L0083-20220528)

Renders nothing when the act has never been amended (the common case), while the amendment history is loading, or when Cellar is unreachable — a warning about a law we know nothing about would be worse than no warning.

**`GET /api/laws/:celex/consolidated`.** Lists the consolidated versions EUR-Lex publishes for an act, oldest first. Cellar has no predicate that resolves from an act to its consolidated versions, so the query matches on the point-in-time CELEX id instead (`32013R0575` → `02013R0575-20260626`). Non-sector-3 ids short-circuit without a SPARQL round trip. Cached in `resolutionCache` like its `/amendments` and `/implementing` neighbours.

## Two decisions worth reviewing

**Corrigenda don't count as amendments.** They correct the published text rather than change the law. This is what keeps the GDPR — 3 corrigenda, 0 amendments, and a single consolidated version that exists only to fold a corrigendum in — from getting a warning it doesn't deserve.

**Future-dated consolidations are excluded from "current".** EUR-Lex prepares a consolidation as soon as an amending act is published, often months before it applies, so the newest version in the list is frequently not the text in force. The endpoint returns everything (keeping the payload cacheable without a "today" baked into it) and the client picks the newest version dated on or before today. Measured in #145: 2 of 13 sampled acts currently carry a future-dated consolidation, so this is a live case, not a hypothetical.

## Why it links out instead of rendering the consolidated text

Checked against live Cellar, and quantified across 14 acts in #145:

- **consolidated versions carry no recitals at all** — 0 on every act sampled, against 49–180 as adopted — so the recital grid, the TF-IDF recital→article map, AI recital titles and the related-recitals rail all go blank;
- **for heavily amended acts the consolidated text is a different act**: the CRR goes 525 → 786 articles, all 265 additions being genuine suffixed insertions (`72a`…`72l`). Every index in the app is keyed to as-adopted article numbering, so those articles have nowhere to land;
- its manifestation sits under `/resource/consolidation/…` (or `/celex/…`), not the `/oj/…` shape `findFmx4Uri` (`fmx-service.js:97`) matches — and only appears when the request carries `Accept-Language`. `search-build.js:236` already handles all three shapes;
- `isFmxDocument` (`fmxParser.mjs:1442`) rejects the `<CONS.ACT>` root. This blocks the **frontend** raw-XML path and cache validation only — the backend `/parsed` route never consults it, which is a correction to what I first wrote here.

None of that is fatal, but it makes rendering a design question — a consolidated version is arguably another *expression* of the same act, not another act — rather than a plumbing task. Linking out is honest in the meantime, and the endpoint is the groundwork either way.

## Testing

- `backend/shared/law-queries.test.js` — id mapping and sorting, exact base matching so `32013R0575` can't absorb `32013R05750`, and the no-SPARQL short circuit.
- `src/utils/consolidatedVersions.test.js` — current/upcoming selection, boundary date, corrigendum-only acts, malformed input.
- `src/components/ConsolidationNotice.test.jsx` — the linked, unlinked, silent and Cellar-down branches.
- Full suites green: 435 vitest, 401 node:test, lint clean. Both variants verified in a browser against a local API and live Cellar data.

No cache constants bumped — no cached payload shape changed, and the new IndexedDB key rides the existing API-JSON envelope.

## Follow-ups not in this PR

- Flagging when the consolidated version is itself behind the newest amendment. #145 measured this as rare — 1 of 13 acts — so it stays out; an amending act dated later may simply not apply yet, and a confidently wrong "this is out of date" is worse than silence.
- Exposing the endpoint as an MCP tool, alongside the other unexposed handlers in item 5 of #135.
- Translating the notice — English only for now, which the catalog's existing fallback handles (other locales already lag by 127 keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZB6GkEWDg9L6ZtrCbjcfF