### PR TITLE
Prevent zero-content parses from rendering as laws

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -6,7 +6,7 @@ const { JsonLegalCacheStore, DEFAULT_SEARCH_CACHE_PATH } = require('./search/sea
 const { CitationGraphStore, DEFAULT_CITATION_GRAPH_PATH } = require('./search/citation-graph-store');
 const { registerApiRoutes } = require('./routes/api-routes');
 const { registerMcpEndpoint } = require('./mcp/mcp-http');
-const { createParsedLawResolver } = require('./shared/parsed-law-service');
+const { createParsedLawResolver, hasParsedLawContent } = require('./shared/parsed-law-service');
 const { createFmxService } = require('./shared/fmx-service');
 const { fetchEurlexHtmlLaw, parseEurlexHtmlToCombined, closeSharedPlaywrightBrowser } = require('./shared/eurlex-html-parser');
 const { createHtmlCacheService } = require('./shared/html-cache-service');
@@ -120,18 +120,6 @@ const CELEX_NAMES = {
   '32022R0868': 'DGA',
   '32023R2854': 'DA'
 };
-
-function hasParsedLawContent(parsed) {
-  return Boolean(
-    parsed
-    && (
-      parsed.articles?.length
-      || parsed.recitals?.length
-      || parsed.annexes?.length
-      || parsed.definitions?.length
-    )
-  );
-}
 
 // fetchEurlexHtmlLaw always fetches the English EUR-Lex HTML page regardless of the
 // requested language (see shared/eurlex-html-parser.js). Cache lookups/writes must key

--- a/backend/shared/parsed-law-service.js
+++ b/backend/shared/parsed-law-service.js
@@ -61,6 +61,7 @@ function createParsedLawResolver({ prepareLawPayload, fetchAndParseHtmlLaw, CELE
       source,
       ...parsed,
     };
+    result.hasContent = hasParsedLawContent(parsed);
 
     cacheSet(parsedCache, cacheKey, result, PARSED_LAW_CACHE_MS, MAX_PARSED_CACHE_ENTRIES);
     return result;
@@ -69,7 +70,20 @@ function createParsedLawResolver({ prepareLawPayload, fetchAndParseHtmlLaw, CELE
   return resolveParsedLaw;
 }
 
+function hasParsedLawContent(parsed) {
+  return Boolean(
+    parsed
+    && (
+      parsed.articles?.length
+      || parsed.recitals?.length
+      || parsed.annexes?.length
+      || parsed.definitions?.length
+    )
+  );
+}
+
 module.exports = {
   createParsedLawResolver,
+  hasParsedLawContent,
   PARSED_LAW_CACHE_MS,
 };

--- a/backend/shared/parsed-law-service.test.js
+++ b/backend/shared/parsed-law-service.test.js
@@ -18,6 +18,7 @@ test('resolveParsedLaw uses the HTML fallback path when skipFmxProbe is set and 
   assert.equal(first.source, 'eurlex-html');
   assert.equal(first.name, 'GDPR');
   assert.equal(first.format, 'combined-v1');
+  assert.equal(first.hasContent, false);
 
   const second = await resolveParsedLaw('32016R0679', 'ENG', { skipFmxProbe: true });
   assert.equal(second.title, first.title);
@@ -51,4 +52,25 @@ test('resolveParsedLaw propagates servedLang from the HTML fallback without over
   const result = await resolveParsedLaw('32016R0679', 'FRA', { skipFmxProbe: true });
   assert.equal(result.lang, 'FRA', 'top-level lang should stay the requested language for routing/URL state');
   assert.equal(result.servedLang, 'ENG', 'servedLang should surface the language actually served');
+});
+
+test('resolveParsedLaw stamps hasContent from parsed collections after spreading the parser result', async () => {
+  const resolveParsedLaw = createParsedLawResolver({
+    prepareLawPayload: async () => { throw new Error('prepareLawPayload should not be called'); },
+    fetchAndParseHtmlLaw: async (celex) => ({
+      title: `Law ${celex}`,
+      articles: celex === 'empty' ? [] : [{}],
+      recitals: [],
+      annexes: [],
+      definitions: [],
+      crossReferences: {},
+      hasContent: true,
+    }),
+  });
+
+  const empty = await resolveParsedLaw('empty', 'ENG', { skipFmxProbe: true });
+  const populated = await resolveParsedLaw('populated', 'ENG', { skipFmxProbe: true });
+
+  assert.equal(empty.hasContent, false);
+  assert.equal(populated.hasContent, true);
 });

--- a/src/components/LawViewer.jsx
+++ b/src/components/LawViewer.jsx
@@ -37,6 +37,7 @@ import { useLawViewerPrint } from "../hooks/law-viewer/useLawViewerPrint.js";
 import { useDefinitionComparison } from "../hooks/law-viewer/useDefinitionComparison.js";
 import { EU_LANGUAGES } from "../utils/formexApi.js";
 import { getCanonicalLawRoute } from "../utils/lawRouting.js";
+import { getEmptyContentDetails } from "../utils/law-viewer/errors.js";
 import { buildChapterEyebrow } from "../utils/law-viewer/tocFormat.js";
 import { LawViewerLoadingState } from "./law-viewer/LawViewerLoadingState.jsx";
 import { LawViewerErrorState } from "./law-viewer/LawViewerErrorState.jsx";
@@ -362,6 +363,12 @@ export function LawViewer() {
                   loadError={activeLoadError}
                   externalFallbackUrl={derived.externalFallbackUrl}
                   retryLoad={source.loadError ? source.retryLoad : primaryDocument.reload}
+                  t={t}
+                />
+              ) : !activeLoadError && !derived.hasLoadedContent ? (
+                <LawViewerErrorState
+                  loadError={getEmptyContentDetails(t)}
+                  externalFallbackUrl={derived.externalFallbackUrl}
                   t={t}
                 />
               ) : selection.selected.kind === "overview" ? (

--- a/src/components/law-viewer/LawViewerErrorState.jsx
+++ b/src/components/law-viewer/LawViewerErrorState.jsx
@@ -35,15 +35,17 @@ export function LawViewerErrorState({ loadError, externalFallbackUrl, retryLoad,
               {t("common.openOnEurlex")}
             </Button>
           ) : null}
-          <Button
-            type="button"
-            variant="outline"
-            className={tone === "notice" ? "border-sky-200 bg-white text-sky-900 hover:bg-sky-100 dark:border-sky-800 dark:bg-sky-950/10 dark:text-sky-100 dark:hover:bg-sky-900/30" : ""}
-            onClick={retryLoad}
-          >
-            <RefreshCw size={16} />
-            {t("common.reloadPage")}
-          </Button>
+          {retryLoad ? (
+            <Button
+              type="button"
+              variant="outline"
+              className={tone === "notice" ? "border-sky-200 bg-white text-sky-900 hover:bg-sky-100 dark:border-sky-800 dark:bg-sky-950/10 dark:text-sky-100 dark:hover:bg-sky-900/30" : ""}
+              onClick={retryLoad}
+            >
+              <RefreshCw size={16} />
+              {t("common.reloadPage")}
+            </Button>
+          ) : null}
         </div>
       </div>
     </div>

--- a/src/hooks/law-viewer/useLawViewerDerivedState.js
+++ b/src/hooks/law-viewer/useLawViewerDerivedState.js
@@ -20,6 +20,7 @@ export function useLawViewerDerivedState({
   const hasLoadedContent = primaryDocument.data.articles.length > 0
     || primaryDocument.data.recitals.length > 0
     || primaryDocument.data.annexes.length > 0;
+  // Backend content also counts definitions; keep the reader predicate unchanged so load errors remain visible.
   const hasCelex = !!source.effectiveCelex;
   const isSideBySide = !isLegacyHtmlFallback && !!preferences.secondaryLang && !!source.effectiveCelex;
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -324,6 +324,8 @@
   "lawViewer": {
     "notAvailableTitle": "This law is not available here yet",
     "notAvailableMessage": "We couldn't find the structured text version we use to display this law in LegalViz. The law itself may still be available on EUR-Lex.",
+    "emptyContentTitle": "This law has no readable content here",
+    "emptyContentMessage": "EUR-Lex did not provide machine-readable text for this law, so LegalViz cannot display it. You can still open the law on EUR-Lex.",
     "lawLoadFailed": "Law could not be loaded",
     "lawLoadServiceFailed": "The law could not be loaded from the Formex service.",
     "referenceResolveFailed": "This law reference could not be resolved automatically.",

--- a/src/utils/formexApi.cacheEnvelopes.test.js
+++ b/src/utils/formexApi.cacheEnvelopes.test.js
@@ -40,6 +40,14 @@ const FMX_XML = `<?xml version="1.0" encoding="UTF-8"?>
   </ACT>
 </COMBINED.FMX>`;
 
+const EMPTY_FMX_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<COMBINED.FMX>
+  <ACT>
+    <TITLE><TI><P>Empty Regulation</P></TI></TITLE>
+    <ENACTING.TERMS></ENACTING.TERMS>
+  </ACT>
+</COMBINED.FMX>`;
+
 // What a captive portal or misconfigured proxy answers 200 with.
 const HTML_ERROR_PAGE = "<!DOCTYPE html><html><body>Sign in to continue</body></html>";
 
@@ -136,11 +144,22 @@ describe("parsed-law envelope (PARSER_VERSION)", () => {
     await seedCache(CACHE_KEY, {
       format: "combined-v1",
       parserVersion: PARSER_VERSION,
-      payload: { title: "Cached title", articles: [], recitals: [] },
+      payload: { title: "Cached title", articles: [{}], recitals: [] },
     });
 
     const result = await getCachedLawPayload(CELEX, "EN");
     expect(result.payload.title).toBe("Cached title");
+  });
+
+  it("does not serve a current zero-content envelope", async () => {
+    const { getCachedLawPayload } = await importFormexApi();
+    await seedCache(CACHE_KEY, {
+      format: "combined-v1",
+      parserVersion: PARSER_VERSION,
+      payload: { title: "Empty cached title", articles: [], recitals: [], annexes: [] },
+    });
+
+    expect(await getCachedLawPayload(CELEX, "EN")).toBeNull();
   });
 
   it("re-parses a stale envelope from its raw XML and re-stamps the cache", async () => {
@@ -148,7 +167,7 @@ describe("parsed-law envelope (PARSER_VERSION)", () => {
     await seedCache(CACHE_KEY, {
       format: "combined-v1",
       parserVersion: PARSER_VERSION - 1,
-      payload: { title: "Parsed by an older version", articles: [], recitals: [] },
+      payload: { title: "Parsed by an older version", articles: [{}], recitals: [] },
       rawXml: FMX_XML,
     });
 
@@ -197,6 +216,14 @@ describe("parsed-law envelope (PARSER_VERSION)", () => {
     expect(persisted.rawXml).toBe(FMX_XML);
   });
 
+  it("does not upgrade a legacy raw-XML cache entry that parses to zero content", async () => {
+    const { getCachedLawPayload } = await importFormexApi();
+    await seedCache(CACHE_KEY, EMPTY_FMX_XML);
+
+    expect(await getCachedLawPayload(CELEX, "EN")).toBeNull();
+    expect(await readCache(CACHE_KEY)).toBe(EMPTY_FMX_XML);
+  });
+
   it("ignores a poisoned raw entry that is not a Formex document", async () => {
     const { getCachedFormex, getCachedLawPayload, hasCachedFormex } = await importFormexApi();
     await seedCache(CACHE_KEY, HTML_ERROR_PAGE);
@@ -210,13 +237,32 @@ describe("parsed-law envelope (PARSER_VERSION)", () => {
     // A /parsed response from another deploy must not be labelled "current":
     // with no rawXml it could never self-heal.
     const { cacheParsedLaw, getCachedLawPayload } = await importFormexApi();
-    cacheParsedLaw(CELEX, "EN", { title: "From another deploy", parserVersion: PARSER_VERSION + 7 }, null);
+    cacheParsedLaw(CELEX, "EN", { title: "From another deploy", articles: [{}], parserVersion: PARSER_VERSION + 7 }, null);
 
     await vi.waitFor(async () => {
       expect(await readCache(CACHE_KEY)).not.toBeNull();
     });
     expect((await readCache(CACHE_KEY)).parserVersion).toBe(PARSER_VERSION + 7);
     expect(await getCachedLawPayload(CELEX, "EN")).toBeNull();
+  });
+
+  it("does not cache a zero-content payload from the local parser", async () => {
+    const { cacheParsedLaw } = await importFormexApi();
+    cacheParsedLaw(CELEX, "EN", { title: "Empty law", articles: [], recitals: [], annexes: [] }, null);
+
+    expect(await readCache(CACHE_KEY)).toBeNull();
+  });
+});
+
+describe("parsed-law fetch persistence", () => {
+  it("returns but does not persist a zero-content response or add it to the library", async () => {
+    const emptyPayload = { title: "Empty law", articles: [], recitals: [], annexes: [] };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(emptyPayload)));
+
+    const { fetchParsedLaw, getLawMeta } = await importFormexApi();
+    await expect(fetchParsedLaw(CELEX, "EN")).resolves.toEqual(emptyPayload);
+    expect(await readCache(CACHE_KEY)).toBeNull();
+    expect(await getLawMeta(CELEX)).toBeNull();
   });
 });
 

--- a/src/utils/formexApi.cacheEnvelopes.test.js
+++ b/src/utils/formexApi.cacheEnvelopes.test.js
@@ -283,6 +283,15 @@ describe("law-text fetch body validation", () => {
     expect(await fetchFormex(CELEX, "EN")).toBe(FMX_XML);
     expect(await readCache(CACHE_KEY)).toBe(FMX_XML);
   });
+
+  it("returns but does not cache or add to the library a well-formed Formex body with zero content", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(textResponse(EMPTY_FMX_XML)));
+
+    const { fetchFormex, getLawMeta } = await importFormexApi();
+    expect(await fetchFormex(CELEX, "EN")).toBe(EMPTY_FMX_XML);
+    expect(await readCache(CACHE_KEY)).toBeNull();
+    expect(await getLawMeta(CELEX)).toBeNull();
+  });
 });
 
 describe("API JSON envelope (API_JSON_CACHE_VERSION)", () => {

--- a/src/utils/formexApi.cacheHygiene.test.js
+++ b/src/utils/formexApi.cacheHygiene.test.js
@@ -161,7 +161,7 @@ describe("formexApi cache hygiene", () => {
 
   describe("fetchParsedLaw parser-version stamping", () => {
     it("stamps the envelope with the backend's reported parserVersion so old-shape payloads read as stale", async () => {
-      const stalePayload = { title: "GDPR", articles: [], parserVersion: PARSER_VERSION - 1 };
+      const stalePayload = { title: "GDPR", articles: [{}], parserVersion: PARSER_VERSION - 1 };
       const fetchMock = vi.fn(async () => jsonResponse(stalePayload));
       vi.stubGlobal("fetch", fetchMock);
 
@@ -183,7 +183,7 @@ describe("formexApi cache hygiene", () => {
     });
 
     it("serves the cached payload without refetching when the backend parserVersion is current", async () => {
-      const currentPayload = { title: "GDPR", articles: [], parserVersion: PARSER_VERSION };
+      const currentPayload = { title: "GDPR", articles: [{}], parserVersion: PARSER_VERSION };
       const fetchMock = vi.fn(async () => jsonResponse(currentPayload));
       vi.stubGlobal("fetch", fetchMock);
 

--- a/src/utils/formexApi.cacheHygiene.test.js
+++ b/src/utils/formexApi.cacheHygiene.test.js
@@ -3,9 +3,11 @@ import { IDBFactory } from "fake-indexeddb";
 import { PARSER_VERSION } from "./fmxParser.js";
 
 // Minimal body that satisfies isFmxDocument (contains "<ACT", "formex",
-// "<ENACTING.TERMS") without needing to be fully parseable in these tests —
-// the code paths under test never run parseFmxToCombined on it.
-const VALID_FMX = '<?xml version="1.0"?><ACT xmlns="http://formex.publications.europa.eu"><ENACTING.TERMS></ENACTING.TERMS></ACT>';
+// "<ENACTING.TERMS") and parses to a non-empty law — fetchFormex parses the
+// body to check for content before caching it (see #153), so an empty
+// <ENACTING.TERMS> here would make it (correctly) refuse to cache this
+// fixture, which is not what these poisoned-cache/validation tests exercise.
+const VALID_FMX = '<?xml version="1.0"?><ACT xmlns="http://formex.publications.europa.eu"><ENACTING.TERMS><ARTICLE IDENTIFIER="001"><TI.ART>Article 1</TI.ART><ALINEA><P>Text.</P></ALINEA></ARTICLE></ENACTING.TERMS></ACT>';
 const HTML_ERROR_PAGE = "<html><head><title>502</title></head><body>Bad gateway</body></html>";
 const CACHE_KEY = "32016R0679_ENG";
 

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -722,14 +722,33 @@ export async function fetchFormex(celex, lang = "EN") {
       );
     }
 
-    // 4. Cache it
-    await cacheSet(cacheKey, xmlText);
-    await upsertLawMeta(celex, { cachedAt: Date.now() });
-    await pruneCacheIfNeeded(celex, PROTECTED_BUNDLED_CELEXES);
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(new CustomEvent("legalviz-formex-cache-updated", {
-        detail: { celex, lang: lang.toUpperCase() },
-      }));
+    // 4. Cache it — but only when it actually parses to a law with content.
+    // A response can be a well-formed Formex document with zero articles/
+    // recitals/annexes (see #148/#153: REACH has no as-adopted manifestation
+    // at all). Caching that raw XML would let it be served forever as a
+    // "cache hit" — this function's own cache-read check above only
+    // validates isFmxDocument, not content — and would add the law to the
+    // library via upsertLawMeta even though it can never be read. Skip
+    // persistence in that case; still return the XML so the caller renders
+    // the empty-content notice instead of a load error. On an unexpected
+    // parse failure here, cache as before rather than block on a check this
+    // function doesn't otherwise need to make.
+    let hasContent = true;
+    try {
+      hasContent = payloadHasContent(parseFmxToCombined(xmlText));
+    } catch {
+      // ignore — isFmxDocument already validated the shape above
+    }
+
+    if (hasContent) {
+      await cacheSet(cacheKey, xmlText);
+      await upsertLawMeta(celex, { cachedAt: Date.now() });
+      await pruneCacheIfNeeded(celex, PROTECTED_BUNDLED_CELEXES);
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("legalviz-formex-cache-updated", {
+          detail: { celex, lang: lang.toUpperCase() },
+        }));
+      }
     }
 
     return xmlText;

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -174,12 +174,19 @@ function hasKnownMissingFmx(celex, lang = "EN") {
   return KNOWN_MISSING_FMX.has(makeCacheKey(celex, lang));
 }
 
+function payloadHasContent(payload) {
+  return Boolean(payload && (
+    payload.articles?.length || payload.recitals?.length || payload.annexes?.length
+  ));
+}
+
 function isCombinedLawEnvelope(value) {
   return !!value
     && typeof value === "object"
     && value.format === "combined-v1"
     && typeof value.payload === "object"
-    && value.payload != null;
+    && value.payload != null
+    && payloadHasContent(value.payload);
 }
 
 function createCombinedLawEnvelope(payload, rawXml = null) {
@@ -753,6 +760,7 @@ export async function getCachedLawPayload(celex, lang = "EN") {
     console.log(`[FormexAPI] Upgrading raw XML cache to envelope: ${cacheKey}`);
     try {
       const payload = parseFmxToCombined(cached);
+      if (!payloadHasContent(payload)) return null;
       await cacheSet(cacheKey, createCombinedLawEnvelope(payload, cached));
       return createCombinedLawEnvelope(payload);
     } catch {
@@ -774,6 +782,7 @@ export async function getCachedLawPayload(celex, lang = "EN") {
       console.log(`[FormexAPI] Re-parsing stale cache (parser v${cached.parserVersion ?? "pre-versioning"} → v${PARSER_VERSION}): ${cacheKey}`);
       try {
         const payload = parseFmxToCombined(cached.rawXml);
+        if (!payloadHasContent(payload)) return null;
         const envelope = createCombinedLawEnvelope(payload, cached.rawXml);
         await cacheSet(cacheKey, envelope);
         return envelope;
@@ -795,6 +804,7 @@ export async function getCachedLawPayload(celex, lang = "EN") {
  * loads skip parsing and parser upgrades can re-parse from the stored XML.
  */
 export function cacheParsedLaw(celex, lang, payload, rawXml) {
+  if (!payloadHasContent(payload)) return;
   const cacheKey = makeCacheKey(celex, lang);
   // Fire-and-forget: callers don't await this, so failures must not become
   // unhandled promise rejections. Matches cacheSet's own silent-ignore policy.
@@ -1061,13 +1071,15 @@ export async function fetchParsedLaw(celex, lang = "EN") {
     }
 
     const payload = await res.json();
-    await cacheSet(cacheKey, createCombinedLawEnvelope(payload));
-    await upsertLawMeta(celex, { cachedAt: Date.now() });
-    await pruneCacheIfNeeded(celex, PROTECTED_BUNDLED_CELEXES);
-    if (typeof window !== "undefined") {
-      window.dispatchEvent(new CustomEvent("legalviz-formex-cache-updated", {
-        detail: { celex, lang: lang.toUpperCase() },
-      }));
+    if (payloadHasContent(payload)) {
+      await cacheSet(cacheKey, createCombinedLawEnvelope(payload));
+      await upsertLawMeta(celex, { cachedAt: Date.now() });
+      await pruneCacheIfNeeded(celex, PROTECTED_BUNDLED_CELEXES);
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new CustomEvent("legalviz-formex-cache-updated", {
+          detail: { celex, lang: lang.toUpperCase() },
+        }));
+      }
     }
 
     return payload;

--- a/src/utils/law-viewer/errors.js
+++ b/src/utils/law-viewer/errors.js
@@ -54,3 +54,13 @@ export function getLoadErrorDetails(error, t) {
     tone: "error",
   };
 }
+
+export function getEmptyContentDetails(t) {
+  return {
+    title: t("lawViewer.emptyContentTitle"),
+    message: t("lawViewer.emptyContentMessage"),
+    fallbackUrl: null,
+    status: null,
+    tone: "notice",
+  };
+}

--- a/src/utils/law-viewer/errors.test.js
+++ b/src/utils/law-viewer/errors.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { FormexApiError } from "../formexApi.js";
-import { getLoadErrorDetails, isMissingStructuredLawText } from "./errors.js";
+import { getEmptyContentDetails, getLoadErrorDetails, isMissingStructuredLawText } from "./errors.js";
 
 const t = (key) => key;
 
@@ -31,5 +31,17 @@ describe("getLoadErrorDetails", () => {
     const details = getLoadErrorDetails(new Error("boom"), t);
     expect(details.tone).toBe("error");
     expect(details.message).toContain("boom");
+  });
+});
+
+describe("getEmptyContentDetails", () => {
+  it("builds a notice without a retry or error status", () => {
+    expect(getEmptyContentDetails(t)).toEqual({
+      title: "lawViewer.emptyContentTitle",
+      message: "lawViewer.emptyContentMessage",
+      fallbackUrl: null,
+      status: null,
+      tone: "notice",
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Expose a shared backend `hasContent` flag for parsed laws.
- Render a notice with an EUR-Lex link when a parse has no readable content.
- Prevent zero-content parsed laws from entering IndexedDB or the law library.
- Add backend, frontend, and cache regression coverage.

## Verification

- `./node_modules/.bin/vitest run` — 36 files, 432 tests passed.
- `./node_modules/.bin/eslint .` — passed.
- `node --test backend/shared/parsed-law-service.test.js` — 3 tests passed.
- The full backend suite was attempted but remains environment-blocked by `Could not locate the bindings file` for `better-sqlite3`; no native `better_sqlite3.node` was built.

Addresses #153; consolidated fallback work remains deferred to PR 2.