### PR TITLE
Render each Formex ALINEA as its own paragraph

### DIFF
--- a/backend/shared/formex-parser/fmxParser.mjs
+++ b/backend/shared/formex-parser/fmxParser.mjs
@@ -33,7 +33,7 @@ import {
  * Bump this whenever the parser output changes (new fields, bug fixes, etc.)
  * so that cached parsed results are automatically re-parsed from raw XML.
  */
-export const PARSER_VERSION = 20;
+export const PARSER_VERSION = 21;
 
 // ---------------------------------------------------------------------------
 // FMX → HTML conversion helpers
@@ -289,8 +289,12 @@ function fmxToHtml(el, ctx = null) {
     return body;
   }
 
-  // ALINEA — unnumbered paragraph block, render children directly
-  if (tag === "ALINEA") return childrenHtml(el, ctx);
+  // ALINEA — one (sub)paragraph. A PARAG may hold several of them (the
+  // "first subparagraph", "second subparagraph" … a law refers to), and FMX
+  // puts their text straight inside ALINEA with no P wrapper — so rendering
+  // the children directly ran consecutive subparagraphs together into one
+  // block ("…enjoyment of the work.Deployers of an AI system…").
+  if (tag === "ALINEA") return renderAlineaBlocks(el, ctx);
 
   // P — plain paragraph
   if (tag === "P") return `<p>${childrenHtml(el, ctx)}</p>`;
@@ -306,6 +310,39 @@ function fmxToHtml(el, ctx = null) {
 
   // Default: just recurse
   return childrenHtml(el, ctx);
+}
+
+// Rendered HTML that already opens with a block-level element and therefore
+// must not be folded into a wrapping <p>.
+const BLOCK_HTML_START = /^\s*<(?:p|div|ul|ol|li|table|aside|blockquote|h[1-6])[\s/>]/i;
+
+/**
+ * Render an ALINEA's children, wrapping runs of inline content in a paragraph
+ * so each ALINEA becomes its own block. Block children (P, LIST, tables …)
+ * pass through untouched.
+ */
+function renderAlineaBlocks(el, ctx = null) {
+  let out = "";
+  let inline = "";
+
+  const flushInline = () => {
+    if (inline.trim()) out += `<p class="oj-normal">${inline}</p>`;
+    inline = "";
+  };
+
+  for (const child of el.childNodes) {
+    const html = fmxToHtml(child, ctx);
+    if (!html) continue;
+    if (BLOCK_HTML_START.test(html)) {
+      flushInline();
+      out += html;
+    } else {
+      inline += html;
+    }
+  }
+  flushInline();
+
+  return out;
 }
 
 function childrenHtml(el, ctx = null) {

--- a/backend/shared/formex-parser/fmxParser.test.js
+++ b/backend/shared/formex-parser/fmxParser.test.js
@@ -379,6 +379,66 @@ describe("parseFmxToCombined — AI Act", () => {
       expect(art.article_html).not.toMatch(/<TXT\b/);
     }
   });
+
+  it("keeps the two subparagraphs of Article 50(4) in separate blocks", () => {
+    const art50 = result.articles.find((a) => String(a.article_number) === "50");
+    // The second subparagraph used to be glued onto the first ("…work.Deployers…").
+    expect(art50.article_html).not.toMatch(/work\.\s*Deployers/);
+    expect(art50.article_html).toMatch(
+      /does not hamper the display or enjoyment of the work\.<\/p>\s*<p[^>]*>Deployers of an AI system that generates or manipulates text/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseFmxToCombined — subparagraphs (ALINEA)
+// ---------------------------------------------------------------------------
+
+describe("parseFmxToCombined — subparagraphs", () => {
+  const wrap = (articleXml) =>
+    `<ACT><BIB.INSTANCE><LG.DOC>EN</LG.DOC></BIB.INSTANCE><ENACTING.TERMS><DIVISION>${articleXml}</DIVISION></ENACTING.TERMS></ACT>`;
+
+  const articleHtml = (articleXml) =>
+    parseFmxToCombined(wrap(articleXml)).articles[0].article_html;
+
+  it("renders each ALINEA of a numbered paragraph as its own block", () => {
+    const html = articleHtml(
+      `<ARTICLE IDENTIFIER="001"><TI.ART>Article 1</TI.ART>` +
+      `<PARAG IDENTIFIER="001.001"><NO.PARAG>1.</NO.PARAG>` +
+      `<ALINEA>First subparagraph.</ALINEA><ALINEA>Second subparagraph.</ALINEA>` +
+      `</PARAG></ARTICLE>`,
+    );
+    expect(html).not.toContain("First subparagraph.Second");
+    expect(html).toMatch(/<p[^>]*>1\.(?:&nbsp;)+First subparagraph\.<\/p>/);
+    expect(html).toMatch(/<p[^>]*>Second subparagraph\.<\/p>/);
+  });
+
+  it("renders a lone unnumbered ALINEA as a single paragraph", () => {
+    const html = articleHtml(
+      `<ARTICLE IDENTIFIER="001"><TI.ART>Article 1</TI.ART><ALINEA>Only text.</ALINEA></ARTICLE>`,
+    );
+    expect(html).toMatch(/<p[^>]*>Only text\.<\/p>/);
+    expect(html.match(/<p\b/g)).toHaveLength(1);
+  });
+
+  it("does not double-wrap an ALINEA whose text already sits in a P", () => {
+    const html = articleHtml(
+      `<ARTICLE IDENTIFIER="001"><TI.ART>Article 1</TI.ART><ALINEA><P>Wrapped text.</P></ALINEA></ARTICLE>`,
+    );
+    expect(html).not.toMatch(/<p[^>]*>\s*<p\b/);
+    expect(html.match(/<p\b/g)).toHaveLength(1);
+  });
+
+  it("keeps a list inside an ALINEA outside the intro paragraph", () => {
+    const html = articleHtml(
+      `<ARTICLE IDENTIFIER="001"><TI.ART>Article 1</TI.ART>` +
+      `<PARAG IDENTIFIER="001.001"><NO.PARAG>1.</NO.PARAG>` +
+      `<ALINEA>The following apply:<LIST TYPE="ALPHA"><ITEM><NP><NO.P>(a)</NO.P><TXT>first item;</TXT></NP></ITEM></LIST></ALINEA>` +
+      `</PARAG></ARTICLE>`,
+    );
+    expect(html).toMatch(/<p[^>]*>1\.(?:&nbsp;)+The following apply:<\/p>/);
+    expect(html).toMatch(/<ol[^>]*class="[^"]*fmx-list/);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

AI Act Article 50(4) rendered its two subparagraphs as one run-on block, with the sentence boundary swallowed:

> …in an appropriate manner that does not hamper the display or enjoyment of the **work.Deployers** of an AI system that generates or manipulates text…

EUR-Lex shows them as two separate paragraphs.

## Cause

In Formex, a `PARAG` holds one `ALINEA` per subparagraph (the "first subparagraph", "second subparagraph" that the acts themselves cross-refer to), and the text sits **directly inside** `ALINEA` with no `<P>` wrapper:

```xml
<PARAG IDENTIFIER="050.004"><NO.PARAG>4.</NO.PARAG>
  <ALINEA>Deployers of an AI system that generates or manipulates image…</ALINEA>
  <ALINEA>Deployers of an AI system that generates or manipulates text…</ALINEA>
</PARAG>
```

`fmxToHtml` rendered `ALINEA` with `childrenHtml(el, ctx)`, so consecutive subparagraphs were concatenated as bare text and the `PARAG` handler then wrapped the whole thing in a single `<p>`. This was not specific to Article 50 — it hit **every** multi-subparagraph provision in every FMX-sourced law (AI Act Art. 26(5), 26(6), 26(10) with its seven subparagraphs, etc.).

## Fix

`ALINEA` now wraps runs of inline content in `<p class="oj-normal">` — the same class the numbered-paragraph path already emitted — and passes block-level children (`P`, `LIST`, tables) through untouched, so an intro line followed by a list still renders correctly and a `<P>`-wrapped ALINEA is not double-wrapped.

Output for single-ALINEA paragraphs is byte-identical to before: the `PARAG` handler injects the number into the first `<p>`, producing the same `<p class="oj-normal">4.&nbsp;&nbsp;&nbsp;…</p>` it produced via the plain-text branch.

`PARSER_VERSION` bumped 20 → 21 so on-disk and IndexedDB caches regenerate.

## Verification

- Parsed the live AI Act Formex ZIP from Cellar (`L_202401689EN`) with the patched parser: Art. 50(4) and Art. 26(5)/(6)/(10) now emit one `<p>` per subparagraph, no glued sentences.
- New tests in `fmxParser.test.js`: an Art. 50(4) regression assertion on the AI Act fixture, plus unit tests for multi-ALINEA paragraphs, a lone unnumbered ALINEA, a `<P>`-wrapped ALINEA (no double wrap), and an ALINEA containing a list.
- `npx vitest run` — 427 passed (36 files); `backend/ npm test` — 399 passed, 0 failed, 2 skipped; `npm run lint` clean.

## Remaining risk

The change touches shared parser output, so it affects HTML for all FMX laws, not only the AI Act; the version bump means the first request per law re-parses rather than serving cache.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZZxgEkdFCk5M59nffFCqr

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZZxgEkdFCk5M59nffFCqr)_