### PR TITLE
Refine cold-start retry: skip terminal errors, widen backoff

### DIFF
--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -261,7 +261,7 @@ export function SearchBox({
         setLawSearchError(error?.message || t("search.apiUnavailable"));
       })
       .finally(() => {
-        if (lawSearchAbortRef.current === controller && lawSearchRequestIdRef.current === requestId) {
+        if (lawSearchAbortRef.current === controller) {
           lawSearchAbortRef.current = null;
           setIsLawSearchLoading(false);
         }

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -60,10 +60,18 @@ export class FormexApiError extends Error {
 // Railway may return a transient gateway/service error while waking the API
 // process after an idle period. Keep the retry window bounded so ordinary API
 // failures still reach the caller promptly, while giving a cold start time to
-// become ready without requiring a page reload.
-const SEARCH_RETRY_DELAYS_MS = [1000, 2000, 4000];
+// become ready without requiring a page reload (15s total: 1s + 2s + 4s + 8s).
+const SEARCH_RETRY_DELAYS_MS = [1000, 2000, 4000, 8000];
 
 function isTransientSearchError(error) {
+  // backend/server.js calls legalCacheStore.load() synchronously before
+  // app.listen(), so by the time a request is accepted the store is either
+  // ready or permanently failed. legal-cache-store.js's searchLaws() throws
+  // this code (via readApiError reading body.code) when isReady() is false —
+  // that's a terminal 503, not a cold-start signal, so retrying it only
+  // delays the final error by the whole backoff window.
+  if (error?.code === "search_cache_unavailable") return false;
+
   const status = Number(error?.status);
   return (status >= 500 && status <= 599)
     || error?.name === "TypeError"

--- a/src/utils/formexApi.search.test.js
+++ b/src/utils/formexApi.search.test.js
@@ -13,6 +13,16 @@ function jsonResponse(payload, status = 200) {
   };
 }
 
+// Railway edge gateway errors have no JSON body (they're HTML/plain-text
+// error pages), so json() rejects — the transient/cold-start case.
+function edgeErrorResponse(status) {
+  return {
+    ok: false,
+    status,
+    json: async () => { throw new SyntaxError("Unexpected token < in JSON"); },
+  };
+}
+
 describe("formexApi law search", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -26,7 +36,7 @@ describe("formexApi law search", () => {
 
   it("retries a transient API failure while Railway wakes the server", async () => {
     const fetchMock = vi.fn()
-      .mockResolvedValueOnce(jsonResponse({ code: "search_cache_unavailable" }, 503))
+      .mockResolvedValueOnce(edgeErrorResponse(502))
       .mockResolvedValueOnce(jsonResponse({ results: [{ celex: "32016R0679" }] }));
     vi.stubGlobal("fetch", fetchMock);
 
@@ -37,5 +47,38 @@ describe("formexApi law search", () => {
 
     await expect(resultPromise).resolves.toEqual({ results: [{ celex: "32016R0679" }] });
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry a terminal search_cache_unavailable error", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse({ code: "search_cache_unavailable" }, 503));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = await importFormexApi();
+    const resultPromise = api.searchLaws("gdpr");
+
+    await expect(resultPromise).rejects.toMatchObject({ code: "search_cache_unavailable" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries through the full backoff window (1s/2s/4s/8s) before succeeding", async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(edgeErrorResponse(502))
+      .mockResolvedValueOnce(edgeErrorResponse(502))
+      .mockResolvedValueOnce(edgeErrorResponse(502))
+      .mockResolvedValueOnce(edgeErrorResponse(502))
+      .mockResolvedValueOnce(jsonResponse({ results: [{ celex: "32016R0679" }] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const api = await importFormexApi();
+    const resultPromise = api.searchLaws("gdpr");
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(2000);
+    await vi.advanceTimersByTimeAsync(4000);
+    await vi.advanceTimersByTimeAsync(8000);
+
+    await expect(resultPromise).resolves.toEqual({ results: [{ celex: "32016R0679" }] });
+    expect(fetchMock).toHaveBeenCalledTimes(5);
   });
 });


### PR DESCRIPTION
Review follow-ups on #155. Targets that PR's branch, so this diff is only the fixes.

## Changes

- **Don't retry `search_cache_unavailable`.** `backend/server.js:83` calls `legalCacheStore.load()` synchronously before `app.listen()` (:328), so once a request is accepted the store is either ready or permanently failed. A 503 carrying that code is terminal, never a warming-up state — retrying it only delayed the final error by the whole backoff window. Genuine cold-start signals (edge 502/503 with no such code, fetch-level `TypeError`) still retry.
- **Widen the backoff** from `[1000, 2000, 4000]` (7s) to `[1000, 2000, 4000, 8000]` (15s). A Railway container wake commonly takes 10–30s, so the previous window could expire while the edge was still returning 502.
- **Drop the redundant request-id check** from the search `.finally()` guard in `TopBar.jsx`. The abort-ref identity check already covers every reachable supersession case, and the extra clause left a stale aborted controller in `lawSearchAbortRef` on the short-query (<2 chars) path. The `.then()`/`.catch()` request-id guards from #155 are untouched — they're correct and regression-tested.

## Tests

- `src/utils/formexApi.search.test.js`: the transient-retry case now uses a bodiless edge 502 (the real cold-start shape) instead of a `search_cache_unavailable` body, which would contradict the new semantics. Added coverage for the terminal 503 (one fetch, rejects with the code) and for the full four-step backoff (five fetches).
- `CI=true npx vitest run` → 37 files, 432 tests passed.
- `CI=true npx eslint src/components/TopBar.jsx src/utils/formexApi.js src/utils/formexApi.search.test.js` → clean.

## Not addressed

Cold starts equally break `searchDefinitions` and the `/parsed` law fetch — a user landing directly on a law URL still fails hard. Left out of scope here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MRBCD9o1xxUF28n3acxRgt)_