### PR TITLE
Surface dataset build timestamps via /api/meta

### DIFF
--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -135,6 +135,23 @@ function registerApiRoutes(app, deps) {
     res.json({ status: 'ok', timestamp: new Date().toISOString() });
   });
 
+  // Surfaces the build timestamps the offline pipeline already stamps onto
+  // each dataset ("when was our dataset last updated") — read-only, no
+  // pipeline changes. Missing/unavailable sources report null rather than
+  // erroring, mirroring the other optional-artifact status endpoints.
+  app.get('/api/meta', rateLimitMiddleware, (req, res) => {
+    const searchStatus = legalCacheStore.getStatus();
+    const citationGraphStatus = citationGraphStore.getStatus();
+    res.json({
+      data: { generatedAt: searchStatus.generatedAt || null },
+      citationGraph: { generatedAt: citationGraphStatus.generatedAt || null },
+      fulltext: {
+        generatedAt: searchStatus.fulltext.generatedAt || null,
+        available: searchStatus.fulltext.available,
+      },
+    });
+  });
+
   app.get('/api/_stats', rateLimitMiddleware, (req, res) => {
     const token = process.env.ANALYTICS_TOKEN;
     if (!token) return res.status(404).json({ error: 'Not found' });

--- a/backend/routes/api-routes.test.js
+++ b/backend/routes/api-routes.test.js
@@ -97,6 +97,7 @@ function registerTestRoutes(overrides = {}) {
       isReady: () => true,
       getArticleCitations: (celex, article, pagination) => ({ celex, article, pagination, citingProvisions: [], citingJudgments: [], counts: { total: 0 } }),
       getActCitations: (celex) => ({ celex, byArticle: [], counts: { total: 0 } }),
+      getStatus: () => ({ ready: true, generatedAt: "2026-03-27T00:00:00.000Z" }),
     },
     findDownloadUrls: async () => ({ type: "xml", urls: [] }),
     findFmx4Uri: async () => "unused",
@@ -204,6 +205,48 @@ test("GET /api/resolve-reference returns cache-backed resolution payload", async
   assert.equal(res.statusCode, 200);
   assert.equal(res.payload.resolved.celex, "32015L2366");
   assert.equal(res.payload.resolved.source, "search-cache");
+});
+
+test("GET /api/meta surfaces the dataset build timestamps stamped by the offline builders", async () => {
+  const { app } = registerTestRoutes();
+  const handler = app.routes.get("/api/meta");
+  const res = createResponseRecorder();
+
+  await handler({}, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.payload, {
+    data: { generatedAt: "2026-03-26T00:00:00.000Z" },
+    citationGraph: { generatedAt: "2026-03-27T00:00:00.000Z" },
+    fulltext: { generatedAt: null, available: false },
+  });
+});
+
+test("GET /api/meta reports nulls without throwing when no data source is loaded", async () => {
+  const { app } = registerTestRoutes({
+    legalCacheStore: {
+      getStatus: () => ({
+        ready: false,
+        generatedAt: null,
+        fulltext: { available: false, generatedAt: null, reason: "not loaded" },
+      }),
+    },
+    citationGraphStore: {
+      isReady: () => false,
+      getStatus: () => ({ ready: false, generatedAt: null }),
+    },
+  });
+  const handler = app.routes.get("/api/meta");
+  const res = createResponseRecorder();
+
+  await handler({}, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.payload, {
+    data: { generatedAt: null },
+    citationGraph: { generatedAt: null },
+    fulltext: { generatedAt: null, available: false },
+  });
 });
 
 test('GET article cited-by passes validated pagination to the citation graph', async () => {

--- a/backend/search/legal-cache-store.js
+++ b/backend/search/legal-cache-store.js
@@ -547,6 +547,10 @@ class JsonLegalCacheStore {
     this.definitionsAvailable = false;
     this.citationCounts = new Map(options.citationCounts || []);
     this.source = null;
+    // Build timestamp of the loaded search cache ("when was our dataset last
+    // updated"), read from the SQLite `metadata` row / JSON `generatedAt`
+    // field written by the builders — never regenerated here.
+    this.datasetGeneratedAt = null;
     this.fulltextDatabase = null;
     this.fulltextSearchStatement = null;
     this.fulltextUnitSearchStatement = null;
@@ -554,7 +558,7 @@ class JsonLegalCacheStore {
     this.fulltextUnitSnippetStatement = null;
     this.fulltextAvailable = false;
     this.fulltextReason = null;
-    this.fulltextStats = { unitCount: 0, actCount: 0, version: null };
+    this.fulltextStats = { unitCount: 0, actCount: 0, version: null, generatedAt: null };
   }
 
   load() {
@@ -582,7 +586,7 @@ class JsonLegalCacheStore {
     this.fulltextUnitSnippetStatement = null;
     this.fulltextAvailable = false;
     this.fulltextReason = null;
-    this.fulltextStats = { unitCount: 0, actCount: 0, version: null };
+    this.fulltextStats = { unitCount: 0, actCount: 0, version: null, generatedAt: null };
     if (!this.fulltextPath || !fs.existsSync(this.fulltextPath)) {
       this.fulltextReason = `Full-text index not found at ${this.fulltextPath}`;
       return;
@@ -657,6 +661,7 @@ class JsonLegalCacheStore {
         unitCount: Number.parseInt(metadata.get("unit_count"), 10) || 0,
         actCount: Number.parseInt(metadata.get("act_count"), 10) || 0,
         version: fulltextVersion,
+        generatedAt: metadata.get("generated_at") || null,
       };
       this.fulltextDatabase = database;
       this.fulltextAvailable = true;
@@ -698,6 +703,7 @@ class JsonLegalCacheStore {
       version: this.fulltextStats.version,
       unitCount: this.fulltextStats.unitCount,
       actCount: this.fulltextStats.actCount,
+      generatedAt: this.fulltextAvailable ? this.fulltextStats.generatedAt : null,
       reason: this.fulltextAvailable ? null : this.fulltextReason,
     };
   }
@@ -773,6 +779,7 @@ class JsonLegalCacheStore {
     this.eurovocSearch = null;
     this.excerptMiniSearch = null;
     this.source = null;
+    this.datasetGeneratedAt = null;
   }
 
   failLoad(message) {
@@ -918,6 +925,9 @@ class JsonLegalCacheStore {
       this.definitionsAvailable = database.prepare(
         "SELECT value FROM metadata WHERE key = 'definitions_available'"
       ).get()?.value === "1";
+      this.datasetGeneratedAt = database.prepare(
+        "SELECT value FROM metadata WHERE key = 'generated_at'"
+      ).get()?.value || null;
       this.source = "sqlite";
       return true;
     } catch (error) {
@@ -952,6 +962,7 @@ class JsonLegalCacheStore {
         : [];
 
       this.payload = parsed;
+      this.datasetGeneratedAt = parsed.generatedAt || null;
       this.indexRecords(records, { includeExcerpt: true });
       try {
         const definitions = readOptionalJson(this.definitionsPath);
@@ -990,6 +1001,7 @@ class JsonLegalCacheStore {
       ready: this.isReady(),
       cachePath: this.cachePath,
       loadedAt: this.loadedAt,
+      generatedAt: this.datasetGeneratedAt,
       count: this.records.length,
       error: this.loadError,
       fulltext: this.getFulltextStatus(),

--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -1,5 +1,5 @@
 import { useNavigate } from "react-router-dom";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { motion as Motion } from "framer-motion";
 import { Github } from "lucide-react";
 import { TopBar, SearchBox } from "./TopBar.jsx";
@@ -13,6 +13,8 @@ import { useLandingLibrary } from "../hooks/useLandingLibrary.js";
 import { useLandingSearchIndex } from "../hooks/useLandingSearchIndex.js";
 import { buildImportedLawCandidate, getCanonicalLawRoute } from "../utils/lawRouting.js";
 import { saveLawMeta } from "../utils/library.js";
+import { fetchDatasetMeta } from "../utils/formexApi.js";
+import { formatMetaDate } from "../utils/formatMetaDate.js";
 
 function inferOfficialReferenceFromCelex(celex) {
   const match = String(celex || "").match(/^3(\d{4})([RLD])0*(\d{1,4})(?:\(\d+\))?$/);
@@ -62,6 +64,22 @@ export function Landing({ forcedLocale = null }) {
     libraryVersion,
   });
   const activeLocale = forcedLocale || locale;
+
+  // Best-effort footer note: fetched lazily after mount, never blocks
+  // rendering, and stays hidden on failure or when no build date is
+  // available — no error UI for what's just a nice-to-have footnote.
+  const [datasetGeneratedAt, setDatasetGeneratedAt] = useState(null);
+  useEffect(() => {
+    let cancelled = false;
+    fetchDatasetMeta()
+      .then((meta) => {
+        if (!cancelled) setDatasetGeneratedAt(meta?.data?.generatedAt || null);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const handleOpenLaw = useCallback(async (law) => {
     // Best-effort bookkeeping: never let a stuck IndexedDB block navigation.
@@ -225,6 +243,11 @@ export function Landing({ forcedLocale = null }) {
             <Github className="h-4 w-4" />
             <span>{t("landing.sourceCode")}</span>
           </a>
+          {datasetGeneratedAt && (
+            <p className="text-gray-400 dark:text-gray-600">
+              {t("landing.datasetUpdated", { date: formatMetaDate(datasetGeneratedAt, activeLocale) })}
+            </p>
+          )}
         </Motion.div>
       </div>
     </div>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -192,6 +192,7 @@
     "never": "Never",
     "sourceCode": "Source code and support on GitHub",
     "builtBy": "Built by Konrad Kollnig at the Law & Tech Lab, Maastricht University.",
+    "datasetUpdated": "Dataset last updated: {date}",
     "addLawDialogEyebrow": "Add a law",
     "addLawCta": "Add another law to your library",
     "addLawShort": "Add another law",

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -912,6 +912,21 @@ export async function resolveEurlexUrl(sourceUrl, lang = "EN") {
   return res.json();
 }
 
+/**
+ * Fetches the build timestamps the offline pipeline stamps onto each dataset
+ * ("when was our dataset last updated"). Not cached — it's a single cheap
+ * lookup, and staleness would defeat the point. Callers should fetch lazily
+ * and tolerate failure silently (see Landing.jsx): this is a nice-to-have
+ * footnote, never something that should block or error the UI.
+ */
+export async function fetchDatasetMeta() {
+  const res = await apiFetch(`${API_BASE}/api/meta`);
+  if (!res.ok) {
+    await readApiError(res, `Dataset metadata fetch failed (${res.status})`);
+  }
+  return res.json();
+}
+
 export async function fetchAmendments(celex) {
   return getInFlightRequest(`amendments:${celex}`, () => fetchJsonWithCache({
     cacheKey: `${celex}_amendments`,


### PR DESCRIPTION
## Summary
- Adds `GET /api/meta`, returning `{ data: { generatedAt }, citationGraph: { generatedAt }, fulltext: { generatedAt, available } }` by reading the `generated_at` / `citation_graph_generated_at` values already stamped into the runtime `metadata` table (and `fulltext_metadata.generated_at` for the optional full-text index) — no pipeline or cache-shape changes, purely a read of existing data.
- `backend/search/legal-cache-store.js`: exposes the search-cache build timestamp (`datasetGeneratedAt`, sourced from SQLite `metadata` or the JSON payload's top-level `generatedAt`) and the full-text index's own `generated_at`, both non-fatal — missing values are `null`, mirroring the existing `fulltextAvailable` pattern. The citation graph timestamp is served straight from `CitationGraphStore#getStatus()`, which already tracked it.
- Frontend: `src/utils/formexApi.js` gets a small `fetchDatasetMeta()` client (uncached, since staleness would defeat the point). `src/components/Landing.jsx` fetches it lazily on mount and shows "Dataset last updated: <date>" in the existing footer block, only once a date is available, formatted with the existing `formatMetaDate` helper — no error UI on failure.

## Test plan
- [x] `cd backend && node --test routes/*.test.js search/*.test.js shared/*.test.js bin/*.test.js mcp/*.test.js` — 431 passed, 2 skipped
- [x] `npm run lint` — clean
- [x] `npx vitest run` — 443 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)