### PR TITLE
Spike: measure whether consolidated texts are buildable

### DIFF
--- a/backend/scripts/consolidated-texts-probe.mjs
+++ b/backend/scripts/consolidated-texts-probe.mjs
@@ -45,6 +45,7 @@ const TIMEOUT_MS = 120_000;
 const SAMPLE = [
   { celex: '32016R0679', label: 'GDPR' },
   { celex: '32022R2065', label: 'Digital Services Act' },
+  { celex: '32022R1925', label: 'Digital Markets Act' },
   { celex: '32024R1689', label: 'AI Act' },
   { celex: '32011L0083', label: 'Consumer Rights Directive' },
   { celex: '32015L2366', label: 'PSD2' },

--- a/backend/scripts/consolidated-texts-probe.mjs
+++ b/backend/scripts/consolidated-texts-probe.mjs
@@ -1,0 +1,350 @@
+#!/usr/bin/env node
+
+/**
+ * Spike harness for issue #135 item 1: consolidated ("as amended") texts.
+ *
+ * For each sampled act it answers, with evidence rather than argument:
+ *
+ *   1. Does EUR-Lex publish consolidated versions, how many, and how stale is
+ *      the newest one relative to the newest amendment?
+ *   2. Is the consolidated text available as Formex at all, and at which
+ *      manifestation URI shape?
+ *   3. Does the shipped parser accept it, and what does it yield?
+ *   4. How far does the consolidated text drift from the as-adopted text the
+ *      app renders today — same articles, or a different act?
+ *
+ * Nothing here is production code: it reuses the shipped parser and the shipped
+ * consolidated-version query so the answers describe the real pipeline, but it
+ * writes no caches and touches no app state.
+ *
+ * Usage (from `backend/`):
+ *   node scripts/consolidated-texts-probe.mjs              # default sample, table output
+ *   node scripts/consolidated-texts-probe.mjs --json       # machine-readable, for diffing runs
+ *   node scripts/consolidated-texts-probe.mjs 32013R0575 32006L0112
+ *   node scripts/consolidated-texts-probe.mjs --articles 32013R0575
+ */
+
+import { createRequire } from 'node:module';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const { fetchConsolidatedVersions, fetchAmendments } = require('../shared/law-queries.js');
+const { parseFmxXml, isFmxDocument } = require('../shared/fmx-parser-node.js');
+
+const CELLAR_BASE = 'http://publications.europa.eu/resource';
+const SPARQL_ENDPOINT = 'https://publications.europa.eu/webapi/rdf/sparql';
+const API_BASE = process.env.LEGALVIZ_API_BASE || 'https://api.legalviz.eu';
+const TIMEOUT_MS = 120_000;
+
+// Sampled to span the axes that matter: never amended (the control), amended
+// once, amended into a different act, pre-Formex, and the two the discussion in
+// #135 named by hand (GDPR as the "barely changed" case, CRR as the worst case).
+const SAMPLE = [
+  { celex: '32016R0679', label: 'GDPR' },
+  { celex: '32022R2065', label: 'Digital Services Act' },
+  { celex: '32024R1689', label: 'AI Act' },
+  { celex: '32011L0083', label: 'Consumer Rights Directive' },
+  { celex: '32015L2366', label: 'PSD2' },
+  { celex: '32015L0849', label: 'AML Directive 4' },
+  { celex: '32013R0575', label: 'CRR' },
+  { celex: '32013L0036', label: 'CRD IV' },
+  { celex: '32006L0112', label: 'VAT Directive' },
+  { celex: '32014L0065', label: 'MiFID II' },
+  { celex: '32009L0138', label: 'Solvency II' },
+  { celex: '32008L0098', label: 'Waste Framework Directive' },
+  { celex: '32003L0087', label: 'Emissions Trading Directive' },
+  { celex: '32006R1907', label: 'REACH' },
+];
+
+const HAS_UNZIP = (() => {
+  try {
+    execFileSync('unzip', ['-v'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+/**
+ * Cellar throws transient 503s and 5xx under load; a run without retries
+ * reports flakiness as missing data, which is the one thing this probe must not
+ * do. 406 is not retried — Cellar returns it for resources it has indexed but
+ * cannot serve, which is a real finding rather than a hiccup.
+ */
+async function getText(url, headers = {}, attempt = 1) {
+  const response = await fetch(url, {
+    headers: { Accept: '*/*', 'Accept-Language': 'eng', ...headers },
+    redirect: 'follow',
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (response.ok) return response.text();
+  if (response.status >= 500 && attempt <= 3) {
+    await new Promise((resolve) => setTimeout(resolve, 2000 * attempt));
+    return getText(url, headers, attempt + 1);
+  }
+  throw new Error(`HTTP ${response.status} for ${url}`);
+}
+
+async function runSparqlQuery(query) {
+  const url = new URL(SPARQL_ENDPOINT);
+  url.searchParams.set('query', query);
+  url.searchParams.set('format', 'application/sparql-results+json');
+  return JSON.parse(await getText(url.toString(), { Accept: 'application/sparql-results+json' }));
+}
+
+function extractUris(rdf) {
+  return [...rdf.matchAll(/rdf:resource="([^"]+)"/g)].map((match) => match[1]);
+}
+
+/**
+ * Resolve a CELEX to its Formex XML, recording which URI shape answered.
+ *
+ * The serving path (`backend/shared/fmx-service.js`) only matches the `/oj/…`
+ * shapes; this deliberately accepts any `.<LANG>.fmx4`, the way the search
+ * builder already does, so the probe can report *which* acts the serving path
+ * would have missed rather than failing alongside it.
+ */
+async function fetchFmxXml(celex, lang = 'ENG') {
+  const rdf = await getText(`${CELLAR_BASE}/celex/${celex}`);
+  const uris = extractUris(rdf);
+  const fmx4 = uris.find((uri) => uri.endsWith(`.${lang}.fmx4`));
+  if (!fmx4) return { uriShape: null, xml: null };
+
+  // Which path segment Cellar answered with. `findFmx4Uri` in the serving path
+  // only matches `/oj/…`, so anything else here is an act it cannot reach.
+  // Note the `/consolidation/…` shape only appears when the request carries
+  // `Accept-Language`; without it Cellar returns a manifestation-less document.
+  const uriShape = (/\/resource\/([^/]+)\//.exec(fmx4) || [])[1] || 'unknown';
+  const manifestation = extractUris(await getText(fmx4));
+
+  const zip = manifestation.find((uri) => uri.endsWith('.zip'));
+  if (zip) {
+    if (!HAS_UNZIP) return { uriShape, xml: null, note: 'zip manifestation, no unzip binary' };
+    const dir = mkdtempSync(path.join(tmpdir(), 'fmx-spike-'));
+    const archive = path.join(dir, 'fmx.zip');
+    const response = await fetch(zip, { redirect: 'follow', signal: AbortSignal.timeout(TIMEOUT_MS) });
+    writeFileSync(archive, Buffer.from(await response.arrayBuffer()));
+    execFileSync('unzip', ['-o', '-q', archive, '-d', dir]);
+    // The act itself is the largest member; the rest are annexes and the
+    // publication wrapper.
+    const members = readdirSync(dir)
+      .filter((name) => name.toLowerCase().endsWith('.xml') && !name.toLowerCase().endsWith('.doc.xml'))
+      .map((name) => path.join(dir, name));
+    if (!members.length) return { uriShape, xml: null, note: 'zip contained no act XML' };
+    const biggest = members.sort((a, b) => readFileSync(b).length - readFileSync(a).length)[0];
+    return { uriShape, xml: readFileSync(biggest, 'utf8') };
+  }
+
+  const xmlUri = manifestation.find((uri) => /\.fmx4\.[^/]+\.xml$/.test(uri) && !uri.endsWith('.doc.xml'));
+  if (!xmlUri) return { uriShape, xml: null, note: 'no XML manifestation' };
+  return { uriShape, xml: await getText(xmlUri) };
+}
+
+function summarizeParse(parsed) {
+  const articleNumbers = (parsed.articles || []).map((article) => String(article.article_number));
+  return {
+    title: parsed.title || '',
+    articles: articleNumbers.length,
+    articleNumbers: new Set(articleNumbers),
+    recitals: (parsed.recitals || []).length,
+    annexes: (parsed.annexes || []).length,
+    definitions: (parsed.definitions || []).length,
+    crossRefSources: Object.keys(parsed.crossReferences || {}).length,
+  };
+}
+
+/** The as-adopted side of the comparison: what the app renders for this act today. */
+async function fetchShippedParse(celex) {
+  const response = await fetch(`${API_BASE}/api/laws/${celex}/parsed?lang=ENG`, {
+    signal: AbortSignal.timeout(TIMEOUT_MS),
+  });
+  if (!response.ok) throw new Error(`HTTP ${response.status} from /parsed`);
+  return summarizeParse(await response.json());
+}
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function probe({ celex, label }) {
+  const row = { celex, label };
+
+  const [{ versions }, { amendments }] = await Promise.all([
+    fetchConsolidatedVersions(celex, runSparqlQuery),
+    fetchAmendments(celex, runSparqlQuery),
+  ]);
+
+  const applied = versions.filter((version) => version.date <= todayIso());
+  const amendmentDates = amendments
+    .filter((entry) => entry.type === 'amendment' && entry.date)
+    .map((entry) => entry.date)
+    .sort();
+
+  row.amendments = amendmentDates.length;
+  row.latestAmendment = amendmentDates.at(-1) || null;
+  row.versions = versions.length;
+  row.futureVersions = versions.length - applied.length;
+  row.latestVersion = applied.at(-1)?.date || null;
+  // Days the consolidated text trails the newest amending act. Approximate by
+  // construction — an amending act dated later may not apply yet — which is
+  // exactly why the reader UI states dates instead of claiming staleness.
+  row.lagDays = row.latestVersion && row.latestAmendment
+    ? Math.round((Date.parse(row.latestAmendment) - Date.parse(row.latestVersion)) / 86_400_000)
+    : null;
+
+  if (!applied.length) {
+    row.status = 'no consolidated version';
+    return row;
+  }
+
+  const consolidatedCelex = applied.at(-1).celex;
+  const { uriShape, xml, note } = await fetchFmxXml(consolidatedCelex);
+  row.uriShape = uriShape;
+  if (!xml) {
+    row.status = note || 'no FMX manifestation';
+    return row;
+  }
+
+  // The frontend's raw-XML gate (src/utils/parsers.js, formexApi.js). The
+  // backend's /parsed route does not consult it — it parses whatever the FMX
+  // service handed back — so this failing blocks the browser path only.
+  row.passesIsFmxDocument = await isFmxDocument(xml);
+  row.rootElement = (/<([A-Z][A-Z.0-9]*)[\s>]/.exec(xml) || [])[1] || null;
+
+  let consolidated;
+  try {
+    consolidated = summarizeParse(await parseFmxXml(xml));
+  } catch (error) {
+    row.status = `parse threw: ${error.message.slice(0, 80)}`;
+    return row;
+  }
+
+  row.consolidated = {
+    articles: consolidated.articles,
+    recitals: consolidated.recitals,
+    annexes: consolidated.annexes,
+    definitions: consolidated.definitions,
+    title: consolidated.title.slice(0, 90),
+  };
+
+  try {
+    const adopted = await fetchShippedParse(celex);
+    row.adopted = {
+      articles: adopted.articles,
+      recitals: adopted.recitals,
+      annexes: adopted.annexes,
+      definitions: adopted.definitions,
+    };
+    row.articlesAdded = [...consolidated.articleNumbers].filter((n) => !adopted.articleNumbers.has(n)).length;
+    row.articlesRemoved = [...adopted.articleNumbers].filter((n) => !consolidated.articleNumbers.has(n)).length;
+    // A consolidated file that opens with a corrigendum's <TITLE> block reports
+    // the corrigendum as the act's title.
+    row.titleLooksWrong = /^corrigendum/i.test(consolidated.title);
+  } catch (error) {
+    row.adoptedError = error.message.slice(0, 60);
+  }
+
+  row.status = 'parsed';
+  return row;
+}
+
+function renderTable(rows) {
+  const pad = (value, width) => String(value ?? '—').padEnd(width);
+  const padStart = (value, width) => String(value ?? '—').padStart(width);
+
+  console.log('');
+  console.log('CONSOLIDATED VERSION AVAILABILITY');
+  console.log('─'.repeat(104));
+  console.log(`${pad('act', 28)}${padStart('amds', 5)}${padStart('vers', 6)}${padStart('ahead', 6)}  ${pad('newest applied', 15)}${padStart('lag(d)', 7)}  ${pad('uri', 14)}`);
+  console.log('─'.repeat(104));
+  for (const row of rows) {
+    console.log(
+      pad(row.label, 28)
+      + padStart(row.amendments, 5)
+      + padStart(row.versions, 6)
+      + padStart(row.futureVersions, 6)
+      + '  ' + pad(row.latestVersion, 15)
+      + padStart(row.lagDays, 7)
+      + '  ' + pad(row.uriShape, 14)
+    );
+  }
+
+  console.log('');
+  console.log('PARSER BEHAVIOUR ON THE CONSOLIDATED TEXT   (consolidated vs as-adopted)');
+  console.log('─'.repeat(104));
+  console.log(`${pad('act', 28)}${pad('root', 10)}${pad('gate', 6)}${pad('articles', 16)}${pad('recitals', 16)}${pad('defs', 14)}${padStart('±art', 8)}`);
+  console.log('─'.repeat(104));
+  for (const row of rows) {
+    if (row.status !== 'parsed') {
+      console.log(pad(row.label, 28) + row.status);
+      continue;
+    }
+    const pair = (key) => `${row.consolidated[key]} vs ${row.adopted ? row.adopted[key] : '?'}`;
+    const delta = row.articlesAdded == null ? '—' : `+${row.articlesAdded}/-${row.articlesRemoved}`;
+    console.log(
+      pad(row.label, 28)
+      + pad(row.rootElement, 10)
+      + pad(row.passesIsFmxDocument ? 'pass' : 'FAIL', 6)
+      + pad(pair('articles'), 16)
+      + pad(pair('recitals'), 16)
+      + pad(pair('definitions'), 14)
+      + padStart(delta, 8)
+      + (row.titleLooksWrong ? '   title=corrigendum' : '')
+    );
+  }
+  console.log('');
+}
+
+/**
+ * Detail mode: name the articles consolidation adds and removes, so a large
+ * "+265" can be checked for what it is — genuine inserted articles (`92a`,
+ * `494b`) versus parser noise.
+ */
+async function reportArticleDelta(celex) {
+  const { versions } = await fetchConsolidatedVersions(celex, runSparqlQuery);
+  const applied = versions.filter((version) => version.date <= todayIso());
+  if (!applied.length) throw new Error(`no applied consolidated version for ${celex}`);
+
+  const { xml } = await fetchFmxXml(applied.at(-1).celex);
+  if (!xml) throw new Error(`no Formex for ${applied.at(-1).celex}`);
+
+  const consolidated = summarizeParse(await parseFmxXml(xml));
+  const adopted = await fetchShippedParse(celex);
+  const added = [...consolidated.articleNumbers].filter((n) => !adopted.articleNumbers.has(n));
+  const removed = [...adopted.articleNumbers].filter((n) => !consolidated.articleNumbers.has(n));
+  const suffixed = added.filter((n) => /[a-z]$/i.test(n));
+
+  console.log(`\n${celex} — consolidated ${applied.at(-1).celex}`);
+  console.log(`  articles: ${consolidated.articles} consolidated vs ${adopted.articles} as adopted`);
+  console.log(`  added   : ${added.length} (${suffixed.length} suffixed, e.g. 92a) — ${added.slice(0, 20).join(', ')}${added.length > 20 ? ' …' : ''}`);
+  console.log(`  removed : ${removed.length} — ${removed.join(', ') || '—'}\n`);
+}
+
+const args = process.argv.slice(2);
+const asJson = args.includes('--json');
+const articlesOf = args.includes('--articles');
+const requested = args.filter((arg) => !arg.startsWith('--'));
+const sample = requested.length
+  ? requested.map((celex) => ({ celex: celex.toUpperCase(), label: celex.toUpperCase() }))
+  : SAMPLE;
+
+if (articlesOf) {
+  for (const entry of sample) await reportArticleDelta(entry.celex);
+  process.exit(0);
+}
+
+const rows = [];
+for (const entry of sample) {
+  process.stderr.write(`· ${entry.label}\n`);
+  try {
+    rows.push(await probe(entry));
+  } catch (error) {
+    rows.push({ ...entry, status: `error: ${error.message.slice(0, 80)}` });
+  }
+}
+
+if (asJson) console.log(JSON.stringify(rows, null, 2));
+else renderTable(rows);

--- a/docs/consolidated-texts-spike.md
+++ b/docs/consolidated-texts-spike.md
@@ -22,7 +22,8 @@ rest of the app is indexed against.
 | act | amendments | versions | not yet applied | newest applied | uri shape |
 |---|---:|---:|---:|---|---|
 | GDPR | 0 | 1 | 0 | 2016-05-04 | `/celex/` |
-| Digital Services Act | — | — | — | *406 from Cellar* | — |
+| Digital Services Act | 0 | 1 | 0 | *406 from Cellar* | — |
+| Digital Markets Act | 0 | 1 | 0 | 2022-10-12 | `/consolidation/` |
 | AI Act | 1 | 2 | 0 | 2026-07-27 | `/consolidation/` |
 | Consumer Rights Directive | 4 | 4 | 1 | 2022-05-28 | `/consolidation/` |
 | PSD2 | 2 | 3 | 0 | 2025-01-17 | `/consolidation/` |
@@ -36,30 +37,56 @@ rest of the app is indexed against.
 | Emissions Trading Directive | 18 | 16 | 0 | 2024-03-01 | `/consolidation/` |
 | REACH | 42 | 68 | 0 | 2026-05-11 | `/consolidation/` |
 
-- **13 of 14 acts have consolidated Formex**, and every one of those parsed.
+- **14 of 15 acts have consolidated Formex**, and every one of those parsed.
   Consolidation chains are long where it matters (REACH 68 versions, CRR 22),
   which is the opposite of the "there usually aren't super long consolidations"
   assumption — that holds only for young or lightly amended acts.
-- **Consolidation is not stale.** In 12 of 13 cases the newest consolidated
+- **Consolidation is not stale.** In 13 of 14 cases the newest consolidated
   version is *newer* than the newest amending act. The one exception is the
   Consumer Rights Directive, where consolidation trails by 641 days. Whatever
   the risk of this feature is, serving out-of-date consolidations is not it.
-- **Future-dated versions are real but rare**: 2 of 13 acts carry a
+- **Future-dated versions are real but rare**: 2 of 14 acts carry a
   consolidation dated after today. Any consumer must filter them or it will
   present a text that has not yet applied.
 - **One act is indexed but unservable.** SPARQL lists `02022R2065-20221027` for
   the DSA; Cellar answers `406` for the resource, on every Accept header tried.
   That is the "Cellar data might be incomplete" concern, quantified at roughly
-  1 in 14 — low, but non-zero, so the UI cannot assume a listed version resolves.
+  1 in 15 — low, but non-zero, so the UI cannot assume a listed version resolves.
+
+### 1a. The featured laws specifically
+
+The eight acts on the landing page are the ones most readers actually open, so
+they were checked separately — both for what the data says and for what the
+#144 notice renders:
+
+| act | amendment history | consolidated | notice shown |
+|---|---|---:|---|
+| GDPR | 3 corrigenda, 0 amendments | 1 | no |
+| DMA | 2 corrigenda, 0 amendments | 1 | no |
+| DSA | 10 corrigenda, 0 amendments | 1 (unservable) | no |
+| AI Act | 4 corrigenda, **1 amendment** | 2 | **yes** |
+| Data Act | 5 corrigenda, 0 amendments | 1 | no |
+| Data Governance Act | 6 corrigenda, 0 amendments | 1 | no |
+| P2B Regulation | 2 corrigenda, 0 amendments | 1 | no |
+| NIS2 | 9 corrigenda, 0 amendments | 1 | no |
+
+Seven of the eight are corrigendum-only. Had corrigenda counted as amendments,
+**every featured law would carry a warning banner** — permanent noise on the
+app's most-visited pages, for acts whose text has never changed. The one that
+fires is the AI Act (amended 2026-07-08, consolidated 2026-07-27), verified in a
+browser end to end alongside GDPR, DSA and DMA rendering nothing.
+
+It also means the DSA's unservable consolidation never reaches a reader: the
+notice does not fire for an unamended act, so the broken link is never offered.
 
 ## 2. Plumbing: three concrete gaps, all small
 
 **The parser already handles the body.** Consolidated Formex is a `<CONS.ACT>`
 root wrapping the same `ENACTING.TERMS → DIVISION → ARTICLE → TI.ART/PARAG`
 structure as an OJ act. `parseFmxToCombined` walks it unmodified and produced
-plausible articles and definitions for all 13. No parser rewrite is implied.
+plausible articles and definitions for all 14. No parser rewrite is implied.
 
-**Gap 1 — `isFmxDocument` rejects every consolidated document** (all 13 rows
+**Gap 1 — `isFmxDocument` rejects every consolidated document** (all 14 rows
 report `FAIL`). It requires the literal `<ACT`, which `<CONS.ACT` does not
 contain. Worth being precise about where this bites: the backend `/parsed` route
 never consults it (`parsed-law-service.js` parses whatever the FMX service
@@ -112,7 +139,7 @@ definition counts are unaffected; the serving path combines all members.
 
 ## 3. The two findings that should actually drive the decision
 
-**Consolidated texts have no recitals. None, anywhere.** Every one of the 13
+**Consolidated texts have no recitals. None, anywhere.** Every one of the 14
 acts parsed to `0` recitals against 49–180 in the as-adopted text. This is not a
 GDPR quirk; it is what EUR-Lex consolidation does. Rendering a consolidated
 version therefore blanks the recital grid, the TF-IDF recital→article map, the
@@ -124,6 +151,7 @@ distinguish this reader from EUR-Lex's own.
 | act | articles consolidated vs adopted | added | removed |
 |---|---|---:|---:|
 | GDPR | 99 vs 99 | 0 | 0 |
+| Digital Markets Act | 54 vs 54 | 0 | 0 |
 | Consumer Rights Directive | 36 vs 37 | 1 | 1 |
 | PSD2 | 118 vs 117 | 1 | 0 |
 | AI Act | 119 vs 113 | 6 | 0 |
@@ -140,7 +168,7 @@ The "only changes a few things" intuition is correct for the GDPR and for young
 acts, and badly wrong for the acts that motivate the feature. Running the probe
 with `--articles 32013R0575` confirms the CRR delta is real, not parser noise:
 **all 265 added articles are suffixed insertions** — `5a`, `10a`, `47a`, `47b`,
-`47c`, `72a`…`72l`, `78a`. Half the operative text of the CRR that a
+`47c`, `72a`…`72l`, `78a`. A third of the operative text of the CRR that a
 practitioner needs does not exist in what LegalViz renders today.
 
 That cuts both ways. It is the strongest argument *for* the feature — and the
@@ -173,7 +201,7 @@ Build it, but not as a second law.
    and its cohort the choice is not "adopted vs consolidated", it is "nothing vs
    something", and none of the index-identity problems apply because there is no
    as-adopted parse to conflict with.
-4. **Do not trust the version list to resolve.** ~1 in 14 is indexed but
+4. **Do not trust the version list to resolve.** ~1 in 15 is indexed but
    unservable; fall back to the as-adopted text rather than erroring.
 
 Not recommended: rendering consolidated text under its own `0…` CELEX as the

--- a/docs/consolidated-texts-spike.md
+++ b/docs/consolidated-texts-spike.md
@@ -1,0 +1,181 @@
+# Spike: consolidated ("as amended") texts
+
+Time-boxed investigation of item 1 in #135. Question: *is rendering consolidated
+texts the cheap plumbing job the issue claims, and is the upstream data good
+enough to build on?*
+
+Everything below is a measurement, not an argument. Reproduce with
+`node scripts/consolidated-texts-probe.mjs` from `backend/` (~12 min, needs
+network; no API keys, no caches written). Numbers are from a run on 2026-08-12
+against live Cellar, with the deployed `api.legalviz.eu` as the as-adopted side.
+
+**Answers, in short.** The data is good — better than expected. The plumbing is
+not cheap, but it is bounded and well understood. The reason to hesitate is
+neither of those: it is that consolidated texts have **no recitals**, and for
+heavily amended acts they are a **substantially different act** from the one the
+rest of the app is indexed against.
+
+---
+
+## 1. Availability: better than the issue assumed
+
+| act | amendments | versions | not yet applied | newest applied | uri shape |
+|---|---:|---:|---:|---|---|
+| GDPR | 0 | 1 | 0 | 2016-05-04 | `/celex/` |
+| Digital Services Act | — | — | — | *406 from Cellar* | — |
+| AI Act | 1 | 2 | 0 | 2026-07-27 | `/consolidation/` |
+| Consumer Rights Directive | 4 | 4 | 1 | 2022-05-28 | `/consolidation/` |
+| PSD2 | 2 | 3 | 0 | 2025-01-17 | `/consolidation/` |
+| AML Directive 4 | 4 | 5 | 0 | 2024-12-30 | `/consolidation/` |
+| CRR | 20 | 22 | 0 | 2026-06-26 | `/consolidation/` |
+| CRD IV | 12 | 14 | 0 | 2026-07-11 | `/consolidation/` |
+| VAT Directive | 32 | 31 | 0 | 2025-04-14 | `/consolidation/` |
+| MiFID II | 12 | 14 | 0 | 2026-06-06 | `/consolidation/` |
+| Solvency II | 12 | 14 | 1 | 2025-01-17 | `/consolidation/` |
+| Waste Framework Directive | 6 | 6 | 0 | 2025-10-16 | `/consolidation/` |
+| Emissions Trading Directive | 18 | 16 | 0 | 2024-03-01 | `/consolidation/` |
+| REACH | 42 | 68 | 0 | 2026-05-11 | `/consolidation/` |
+
+- **13 of 14 acts have consolidated Formex**, and every one of those parsed.
+  Consolidation chains are long where it matters (REACH 68 versions, CRR 22),
+  which is the opposite of the "there usually aren't super long consolidations"
+  assumption — that holds only for young or lightly amended acts.
+- **Consolidation is not stale.** In 12 of 13 cases the newest consolidated
+  version is *newer* than the newest amending act. The one exception is the
+  Consumer Rights Directive, where consolidation trails by 641 days. Whatever
+  the risk of this feature is, serving out-of-date consolidations is not it.
+- **Future-dated versions are real but rare**: 2 of 13 acts carry a
+  consolidation dated after today. Any consumer must filter them or it will
+  present a text that has not yet applied.
+- **One act is indexed but unservable.** SPARQL lists `02022R2065-20221027` for
+  the DSA; Cellar answers `406` for the resource, on every Accept header tried.
+  That is the "Cellar data might be incomplete" concern, quantified at roughly
+  1 in 14 — low, but non-zero, so the UI cannot assume a listed version resolves.
+
+## 2. Plumbing: three concrete gaps, all small
+
+**The parser already handles the body.** Consolidated Formex is a `<CONS.ACT>`
+root wrapping the same `ENACTING.TERMS → DIVISION → ARTICLE → TI.ART/PARAG`
+structure as an OJ act. `parseFmxToCombined` walks it unmodified and produced
+plausible articles and definitions for all 13. No parser rewrite is implied.
+
+**Gap 1 — `isFmxDocument` rejects every consolidated document** (all 13 rows
+report `FAIL`). It requires the literal `<ACT`, which `<CONS.ACT` does not
+contain. Worth being precise about where this bites: the backend `/parsed` route
+never consults it (`parsed-law-service.js` parses whatever the FMX service
+returned), so this blocks the **frontend** raw-XML path and cache validation
+(`src/utils/parsers.js`, `formexApi.js:711`) only.
+
+**Gap 2 — the manifestation URI shape.** `findFmx4Uri` in the serving path
+(`fmx-service.js:97`) matches `/oj/…` only. Consolidated manifestations live at
+`/resource/consolidation/<id>%2F<date>.ENG.fmx4`, or occasionally
+`/resource/celex/…` (the GDPR). The generic `\.[A-Z]{3}\.fmx4$` matcher in
+`search-build.js:236` already handles all three — the fix exists in the repo, it
+just isn't in the path that serves readers.
+
+**Gap 2a — the `/consolidation/` URI only appears with `Accept-Language`.**
+Without that header Cellar returns a document listing no FMX manifestation at
+all. The serving path already sends `Accept-Language: eng`; anything new must
+not drop it, or consolidated acts will look like they have no Formex.
+
+**Gap 3 — title extraction.** Consolidated files open with a `<GR.CORRIG>`
+family block whose `<TITLE>` precedes the act's own, so a naive first-`TITLE`
+read yields the corrigendum's title. (Not observed in the parsed output for the
+sample, so the current traversal appears to avoid it — but it is a trap for any
+new metadata code.)
+
+## 2a. Cost per version: one file, not a chain
+
+Worth stating explicitly, because the version counts above invite the opposite
+assumption: **each consolidated version is a complete standalone document, not a
+delta.** REACH's 68 versions are 68 independent snapshots of the whole act. To
+render the current text you fetch exactly one of them, and nothing has to be
+replayed in order.
+
+Measured end-to-end for the newest applied version of three heavily amended
+acts (resource RDF → manifestation RDF → payload):
+
+| act | requests | payload | wall time |
+|---|---:|---:|---:|
+| CRR | 3 | 1.0 MB (zip) | 1.7 s |
+| REACH | 3 | 0.6 MB (zip) | 1.2 s |
+| VAT Directive | 3 | 0.1 MB (zip) | 1.1 s |
+
+The two RDF hops are the same shape the FMX service already performs for
+as-adopted acts, and the existing disk cache keys on CELEX, so a consolidated
+id caches like any other. Large consolidated acts arrive as a single
+`CONSLEG_*.fmx4.zip`, which `findDownloadUrls` already handles.
+
+*Harness limitation:* the probe unzips and parses only the largest member (the
+act body), so its annex counts understate zipped acts. Article, recital and
+definition counts are unaffected; the serving path combines all members.
+
+## 3. The two findings that should actually drive the decision
+
+**Consolidated texts have no recitals. None, anywhere.** Every one of the 13
+acts parsed to `0` recitals against 49–180 in the as-adopted text. This is not a
+GDPR quirk; it is what EUR-Lex consolidation does. Rendering a consolidated
+version therefore blanks the recital grid, the TF-IDF recital→article map, the
+AI recital titles and the related-recitals rail — the features that most
+distinguish this reader from EUR-Lex's own.
+
+**For heavily amended acts, the consolidated text is a different act.**
+
+| act | articles consolidated vs adopted | added | removed |
+|---|---|---:|---:|
+| GDPR | 99 vs 99 | 0 | 0 |
+| Consumer Rights Directive | 36 vs 37 | 1 | 1 |
+| PSD2 | 118 vs 117 | 1 | 0 |
+| AI Act | 119 vs 113 | 6 | 0 |
+| MiFID II | 103 vs 102 | 6 | 5 |
+| Waste Framework Directive | 54 vs 45 | 11 | 0 |
+| AML Directive 4 | 81 vs 69 | 12 | 0 |
+| Solvency II | 334 vs 318 | 22 | 6 |
+| CRD IV | 197 vs 165 | 32 | 0 |
+| Emissions Trading Directive | 83 vs 33 | 50 | 0 |
+| VAT Directive | 496 vs 414 | 82 | 0 |
+| CRR | 786 vs 525 | 265 | 5 |
+
+The "only changes a few things" intuition is correct for the GDPR and for young
+acts, and badly wrong for the acts that motivate the feature. Running the probe
+with `--articles 32013R0575` confirms the CRR delta is real, not parser noise:
+**all 265 added articles are suffixed insertions** — `5a`, `10a`, `47a`, `47b`,
+`47c`, `72a`…`72l`, `78a`. Half the operative text of the CRR that a
+practitioner needs does not exist in what LegalViz renders today.
+
+That cuts both ways. It is the strongest argument *for* the feature — and the
+reason it cannot be modelled as "just another CELEX", because every index in the
+app (search excerpts, citation graph, definitions, case-law `articleRefs`,
+prerendered pages) is keyed to the as-adopted article numbering. A judgment
+citing "Article 72b CRR" has nowhere to land today.
+
+**Bonus finding: consolidated Formex rescues acts the current pipeline fails
+on.** REACH renders as **0 articles, 0 recitals, 0 annexes** from the deployed
+API right now (`source: eurlex-html` — the HTML fallback yields nothing). Its
+consolidated Formex parses to 141 articles. For pre-Formex acts, consolidation
+is not a "current text" feature at all — it is the only way to render them.
+
+## 4. Recommendation
+
+Build it, but not as a second law.
+
+1. **Model a consolidation as another *expression* of the act.** Keep the
+   sector-3 CELEX as identity for search, citation graph, definitions, case law,
+   prerender and URLs; add a version dimension (`?version=2026-06-26`) that
+   swaps article bodies. This is what keeps the recital loss survivable — serve
+   the as-adopted recitals alongside consolidated articles, which is also the
+   legally correct pairing, since consolidation does not amend recitals.
+2. **Accept that article-level joins need a mapping.** Inserted articles
+   (`72b`) have no as-adopted counterpart, so case-law and citation-graph links
+   degrade rather than resolve. Decide deliberately whether an unmatched article
+   shows nothing or falls back to the base act.
+3. **Sequence pre-Formex acts first if you want the cheapest win.** For REACH
+   and its cohort the choice is not "adopted vs consolidated", it is "nothing vs
+   something", and none of the index-identity problems apply because there is no
+   as-adopted parse to conflict with.
+4. **Do not trust the version list to resolve.** ~1 in 14 is indexed but
+   unservable; fall back to the as-adopted text rather than erroring.
+
+Not recommended: rendering consolidated text under its own `0…` CELEX as the
+issue proposes. It is the fastest route to a law page with no recitals, no case
+law, no citation graph, and no way back.


### PR DESCRIPTION
**Stacked on #144** — review that one first; this PR's diff is only `backend/scripts/consolidated-texts-probe.mjs` and `docs/consolidated-texts-spike.md`. No production code, no caches written, nothing wired into the app.

The spike from the #135 discussion: is item 1 the "plumbing, not parsing" job the issue claims, and is the Cellar data good enough to build on? 14 acts sampled, measured against live Cellar with the deployed API as the as-adopted side. Reproduce with `node scripts/consolidated-texts-probe.mjs` from `backend/` (~12 min).

## What came back

**The data is better than either of us assumed.** 13 of 14 acts have consolidated Formex, all 13 parse with the shipped parser unmodified, and in 12 of 13 the newest consolidation is *newer* than the newest amending act. Consolidation chains are long exactly where it matters (REACH 68 versions, CRR 22), so "there usually aren't super long consolidations" holds only for young acts. One act — the DSA — is listed by SPARQL but returns 406 from Cellar on every Accept header, which puts your "Cellar might be incomplete" instinct at roughly 1 in 14: low, but a version list can't be assumed to resolve.

**The plumbing is three small gaps**, all named with file:line in the doc: `isFmxDocument` rejects `<CONS.ACT>` (frontend path only — worth correcting what I said earlier, the backend `/parsed` route never consults it), `findFmx4Uri` matches `/oj/` while consolidated manifestations live under `/consolidation/`, and that URI only appears when the request carries `Accept-Language`. The generic matcher in `search-build.js:236` already handles all three shapes.

**Neither of those should drive the decision. These two should:**

*Consolidated texts have no recitals.* Zero, on all 13, against 49–180 in the as-adopted text. Not a GDPR quirk — it's what consolidation does. That blanks the recital grid, the TF-IDF map, the AI recital titles and the related-recitals rail.

*For heavily amended acts, the consolidated text is a different act.* The CRR goes from 525 articles to 786. Running the probe with `--articles 32013R0575` confirms all 265 additions are genuine suffixed insertions — `5a`, `47a`, `72a`…`72l`. Roughly a third of the operative CRR a practitioner needs does not exist in what LegalViz renders today. That's the strongest argument *for* the feature, and the reason it can't be a second CELEX: every index in the app is keyed to as-adopted article numbering, so a judgment citing "Article 72b CRR" has nowhere to land.

**Bonus, and possibly the cheapest win in here:** REACH currently renders as **0 articles, 0 recitals, 0 annexes** from the deployed API — the HTML fallback yields nothing. Its consolidated Formex parses to 141 articles. For pre-Formex acts this isn't a "current text" feature at all; it's the only way to render them.

## On your fetch-cost question

No sequential chain. Each version is a complete standalone document, not a delta — REACH's 68 versions are 68 independent snapshots, and you fetch exactly the one you want. Measured, newest applied version:

| act | requests | payload | wall |
|---|---:|---:|---:|
| CRR | 3 | 1.0 MB (zip) | 1.7 s |
| REACH | 3 | 0.6 MB (zip) | 1.2 s |
| VAT Directive | 3 | 0.1 MB (zip) | 1.1 s |

Same two-RDF-hop shape the FMX service already does for as-adopted acts, and the disk cache keys on CELEX, so a consolidated id caches like any other.

## Recommendation in the doc

Build it, but as another *expression* of the act rather than a second law: keep the sector-3 CELEX as identity for search, citation graph, definitions, case law and URLs, add a version dimension that swaps article bodies, and serve as-adopted recitals alongside consolidated articles — which is also the legally correct pairing, since consolidation doesn't amend recitals. Sequence pre-Formex acts first if you want the cheapest slice; there the choice is "nothing vs something" and none of the identity problems apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZB6GkEWDg9L6ZtrCbjcfF

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZB6GkEWDg9L6ZtrCbjcfF)_