### PR TITLE
Fix law search recovery after Railway cold starts

### DIFF
--- a/src/components/SearchBox.celex.test.jsx
+++ b/src/components/SearchBox.celex.test.jsx
@@ -135,6 +135,55 @@ describe("SearchBox — CELEX / EUR-Lex direct open", () => {
     expect(document.body.textContent).toContain("Open directly");
   });
 
+  it("recovers on a new query after a failed backend request", async () => {
+    searchLaws
+      .mockRejectedValueOnce(new Error("search_cache_unavailable"))
+      .mockResolvedValueOnce({
+        results: [{ celex: "32016R0679", title: "General Data Protection Regulation" }],
+      });
+    renderSearchBox(vi.fn());
+
+    typeQuery("first query");
+    await flush();
+    expect(document.body.textContent).toContain("search_cache_unavailable");
+
+    typeQuery("gdpr");
+    await flush();
+
+    expect(document.body.textContent).toContain("General Data Protection Regulation");
+    expect(searchLaws).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let a late failed request replace newer results", async () => {
+    let rejectFirstRequest;
+    const firstRequest = new Promise((resolve, reject) => {
+      rejectFirstRequest = reject;
+    });
+    searchLaws
+      .mockReturnValueOnce(firstRequest)
+      .mockResolvedValueOnce({
+        results: [{ celex: "32016R0679", title: "General Data Protection Regulation" }],
+      });
+    renderSearchBox(vi.fn());
+
+    typeQuery("first query");
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    typeQuery("gdpr");
+    await flush();
+    expect(document.body.textContent).toContain("General Data Protection Regulation");
+
+    await act(async () => {
+      rejectFirstRequest(new Error("late cold-start failure"));
+      await Promise.resolve();
+    });
+
+    expect(document.body.textContent).toContain("General Data Protection Regulation");
+    expect(document.body.textContent).not.toContain("late cold-start failure");
+  });
+
   it("queries the backend by canonical CELEX for a pasted EUR-Lex URL", async () => {
     // The backend anchors its CELEX regex at the start of the query, so a raw
     // URL never resolves to an exact match. Sending the derived CELEX makes the

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -108,6 +108,7 @@ export function SearchBox({
   const modalInputRef = useRef(null);
   const resultsRef = useRef(null);
   const lawSearchAbortRef = useRef(null);
+  const lawSearchRequestIdRef = useRef(0);
   const lawSearchDebounceRef = useRef(null);
   const definitionSearchAbortRef = useRef(null);
   const definitionSearchDebounceRef = useRef(null);
@@ -186,6 +187,8 @@ export function SearchBox({
 
   const runLawSearch = useCallback((nextQuery) => {
     const trimmedQuery = String(nextQuery || "").trim();
+    const requestId = lawSearchRequestIdRef.current + 1;
+    lawSearchRequestIdRef.current = requestId;
 
     if (lawSearchAbortRef.current) {
       lawSearchAbortRef.current.abort();
@@ -232,6 +235,7 @@ export function SearchBox({
 
     searchLawsApi(backendQuery, { limit: 12, signal: controller.signal })
       .then((payload) => {
+        if (lawSearchRequestIdRef.current !== requestId) return;
         const nextResults = Array.isArray(payload?.results)
           ? payload.results.map((item) => ({
             ...item,
@@ -245,7 +249,7 @@ export function SearchBox({
         setSelectedIndex(-1);
       })
       .catch((error) => {
-        if (error?.name === "AbortError") return;
+        if (error?.name === "AbortError" || lawSearchRequestIdRef.current !== requestId) return;
         console.error("Failed to search laws", error);
         // Even if the index lookup fails, a valid CELEX can still be opened.
         if (celexQuery) {
@@ -257,7 +261,7 @@ export function SearchBox({
         setLawSearchError(error?.message || t("search.apiUnavailable"));
       })
       .finally(() => {
-        if (lawSearchAbortRef.current === controller) {
+        if (lawSearchAbortRef.current === controller && lawSearchRequestIdRef.current === requestId) {
           lawSearchAbortRef.current = null;
           setIsLawSearchLoading(false);
         }
@@ -483,6 +487,7 @@ export function SearchBox({
   // the results for the newly selected mode.
   useEffect(() => {
     if (!isLawMode) {
+      lawSearchRequestIdRef.current += 1;
       lawSearchAbortRef.current?.abort();
       lawSearchAbortRef.current = null;
       if (lawSearchDebounceRef.current) {

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -57,6 +57,52 @@ export class FormexApiError extends Error {
   }
 }
 
+// Railway may return a transient gateway/service error while waking the API
+// process after an idle period. Keep the retry window bounded so ordinary API
+// failures still reach the caller promptly, while giving a cold start time to
+// become ready without requiring a page reload.
+const SEARCH_RETRY_DELAYS_MS = [1000, 2000, 4000];
+
+function isTransientSearchError(error) {
+  const status = Number(error?.status);
+  return (status >= 500 && status <= 599)
+    || error?.name === "TypeError"
+    || error?.name === "NetworkError";
+}
+
+function createAbortError() {
+  const error = new Error("The operation was aborted");
+  error.name = "AbortError";
+  return error;
+}
+
+function waitForSearchRetry(delayMs, signal) {
+  return new Promise((resolve, reject) => {
+    let timeoutId = null;
+
+    const cleanup = () => {
+      if (timeoutId !== null) clearTimeout(timeoutId);
+      signal?.removeEventListener("abort", handleAbort);
+    };
+
+    const handleAbort = () => {
+      cleanup();
+      reject(createAbortError());
+    };
+
+    if (signal?.aborted) {
+      handleAbort();
+      return;
+    }
+
+    timeoutId = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, delayMs);
+    signal?.addEventListener("abort", handleAbort, { once: true });
+  });
+}
+
 // ---------------------------------------------------------------------------
 // IndexedDB helpers
 // ---------------------------------------------------------------------------
@@ -965,13 +1011,30 @@ export async function searchLaws(query, { limit = 10, noRewrite = false, signal 
   }
 
   const url = `${API_BASE}/api/search?${params.toString()}`;
-  const res = await apiFetch(url, { signal });
+  let retryIndex = 0;
 
-  if (!res.ok) {
-    await readApiError(res, `Law search failed (${res.status})`);
+  while (true) {
+    try {
+      const res = await apiFetch(url, { signal });
+
+      if (!res.ok) {
+        await readApiError(res, `Law search failed (${res.status})`);
+      }
+
+      return await res.json();
+    } catch (error) {
+      if (
+        error?.name === "AbortError"
+        || !isTransientSearchError(error)
+        || retryIndex >= SEARCH_RETRY_DELAYS_MS.length
+      ) {
+        throw error;
+      }
+
+      await waitForSearchRetry(SEARCH_RETRY_DELAYS_MS[retryIndex], signal);
+      retryIndex += 1;
+    }
   }
-
-  return res.json();
 }
 
 export async function searchDefinitions(query, { limit = 10, filter = "", signal } = {}) {

--- a/src/utils/formexApi.search.test.js
+++ b/src/utils/formexApi.search.test.js
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+async function importFormexApi() {
+  vi.resetModules();
+  return import("./formexApi.js");
+}
+
+function jsonResponse(payload, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => payload,
+  };
+}
+
+describe("formexApi law search", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("retries a transient API failure while Railway wakes the server", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ code: "search_cache_unavailable" }, 503))
+      .mockResolvedValueOnce(jsonResponse({ results: [{ celex: "32016R0679" }] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = await importFormexApi();
+    const resultPromise = api.searchLaws("gdpr");
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await expect(resultPromise).resolves.toEqual({ results: [{ celex: "32016R0679" }] });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Retry transient 5xx and network failures while the Railway API wakes after inactivity.
- Prevent late failures from replacing results from a newer query.
- Add regression coverage for recovery and stale responses.

## Tests

- CI=true pnpm test:web
- CI=true pnpm exec eslint src/components/TopBar.jsx src/components/SearchBox.celex.test.jsx src/utils/formexApi.js src/utils/formexApi.search.test.js