### PR TITLE
Fix French elision truncation and read Swedish DLIST definitions

### DIFF
--- a/backend/shared/formex-parser/fmxParser.mjs
+++ b/backend/shared/formex-parser/fmxParser.mjs
@@ -33,7 +33,7 @@ import {
  * Bump this whenever the parser output changes (new fields, bug fixes, etc.)
  * so that cached parsed results are automatically re-parsed from raw XML.
  */
-export const PARSER_VERSION = 21;
+export const PARSER_VERSION = 22;
 
 // ---------------------------------------------------------------------------
 // FMX → HTML conversion helpers
@@ -1900,17 +1900,26 @@ export function parseFmxToCombined(xmlText) {
         if (fbMatch?.[1]) {
           const term = fbMatch[1].trim();
           const definition = text.slice(fbMatch[0].length).trim();
-          if (term && definition) {
-            // For every language except LT and SV, fallbackDefRegex also
-            // requires quote characters around the term. LT and SV are the
-            // two languages whose Formex text never carries QUOT.START/
-            // QUOT.END around the defined term at all (see
-            // buildFallbackDefRegex), so their fallback matches on a bare
-            // dash/colon — a shape common enough in ordinary operative prose
-            // ("0,09 % – ...", "70 % : ...") that it clears the corroboration
-            // bar below on nearly any article. Flag those matches so an
-            // untitled article can discount them (Finding 1).
-            const quoted = lang.code !== "LT" && lang.code !== "SV";
+          // For every language except LT and SV, fallbackDefRegex also
+          // requires quote characters around the term. LT and SV are the
+          // two languages whose Formex text never carries QUOT.START/
+          // QUOT.END around the defined term at all (see
+          // buildFallbackDefRegex), so their fallback matches on a bare
+          // dash/colon — a shape common enough in ordinary operative prose
+          // ("0,09 % – ...", "70 % : ...") that it clears the corroboration
+          // bar below on nearly any article. Flag those matches so an
+          // untitled article can discount them (Finding 1).
+          const quoted = lang.code !== "LT" && lang.code !== "SV";
+          // A quote-delimited term may be followed by nothing but a comma
+          // or colon before the definition continues in a nested list under
+          // a sibling <P> ("«État membre d’origine»," (a) … (b) …) — the
+          // same empty-group-2 shape buildMeansRegex documents as expected
+          // ("'night worker' means:" followed by lettered sub-points), so an
+          // empty definition is accepted there too. LT/SV's bare colon/dash
+          // fallback has no such precedent and is already the most
+          // over-match-prone pattern here (Finding 1), so it still requires
+          // actual trailing definition text.
+          if (term && (definition || quoted)) {
             matched = makeDefinition(term, definition, quoted);
           }
         }

--- a/backend/shared/formex-parser/fmxParser.mjs
+++ b/backend/shared/formex-parser/fmxParser.mjs
@@ -1833,9 +1833,33 @@ export function parseFmxToCombined(xmlText) {
       }
     }
 
+    // Some languages (Swedish CRR, Regulation (EU) No 575/2013) encode each
+    // definition structurally instead of with quote marks or a repeated
+    // verb: <DLIST><DLIST.ITEM><PREFIX>(1)</PREFIX><TERM>kreditinstitut</TERM>
+    // <DEFINITION>…</DEFINITION></DLIST.ITEM>…</DLIST>. TERM and DEFINITION
+    // name their role explicitly, so no regex is needed — and unlike a regex
+    // match this can never be ambiguous, so `directTerm` entries are treated
+    // as unquoted-but-unambiguous below (see the corroboration comment near
+    // the bottom of this file).
+    for (const dlistItem of artEl.querySelectorAll("DLIST\\.ITEM")) {
+      if (dlistItem.closest("QUOT\\.S")) continue;
+      const termEl = dlistItem.querySelector(":scope > TERM");
+      const defEl = dlistItem.querySelector(":scope > DEFINITION");
+      if (!termEl || !defEl) continue;
+      const prefixEl = dlistItem.querySelector(":scope > PREFIX");
+      entries.push({ textEl: defEl, pointEl: prefixEl, group: null, directTerm: allText(termEl) });
+    }
+
     for (const parag of artEl.querySelectorAll("PARAG")) {
       if (parag.closest("QUOT\\.S")) continue;
-      if (parag.querySelector("ITEM")) continue;
+      // A DLIST is walked structurally above; flattening its ALINEA/PARAG
+      // through pushBody() as prose (below) would fold every DLIST.ITEM's
+      // term and definition into one garbled blob keyed off the intro
+      // sentence's own colon — exactly the shape that gave Swedish CRR
+      // ~31 junk definitions before the untitled-article guard, and here
+      // would also swallow the titled Article 4 that legitimately uses this
+      // structure.
+      if (parag.querySelector("ITEM") || parag.querySelector("DLIST\\.ITEM")) continue;
       pushBody(parag.querySelector("ALINEA") || parag, parag.querySelector("NO\\.PARAG"));
     }
 
@@ -1843,7 +1867,7 @@ export function parseFmxToCombined(xmlText) {
     // straight off the ARTICLE (VAT Article 48 again).
     for (const child of artEl.children) {
       if (child.tagName !== "ALINEA") continue;
-      if (child.querySelector("ITEM")) continue;
+      if (child.querySelector("ITEM") || child.querySelector("DLIST\\.ITEM")) continue;
       pushBody(child, null);
     }
 
@@ -1864,7 +1888,7 @@ export function parseFmxToCombined(xmlText) {
     // folded into its definition text instead of being dropped.
     let openContinuation = null;
 
-    for (const { textEl, pointEl, group } of definitionEntries(artEl)) {
+    for (const { textEl, pointEl, group, directTerm } of definitionEntries(artEl)) {
       const text = allText(textEl);
       if (!text) continue;
       const txtEl = textEl;
@@ -1881,6 +1905,22 @@ export function parseFmxToCombined(xmlText) {
         ],
       });
 
+      let matched = null;
+
+      if (directTerm) {
+        // Structural DLIST.ITEM entry (see definitionEntries): TERM and
+        // DEFINITION already name the term and its text, so no pattern
+        // match is needed. Unambiguous by construction — treat it like a
+        // quoted match for the untitled-article corroboration bar below.
+        const term = directTerm.trim();
+        if (term) matched = makeDefinition(term, text, true);
+        if (matched) {
+          found.push(matched);
+          openContinuation = null;
+          continue;
+        }
+      }
+
       // Verb-first languages (GA, IT, ES, PT): meansVerb 'term' definition.
       // Term-first languages: 'term' meansVerb definition.
       // Either way, try the configured meansVerb first, then fall back to the
@@ -1889,7 +1929,6 @@ export function parseFmxToCombined(xmlText) {
       // The verb-first languages need that fallback too: FR/IT/ES/PT state
       // the verb once ("on entend par:") and then list «terme», définition.
       const termMatch = text.match(meansRegex);
-      let matched = null;
       if (termMatch?.[1]) {
         const term = termMatch[1].trim();
         const definition = text.slice(termMatch[0].length).trim();

--- a/backend/shared/formex-parser/fmxParser.test.js
+++ b/backend/shared/formex-parser/fmxParser.test.js
@@ -1739,3 +1739,116 @@ describe("definition extraction: elision apostrophes in quote-delimited terms", 
     expect(result.definitions).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Structural (DLIST) definitions and an HT-italic over-match guard
+// ---------------------------------------------------------------------------
+
+describe("definition extraction: structural DLIST entries", () => {
+  function actWithArticlesLang(langCode, articlesXml) {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<COMBINED.FMX>
+  <ACT>
+    <BIB.INSTANCE><LG.DOC>${langCode}</LG.DOC></BIB.INSTANCE>
+    <TITLE><TI><P>Regulation (EU) No 575/2013</P></TI></TITLE>
+    <ENACTING.TERMS>${articlesXml}</ENACTING.TERMS>
+  </ACT>
+</COMBINED.FMX>`;
+  }
+
+  it("reads DLIST.ITEM definitions structurally, using PREFIX as the source point", () => {
+    // Swedish CRR (32013R0575 SWE) Article 4 encodes each definition as
+    // DLIST > DLIST.ITEM > PREFIX/TERM/DEFINITION instead of the
+    // LIST/ITEM/NP/TXT shape definitionEntries() otherwise scans. No regex
+    // is needed: TERM and DEFINITION already name their role.
+    const result = parseFmxToCombined(actWithArticlesLang("SV", `
+      <ARTICLE IDENTIFIER="004">
+        <TI.ART>Artikel 4</TI.ART>
+        <STI.ART>Definitioner</STI.ART>
+        <PARAG IDENTIFIER="004.001"><NO.PARAG>1.</NO.PARAG>
+          <ALINEA>
+            <P>I denna förordning gäller följande definitioner:</P>
+            <DLIST SEPARATOR=":">
+              <DLIST.ITEM><PREFIX>(1)</PREFIX><TERM>kreditinstitut</TERM><DEFINITION>ett företag som tar emot insättningar.</DEFINITION></DLIST.ITEM>
+              <DLIST.ITEM><PREFIX>(2)</PREFIX><TERM>institut</TERM><DEFINITION>ett kreditinstitut eller ett värdepappersföretag.</DEFINITION></DLIST.ITEM>
+            </DLIST>
+          </ALINEA>
+        </PARAG>
+      </ARTICLE>`));
+
+    expect(result.definitions.map((d) => d.term)).toEqual(["kreditinstitut", "institut"]);
+    expect(result.definitions[0]).toMatchObject({
+      definition: "ett företag som tar emot insättningar.",
+      sourcePoint: "(1)",
+    });
+  });
+
+  it("does not flatten a DLIST into one blob via the PARAG/ALINEA prose fallback", () => {
+    // Before DLIST.ITEM was read structurally, definitionEntries() found no
+    // <ITEM> in this ALINEA and pushed the whole body — intro sentence plus
+    // every DLIST.ITEM concatenated — as one prose entry, matched only up
+    // to the intro's own colon by SV's quote-less fallback (the "~4
+    // junk-ish entries" this task started from).
+    const result = parseFmxToCombined(actWithArticlesLang("SV", `
+      <ARTICLE IDENTIFIER="005">
+        <TI.ART>Artikel 5</TI.ART>
+        <STI.ART>Särskilda definitioner</STI.ART>
+        <ALINEA>
+          <P>Vid tillämpningen av del tre gäller följande definitioner:</P>
+          <DLIST SEPARATOR=":">
+            <DLIST.ITEM><PREFIX>(1)</PREFIX><TERM>exponering</TERM><DEFINITION>en tillgång eller post utanför balansräkningen.</DEFINITION></DLIST.ITEM>
+          </DLIST>
+        </ALINEA>
+      </ARTICLE>`));
+
+    expect(result.definitions).toEqual([
+      expect.objectContaining({ term: "exponering", sourceArticle: "5" }),
+    ]);
+  });
+
+  it("does not adopt a DLIST.ITEM quoted from the act being amended", () => {
+    const result = parseFmxToCombined(actWithArticlesLang("SV", `
+      <ARTICLE IDENTIFIER="500">
+        <TI.ART>Artikel 500</TI.ART>
+        <STI.ART>Ändring av förordning (EU) nr 648/2012</STI.ART>
+        <ALINEA>
+          <P>Förordning (EU) nr 648/2012 ska ändras på följande sätt:</P>
+          <P><QUOT.S LEVEL="1">
+            <DLIST SEPARATOR=":">
+              <DLIST.ITEM><PREFIX>(1)</PREFIX><TERM>clearingmedlem</TERM><DEFINITION>en clearingmedlem enligt artikel 2.14.</DEFINITION></DLIST.ITEM>
+            </DLIST>
+          </QUOT.S></P>
+        </ALINEA>
+      </ARTICLE>`));
+
+    expect(result.definitions).toEqual([]);
+  });
+
+  it("does not treat HT-italic prose in an untitled article as a definition", () => {
+    // Swedish VAT (32006L0112 SWE) Article 5 marks its defined terms as
+    // <HT TYPE="ITALIC">term:</HT> instead of quoting them, but the article
+    // carries no STI.ART — declaresItself is false — and HT TYPE="ITALIC" is
+    // a generic emphasis marker used throughout Formex documents for
+    // reasons unrelated to defining a term. This shape is deliberately NOT
+    // given a title-gated fast path (see the task notes): even gated by
+    // title it would not help this real, untitled article, and loosening it
+    // to fire on untitled articles would reopen exactly the over-match risk
+    // the quote-less guard above already closes. allText() flattens the HT
+    // wrapper away, so this already falls through to the same quote-less
+    // colon fallback and the same untitled-article guard as any other
+    // language.
+    const result = parseFmxToCombined(actWithArticlesLang("SV", `
+      <ARTICLE IDENTIFIER="005">
+        <TI.ART>Artikel 5</TI.ART>
+        <ALINEA>
+          <P>Vid tillämpningen av detta direktiv avses med</P>
+          <LIST TYPE="ARAB">
+            <ITEM><NP><NO.P>1.</NO.P><TXT><HT TYPE="ITALIC">gemenskapen och gemenskapens territorium:</HT> medlemsstaternas samtliga territorier.</TXT></NP></ITEM>
+            <ITEM><NP><NO.P>2.</NO.P><TXT><HT TYPE="ITALIC">tredje territorier</HT>: de territorier som anges i artikel 6.</TXT></NP></ITEM>
+          </LIST>
+        </ALINEA>
+      </ARTICLE>`));
+
+    expect(result.definitions).toEqual([]);
+  });
+});

--- a/backend/shared/formex-parser/fmxParser.test.js
+++ b/backend/shared/formex-parser/fmxParser.test.js
@@ -1649,3 +1649,93 @@ describe("definition extraction beyond the titled definitions article", () => {
     expect(result.definitions.map((d) => d.term)).toEqual(["kreditinstitut"]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Elision apostrophes in quote-delimited terms (FR/IT/PT and other
+// verb_first languages)
+// ---------------------------------------------------------------------------
+
+describe("definition extraction: elision apostrophes in quote-delimited terms", () => {
+  function actWithArticlesLang(langCode, articlesXml) {
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<COMBINED.FMX>
+  <ACT>
+    <BIB.INSTANCE><LG.DOC>${langCode}</LG.DOC></BIB.INSTANCE>
+    <TITLE><TI><P>Regulation (EU) No 575/2013</P></TI></TITLE>
+    <ENACTING.TERMS>${articlesXml}</ENACTING.TERMS>
+  </ACT>
+</COMBINED.FMX>`;
+  }
+
+  const quoted = (term) => `<QUOT.START CODE="2018"/>${term}<QUOT.END CODE="2019"/>`;
+
+  it("extracts a French term through a grammatical elision apostrophe", () => {
+    // MiFID II FRA (32014L0065) Article 4(55): "«État membre d’origine»,"
+    // used to parse to term "État membre d" with "origine»," folded into the
+    // definition, because the elision apostrophe is the same glyph FR's
+    // quoteChars uses as a closing quote. The definition itself continues in
+    // a nested list, so this item legitimately has no trailing definition
+    // text in its own <TXT> — see the next test for a genuine closing quote.
+    const result = parseFmxToCombined(actWithArticlesLang("FR", `
+      <ARTICLE IDENTIFIER="004">
+        <TI.ART>Article 4</TI.ART>
+        <STI.ART>Définitions</STI.ART>
+        <ALINEA>
+          <P>Aux fins de la présente directive, on entend par:</P>
+          <LIST TYPE="ARAB">
+            <ITEM><NP><NO.P>55)</NO.P><TXT>${quoted("État membre d’origine")},</TXT></NP></ITEM>
+          </LIST>
+        </ALINEA>
+      </ARTICLE>`));
+
+    expect(result.definitions).toHaveLength(1);
+    expect(result.definitions[0]).toMatchObject({
+      term: "État membre d’origine",
+      definition: "",
+    });
+  });
+
+  it("still terminates a French term at its true closing quote", () => {
+    // A term with no elision, immediately followed by the ordinary
+    // comma/verb separator, must keep working exactly as before — the
+    // elision lookaround only ever widens the match when both neighbours of
+    // the quote character are letters.
+    const result = parseFmxToCombined(actWithArticlesLang("FR", `
+      <ARTICLE IDENTIFIER="004">
+        <TI.ART>Article 4</TI.ART>
+        <STI.ART>Définitions</STI.ART>
+        <ALINEA>
+          <P>Aux fins de la présente directive, on entend par:</P>
+          <LIST TYPE="ARAB">
+            <ITEM><NP><NO.P>1)</NO.P><TXT>${quoted("client professionnel")}, tout client qui possède l’expérience nécessaire.</TXT></NP></ITEM>
+          </LIST>
+        </ALINEA>
+      </ARTICLE>`));
+
+    expect(result.definitions).toHaveLength(1);
+    expect(result.definitions[0]).toMatchObject({
+      term: "client professionnel",
+      definition: "tout client qui possède l’expérience nécessaire.",
+    });
+  });
+
+  it("still rejects SV's quote-less colon fallback when it has no definition text", () => {
+    // The empty-definition allowance the elision fix needed above is scoped
+    // to quote-delimited languages, whose meansRegex path already accepted
+    // an empty group 2 for "'term' means:" followed by lettered sub-points.
+    // LT/SV's bare colon/dash fallback has no such structural signal and is
+    // already the most over-match-prone pattern in this parser (Finding 1),
+    // so it must keep requiring actual definition text even inside a titled
+    // definitions article.
+    const result = parseFmxToCombined(actWithArticlesLang("SV", `
+      <ARTICLE IDENTIFIER="004">
+        <TI.ART>Artikel 4</TI.ART>
+        <STI.ART>Definitioner</STI.ART>
+        <ALINEA>
+          <P>kreditinstitut:</P>
+        </ALINEA>
+      </ARTICLE>`));
+
+    expect(result.definitions).toEqual([]);
+  });
+});

--- a/backend/shared/formex-parser/languages.mjs
+++ b/backend/shared/formex-parser/languages.mjs
@@ -716,6 +716,27 @@ function quoteCharClass(lang) {
 }
 
 /**
+ * Body pattern for a quote-delimited term: any character that is not a quote
+ * character, OR a straight/typographic apostrophe standing directly between
+ * two letters.
+ *
+ * French, Italian and other Romance languages elide a short word before a
+ * vowel with an apostrophe -- "d'origine", "l'Etat", "all'ingrosso" -- using
+ * the very same glyph (U+0027 / U+2019) their quoteChars list as a
+ * quotation mark. A plain negated class ([^q]+) reads that elision
+ * apostrophe as the term's closing quote and truncates the term mid-word
+ * ("Etat membre d'origine" -> "Etat membre d"). A genuine closing quote is
+ * never immediately followed by a letter -- the meansVerb or a separator
+ * always intervenes -- so treating a letter-apostrophe-letter run as term
+ * text is safe everywhere the negated class is already used: the lookaround
+ * only fires when both neighbours are letters, so it can never swallow a
+ * true closing quote. Requires the "u" regex flag (uses \p{L}).
+ */
+function termBody(q) {
+  return `(?:[^${q}]|(?<=\\p{L})['\u2019](?=\\p{L}))`;
+}
+
+/**
  * Build the "means" regex for definition extraction from the language config.
  *
  * Two formats:
@@ -734,7 +755,7 @@ export function buildMeansRegex(lang) {
   const verb = `(?:${lang.meansVerb})`;
   if (lang.definitionFormat === "verb_first") {
     // "meansVerb [q]term[q]" — term comes AFTER the verb
-    return new RegExp(`^${verb}\\s+[${q}]([^${q}]+)[${q}]`, "i");
+    return new RegExp(`^${verb}\\s+[${q}](${termBody(q)}+)[${q}]`, "iu");
   }
   // Default: "'term' meansVerb definition"
   //
@@ -781,9 +802,9 @@ export function buildInlineDefRegex(lang) {
   const q = quoteCharClass(lang);
   const verb = `(?:${lang.meansVerb})`;
   if (lang.definitionFormat === "verb_first") {
-    return new RegExp(`${verb}\\s+[${q}]([^${q}]+)[${q}]\\s*`, "gi");
+    return new RegExp(`${verb}\\s+[${q}](${termBody(q)}+)[${q}]\\s*`, "giu");
   }
-  return new RegExp(`[${q}]([^${q}]+)[${q}]\\s+${verb}\\s+`, "gi");
+  return new RegExp(`[${q}](${termBody(q)}+)[${q}]\\s+${verb}\\s+`, "giu");
 }
 
 /**
@@ -826,8 +847,8 @@ export function buildFallbackDefRegex(lang) {
   // All other languages: term is surrounded by quote characters from quoteChars.
   // After the closing quote there may be: colon, en-dash (–), comma, or nothing.
   return new RegExp(
-    `^[${q}]([^${q}]+)[${q}]\\s*[:\\u2013\\u2014,]?\\s*`,
-    "i"
+    `^[${q}](${termBody(q)}+)[${q}]\\s*[:\\u2013\\u2014,]?\\s*`,
+    "iu"
   );
 }
 


### PR DESCRIPTION
Stacked on #146. Two pre-existing multilingual definition-extraction bugs, surfaced while live-verifying #146's fixes.

## Elision apostrophes truncated verb-first terms

The FR/IT/ES/PT quote character set includes the apostrophe, which those languages also use for grammatical elision. The term patterns treated any apostrophe as a closing quote, so MiFID II (FRA) Article 4(55) «État membre d'origine» parsed to term "État membre d" with the rest folded into the definition. An apostrophe flanked by letters on both sides is now term text; a genuine closing quote (followed by space/punctuation) still terminates the term. Fixing this exposed a second guard bug that silently dropped quote-delimited terms whose definition continues in a nested list ("«État membre d'origine»,"); relaxed for quoted matches only, never for the LT/SV quote-less fallback.

Live before/after (MiFID II): FRA 63→63 with 7 terms de-truncated, ITA 63→63 (2 fixed), POR 62→63, DEU 62→63. GDPR ENG unchanged.

## Swedish DLIST definitions were invisible

Swedish acts encode definitions structurally — `<DLIST><DLIST.ITEM><PREFIX>(1)</PREFIX><TERM>…</TERM><DEFINITION>…</DEFINITION>` — none of the LIST/ITEM/NP/TXT shapes the parser scans. `definitionEntries()` now reads DLIST.ITEM directly (no regex needed), honoring the QUOT.S exclusion, and the prose loops skip DLIST bodies so they are no longer flattened into garbled blobs. CRR (SWE): 4 garbled entries → 316 real definitions.

The other Swedish shape found (italicized term + colon in untitled articles, VAT Article 5) is deliberately **not** implemented: every real occurrence is untitled, so the safe titled-only gate yields nothing, and an untitled gate would reopen the over-match risk #146 just closed. A regression test locks in the non-match.

## Notes for review

- **`PARSER_VERSION` 21 → 22** (this PR can merge/deploy independently of #146's 21).
- 7 new regression tests; 149 parser tests, full suites and lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)