### PR TITLE
Re-check in-force status for acts already in the search cache

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -668,6 +668,25 @@ node --max-old-space-size=8192 search/fetch-eurovoc.js
 node --max-old-space-size=8192 search/fetch-in-force.js
 ```
 
+`fetch-in-force.js` only ever fills a gap: it skips any record that already
+carries `inForce` and any celex already answered in `data/in-force.json`, so it
+never re-asks Cellar about a status once known. Because `inForce` is
+time-varying (an act can be repealed after its first harvest), that first-ever
+value would otherwise be carried forward indefinitely. `search/in-force-recheck.js`
+is the periodic counterpart: it clears both skips for a bounded slice — acts
+whose `endOfValidity` has passed but still read `inForce: true` first, then a
+rotating age-based batch ordered by `statusCheckedAt` — and re-queries just
+that slice, so the whole cache turns over on a known cycle without re-querying
+all ~80k acts on every run (issue #167). Not wired into any workflow — the
+schedule is a deploy decision, not a code one:
+
+```bash
+node --max-old-space-size=8192 search/in-force-recheck.js --batch-size 2000 --cycle-days 30
+```
+
+`--sweep` re-checks the entire cache in one run and must be passed explicitly;
+there is no unbounded default.
+
 If whole acts are missing rather than a field — a transient Cellar failure during
 the sweep, or an act Cellar had not indexed yet when it ran — add them by CELEX
 instead of re-sweeping the year around them:

--- a/backend/search/in-force-enrich.js
+++ b/backend/search/in-force-enrich.js
@@ -162,10 +162,17 @@ async function enrichRecordsWithInForce(records, options = {}) {
 
   const journal = readJournal(journalPath);
   const stats = { targeted: 0, fromJournal: 0, fetched: 0, withStatus: 0, inForce: 0, alreadyPresent: 0 };
+  // Stamped only when this call actually asked Cellar (the found/unknown
+  // branches below) — reused from the journal is replaying a prior
+  // confirmation, not a fresh one, so it is deliberately left unstamped. This
+  // is what search/in-force-recheck.js (issue #167) reads to pick its rotating
+  // slice: a record with no stamp, or the oldest stamp, is the most overdue.
+  const checkedAt = new Date().toISOString();
 
-  const applyEntry = (record, entry) => {
+  const applyEntry = (record, entry, { confirmed = false } = {}) => {
     record.inForce = entry.inForce ?? null;
     record.endOfValidity = entry.endOfValidity ?? null;
+    if (confirmed) record.statusCheckedAt = checkedAt;
     if (record.inForce !== null) {
       stats.withStatus += 1;
       if (record.inForce) stats.inForce += 1;
@@ -215,7 +222,7 @@ async function enrichRecordsWithInForce(records, options = {}) {
         };
         journal[celex] = entry;
         const record = byCelex.get(celex);
-        if (record) applyEntry(record, entry);
+        if (record) applyEntry(record, entry, { confirmed: true });
       }
 
       // An act Cellar has no status for is journaled as unknown so a rerun skips
@@ -226,7 +233,7 @@ async function enrichRecordsWithInForce(records, options = {}) {
         if (found.has(celex)) continue;
         journal[celex] = unknown;
         const record = byCelex.get(celex);
-        if (record) applyEntry(record, unknown);
+        if (record) applyEntry(record, unknown, { confirmed: true });
       }
 
       stats.fetched += batch.length;
@@ -252,4 +259,5 @@ module.exports = {
   parseEndOfValidity,
   parseInForce,
   readJournal,
+  writeJournal,
 };

--- a/backend/search/in-force-recheck.js
+++ b/backend/search/in-force-recheck.js
@@ -1,0 +1,286 @@
+"use strict";
+
+// Periodic in-force RE-check (issue #167).
+//
+// in-force-enrich.js only ever fills a *gap*: it skips any record that already
+// carries `inForce`, and separately skips any celex already answered in
+// data/in-force.json. Every record restored from the published search cache
+// carries the field, and the journal survives every rebuild, so in practice no
+// act's status is ever re-asked after its first harvest — a repealed act keeps
+// reading `inForce: true` forever.
+//
+// This module defeats both skips for a bounded slice only: it clears
+// `inForce` / `endOfValidity` on the slice's records AND drops the matching
+// journal entries, then hands the slice to enrichRecordsWithInForce, which
+// then has no choice but to ask Cellar again. Everything outside the slice is
+// untouched — this is not a rebuild and not a sweep.
+//
+// Slice selection (in priority order):
+//   1. Records whose `endOfValidity` has already passed but which still read
+//      `inForce: true` — these are known-wrong regardless of when they were
+//      last checked, so they always make the slice first.
+//   2. A rotating age-based fill, oldest `statusCheckedAt` first (a record
+//      that predates the field sorts as infinitely stale), up to --batch-size.
+// That rotation is what gives the cache a known, stated turnover cycle: at
+// batch-size B against N eligible records, a full sweep takes ceil(N / B) runs.
+//
+// Not invoked by any workflow — the scheduling decision is a human's. Proposed
+// invocation (NOT wired here, see the PR description):
+//   node search/in-force-recheck.js --batch-size 2000 --cycle-days 30
+//
+// Usage:
+//   node search/in-force-recheck.js [--batch-size N] [--cycle-days N]
+//     [--cache-path path] [--sweep]
+//   --sweep treats the whole cache as the slice (explicit opt-in only — an
+//   ~80k-act corpus must not be re-queried by default).
+
+const fs = require("fs");
+const zlib = require("zlib");
+
+const { JsonLegalCacheStore } = require("./legal-cache-store");
+const {
+  DEFAULT_JOURNAL_PATH,
+  enrichRecordsWithInForce,
+  readJournal,
+  writeJournal,
+} = require("./in-force-enrich");
+
+const LABEL = "in-force-recheck";
+const DEFAULT_BATCH_SIZE = 2000;
+const DEFAULT_CYCLE_DAYS = 30;
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function isExpiredButInForce(record, today) {
+  return record.inForce === true
+    && typeof record.endOfValidity === "string"
+    && record.endOfValidity < today;
+}
+
+// Missing or unparseable statusCheckedAt sorts as "oldest": a record that
+// predates the field is at least as overdue as one checked at the dawn of time.
+function statusAgeKey(record) {
+  const parsed = record.statusCheckedAt ? Date.parse(record.statusCheckedAt) : NaN;
+  return Number.isNaN(parsed) ? -Infinity : parsed;
+}
+
+// Priority 1 (expired-but-in-force) always makes the slice, even if it alone
+// exceeds batchSize — these are the cheapest, most confidently wrong records
+// in the cache and should never be starved by the rotation. Priority 2 fills
+// whatever budget is left, oldest-checked first.
+function selectRecheckSlice(records, options = {}) {
+  const { batchSize = DEFAULT_BATCH_SIZE, today = todayIso(), sweep = false } = options;
+  const eligible = records.filter((record) => record.celex);
+
+  if (sweep) return eligible.slice();
+
+  const expired = eligible.filter((record) => isExpiredButInForce(record, today));
+  const expiredCelex = new Set(expired.map((record) => record.celex));
+
+  const remaining = Math.max(0, batchSize - expired.length);
+  const rotationPool = eligible
+    .filter((record) => !expiredCelex.has(record.celex))
+    .sort((a, b) => statusAgeKey(a) - statusAgeKey(b));
+
+  return expired.concat(rotationPool.slice(0, remaining));
+}
+
+// Defeats both in-force-enrich.js skips for exactly this slice: the in-memory
+// field guard (`record.inForce !== undefined`) and the on-disk journal entry
+// keyed by celex. Mutates `slice` members in place and rewrites the journal
+// file with the slice's entries removed; everything else in the journal (and
+// every record outside the slice) is left alone.
+function primeSliceForRecheck(slice, journalPath) {
+  const journal = readJournal(journalPath);
+  let journalEntriesDropped = 0;
+  for (const record of slice) {
+    delete record.inForce;
+    delete record.endOfValidity;
+    if (Object.prototype.hasOwnProperty.call(journal, record.celex)) {
+      delete journal[record.celex];
+      journalEntriesDropped += 1;
+    }
+  }
+  writeJournal(journalPath, journal);
+  return { journalEntriesDropped };
+}
+
+function classifyFlip(before, after) {
+  if (before.inForce === true && after.inForce === false) return "toRepealed";
+  if (before.inForce === false && after.inForce === true) return "toInForce";
+  return null;
+}
+
+// Orchestrates one bounded recheck run over `records` (mutated in place, same
+// contract as enrichRecordsWithInForce). Returns how many records were
+// touched, how many were actually re-queried (vs. answered from a still-valid
+// journal entry for some *other* celex — should be ~0 for the slice since we
+// just dropped its own entries), and — the number that matters for catching a
+// silent no-op regression — how many statuses actually flipped.
+async function runRecheck(records, options = {}) {
+  const {
+    journalPath = DEFAULT_JOURNAL_PATH,
+    batchSize = DEFAULT_BATCH_SIZE,
+    sweep = false,
+    today = todayIso(),
+    log = () => {},
+    runQueryFn,
+  } = options;
+
+  const slice = selectRecheckSlice(records, { batchSize, today, sweep });
+  const before = new Map(
+    slice.map((record) => [record.celex, { inForce: record.inForce, endOfValidity: record.endOfValidity }]),
+  );
+
+  const { journalEntriesDropped } = primeSliceForRecheck(slice, journalPath);
+  log(`slice=${slice.length} sweep=${sweep} journalEntriesDropped=${journalEntriesDropped}`);
+
+  const enrichStats = await enrichRecordsWithInForce(slice, {
+    journalPath,
+    log,
+    ...(runQueryFn ? { runQueryFn } : {}),
+  });
+
+  let flippedToRepealed = 0;
+  let flippedToInForce = 0;
+  for (const record of slice) {
+    const prev = before.get(record.celex);
+    const flip = classifyFlip(prev, record);
+    if (flip === "toRepealed") flippedToRepealed += 1;
+    else if (flip === "toInForce") flippedToInForce += 1;
+  }
+
+  return {
+    sliceSize: slice.length,
+    journalEntriesDropped,
+    requeried: enrichStats.fetched,
+    flippedToRepealed,
+    flippedToInForce,
+    flipped: flippedToRepealed + flippedToInForce,
+    enrichStats,
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    cachePath: undefined,
+    batchSize: DEFAULT_BATCH_SIZE,
+    cycleDays: DEFAULT_CYCLE_DAYS,
+    sweep: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--batch-size" && argv[index + 1]) {
+      options.batchSize = Number.parseInt(argv[++index], 10) || DEFAULT_BATCH_SIZE;
+    } else if (token === "--cycle-days" && argv[index + 1]) {
+      options.cycleDays = Number.parseInt(argv[++index], 10) || DEFAULT_CYCLE_DAYS;
+    } else if (token === "--cache-path" && argv[index + 1]) {
+      options.cachePath = argv[++index];
+    } else if (token === "--sweep") {
+      options.sweep = true;
+    }
+  }
+  return options;
+}
+
+// store.payload.records are the untouched parsed records — see the identical
+// note in fetch-in-force.js. Writing the payload back keeps every other field
+// (date, eurovoc, excerpt, ...) byte-for-byte as the builder wrote it.
+function writeCache(store) {
+  const json = `${JSON.stringify(store.payload)}\n`;
+  const cachePath = store.cachePath;
+  const gzPath = `${cachePath}.gz`;
+
+  const tempJson = `${cachePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tempJson, json, "utf8");
+  fs.renameSync(tempJson, cachePath);
+
+  const tempGz = `${gzPath}.${process.pid}.tmp`;
+  fs.writeFileSync(tempGz, zlib.gzipSync(Buffer.from(json, "utf8")));
+  fs.renameSync(tempGz, gzPath);
+
+  return { cachePath, gzPath };
+}
+
+// Same regression guard as fetch-in-force.js: this tool only ever touches
+// inForce/endOfValidity/statusCheckedAt on a slice, so date/eurovoc coverage
+// must never move. A drop means this ran against the wrong cache.
+function assertEnrichmentIntact(records, before) {
+  const dated = records.filter((r) => r.date).length;
+  const topiced = records.filter((r) => Array.isArray(r.eurovoc)).length;
+  if (dated < before.dated || topiced < before.topiced) {
+    throw new Error(
+      `refusing to write: enrichment regressed (dates ${before.dated} -> ${dated}, `
+      + `eurovoc ${before.topiced} -> ${topiced}). The cache this ran against is not the enriched one.`,
+    );
+  }
+  return { dated, topiced };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  const store = new JsonLegalCacheStore(options.cachePath, { preferJson: true });
+  if (!store.load()) {
+    throw new Error(`Failed to load search cache: ${store.loadError}`);
+  }
+
+  const records = store.payload.records;
+  const before = {
+    dated: records.filter((r) => r.date).length,
+    topiced: records.filter((r) => Array.isArray(r.eurovoc)).length,
+  };
+  console.log(`[${LABEL}] loaded ${records.length} records from ${store.cachePath}`);
+  if (options.sweep) {
+    console.log(`[${LABEL}] --sweep: treating the ENTIRE cache as the slice, ignoring --batch-size`);
+  } else {
+    console.log(`[${LABEL}] batch-size=${options.batchSize} cycle-days=${options.cycleDays}`
+      + ` (at this batch size, a full rotation takes ceil(eligible / batch-size) runs,`
+      + ` i.e. roughly every ${options.cycleDays} x ceil(eligible / batch-size) days if run on that cadence)`);
+  }
+
+  const result = await runRecheck(records, {
+    batchSize: options.batchSize,
+    sweep: options.sweep,
+    log: (message) => console.log(`[${LABEL}] ${message}`),
+  });
+
+  console.log(
+    `[${LABEL}] rechecked ${result.sliceSize} records`
+    + ` (${result.journalEntriesDropped} journal entries dropped, ${result.requeried} re-queried against Cellar)`,
+  );
+  console.log(
+    `[${LABEL}] status flips: ${result.flipped} total`
+    + ` (${result.flippedToRepealed} in-force -> repealed, ${result.flippedToInForce} repealed -> in-force)`,
+  );
+  if (result.flipped === 0 && result.requeried > 0) {
+    console.log(`[${LABEL}] note: 0 flips out of ${result.requeried} re-queried records is expected on most runs — status rarely changes day to day.`);
+  }
+
+  const after = assertEnrichmentIntact(records, before);
+  console.log(`[${LABEL}] enrichment intact: ${after.dated} dated, ${after.topiced} with topics`);
+
+  const { cachePath, gzPath } = writeCache(store);
+  console.log(`[${LABEL}] wrote ${cachePath} and ${gzPath}`);
+  console.log(`[${LABEL}] next: publish the .gz as the data-vN release asset and bump DATA_RELEASE_TAG in backend/Dockerfile`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`[${LABEL}] fatal:`, error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_CYCLE_DAYS,
+  classifyFlip,
+  isExpiredButInForce,
+  primeSliceForRecheck,
+  runRecheck,
+  selectRecheckSlice,
+  statusAgeKey,
+};

--- a/backend/search/in-force-recheck.test.js
+++ b/backend/search/in-force-recheck.test.js
@@ -1,0 +1,156 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { readJournal } = require("./in-force-enrich");
+const {
+  classifyFlip,
+  isExpiredButInForce,
+  primeSliceForRecheck,
+  runRecheck,
+  selectRecheckSlice,
+} = require("./in-force-recheck");
+
+function tempJournal(contents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "in-force-recheck-"));
+  const journalPath = path.join(dir, "in-force.json");
+  if (contents !== undefined) fs.writeFileSync(journalPath, JSON.stringify(contents), "utf8");
+  return journalPath;
+}
+
+function bindings(rows) {
+  return { results: { bindings: rows } };
+}
+
+test("isExpiredButInForce flags an act flagged in force past its own endOfValidity", () => {
+  assert.equal(isExpiredButInForce({ inForce: true, endOfValidity: "2020-01-01" }, "2026-08-20"), true);
+  assert.equal(isExpiredButInForce({ inForce: true, endOfValidity: "2030-01-01" }, "2026-08-20"), false);
+  assert.equal(isExpiredButInForce({ inForce: false, endOfValidity: "2020-01-01" }, "2026-08-20"), false);
+  assert.equal(isExpiredButInForce({ inForce: true, endOfValidity: null }, "2026-08-20"), false);
+});
+
+test("selectRecheckSlice puts expired-but-in-force records first, ahead of the rotation", () => {
+  const records = [
+    { celex: "A", inForce: true, endOfValidity: "2020-01-01", statusCheckedAt: "2026-01-01T00:00:00.000Z" }, // expired, known-wrong
+    { celex: "B", inForce: true, endOfValidity: "2030-01-01", statusCheckedAt: "2020-01-01T00:00:00.000Z" }, // oldest checked, not expired
+    { celex: "C", inForce: false, endOfValidity: "2018-05-24" }, // never checked (predates field)
+    { celex: "D", inForce: true, endOfValidity: "2030-01-01", statusCheckedAt: "2026-06-01T00:00:00.000Z" }, // freshly checked
+  ];
+
+  const slice = selectRecheckSlice(records, { batchSize: 3, today: "2026-08-20" });
+  const celexes = slice.map((r) => r.celex);
+
+  // A is expired-but-in-force: must be first regardless of its (recent) stamp.
+  assert.equal(celexes[0], "A");
+  // Remaining budget (2) goes to the two oldest/unstamped records, C and B,
+  // ahead of the freshly-checked D.
+  assert.deepEqual(new Set(celexes.slice(1)), new Set(["B", "C"]));
+  assert.equal(celexes.includes("D"), false);
+});
+
+test("selectRecheckSlice includes every expired-but-in-force record even beyond batchSize", () => {
+  const records = [
+    { celex: "A", inForce: true, endOfValidity: "2020-01-01" },
+    { celex: "B", inForce: true, endOfValidity: "2020-01-01" },
+    { celex: "C", inForce: true, endOfValidity: "2030-01-01" },
+  ];
+  const slice = selectRecheckSlice(records, { batchSize: 1, today: "2026-08-20" });
+  assert.deepEqual(new Set(slice.map((r) => r.celex)), new Set(["A", "B"]));
+});
+
+test("selectRecheckSlice --sweep returns the whole eligible set, ignoring batchSize", () => {
+  const records = [{ celex: "A" }, { celex: "B" }, { celex: "C" }, { celex: "D" }];
+  const slice = selectRecheckSlice(records, { batchSize: 1, sweep: true });
+  assert.equal(slice.length, 4);
+});
+
+test("primeSliceForRecheck clears the record fields and drops only the slice's journal entries", () => {
+  const journalPath = tempJournal({
+    A: { inForce: true, endOfValidity: null },
+    B: { inForce: false, endOfValidity: "2018-05-24" },
+    UNRELATED: { inForce: true, endOfValidity: null },
+  });
+  const slice = [
+    { celex: "A", inForce: true, endOfValidity: null },
+    { celex: "B", inForce: false, endOfValidity: "2018-05-24" },
+  ];
+
+  const { journalEntriesDropped } = primeSliceForRecheck(slice, journalPath);
+
+  assert.equal(journalEntriesDropped, 2);
+  assert.equal(slice[0].inForce, undefined);
+  assert.equal(slice[0].endOfValidity, undefined);
+  assert.equal(slice[1].inForce, undefined);
+
+  const journal = readJournal(journalPath);
+  assert.equal(journal.A, undefined);
+  assert.equal(journal.B, undefined);
+  // The unrelated entry, for a celex outside the slice, must survive untouched.
+  assert.deepEqual(journal.UNRELATED, { inForce: true, endOfValidity: null });
+});
+
+test("classifyFlip only reports true in-force <-> repealed transitions", () => {
+  assert.equal(classifyFlip({ inForce: true }, { inForce: false }), "toRepealed");
+  assert.equal(classifyFlip({ inForce: false }, { inForce: true }), "toInForce");
+  assert.equal(classifyFlip({ inForce: true }, { inForce: true }), null);
+  assert.equal(classifyFlip({ inForce: null }, { inForce: true }), null);
+  assert.equal(classifyFlip({ inForce: true }, { inForce: null }), null);
+});
+
+test("runRecheck leaves a non-slice record entirely untouched", async () => {
+  const journalPath = tempJournal({});
+  const stale = { celex: "STALE", inForce: true, endOfValidity: "2020-01-01" }; // expired, will be selected
+  const fresh = { celex: "FRESH", inForce: true, endOfValidity: "2030-01-01", statusCheckedAt: "2026-08-19T00:00:00.000Z" };
+  const records = [stale, fresh];
+
+  await runRecheck(records, {
+    journalPath,
+    batchSize: 1, // only room for the one expired record; FRESH must not be pulled into the rotation
+    today: "2026-08-20",
+    runQueryFn: async () => bindings([{ celex: { value: "STALE" }, inForce: { value: "0" } }]),
+  });
+
+  assert.equal(fresh.inForce, true);
+  assert.equal(fresh.endOfValidity, "2030-01-01");
+  assert.equal(fresh.statusCheckedAt, "2026-08-19T00:00:00.000Z");
+});
+
+test("runRecheck's flip counter counts actual flips, not the number re-queried", async () => {
+  const journalPath = tempJournal({});
+  const records = [
+    { celex: "REPEALED", inForce: true, endOfValidity: "2020-01-01" }, // will flip to false
+    { celex: "STILL_TRUE", inForce: true, endOfValidity: "2020-01-01" }, // stays true (Cellar disagrees with the date)
+  ];
+
+  const result = await runRecheck(records, {
+    journalPath,
+    batchSize: 10,
+    today: "2026-08-20",
+    runQueryFn: async () => bindings([
+      { celex: { value: "REPEALED" }, inForce: { value: "0" } },
+      { celex: { value: "STILL_TRUE" }, inForce: { value: "1" } },
+    ]),
+  });
+
+  assert.equal(result.requeried, 2);
+  assert.equal(result.flipped, 1);
+  assert.equal(result.flippedToRepealed, 1);
+  assert.equal(result.flippedToInForce, 0);
+});
+
+test("runRecheck stamps statusCheckedAt on every slice member it actually re-queried", async () => {
+  const journalPath = tempJournal({});
+  const records = [{ celex: "A", inForce: true, endOfValidity: "2020-01-01" }];
+
+  await runRecheck(records, {
+    journalPath,
+    batchSize: 10,
+    today: "2026-08-20",
+    runQueryFn: async () => bindings([{ celex: { value: "A" }, inForce: { value: "1" } }]),
+  });
+
+  assert.equal(typeof records[0].statusCheckedAt, "string");
+  assert.ok(!Number.isNaN(Date.parse(records[0].statusCheckedAt)));
+});


### PR DESCRIPTION
Fixes #167.

## Problem

`inForce` / `endOfValidity` are time-varying, but nothing ever re-queries the status of an act already in the search cache — its first-ever value is carried forward indefinitely. A law repealed since its first harvest keeps `inForce: true` in the shipped cache, in the SQLite data the API serves, and in the UI.

Two independent skips cause it, and both must be defeated to re-check anything:

1. `in-force-enrich.js` skips any record already carrying `inForce` — and every record restored from the published `search-cache.json.gz` carries it.
2. The `data/in-force.json` journal is restored and re-published across runs, so even a cleared record is answered from disk rather than from SPARQL.

## What this adds

**`backend/search/in-force-recheck.js`** — a bounded periodic re-check that defeats both skips for a slice only, then hands that slice to `enrichRecordsWithInForce`.

Slice selection, in priority order:

1. **Expired-but-in-force** — records whose `endOfValidity` has passed while still reading `inForce: true`. Known-wrong regardless of when they were last checked, so they always make the slice even if they alone exceed the batch size.
2. **Rotating age fill** — oldest `statusCheckedAt` first, up to `--batch-size`. A record predating the field sorts as infinitely stale, so the backfill drains before anything gets re-checked twice.

At batch size B over N eligible records a full turnover takes `ceil(N / B)` runs — stated in the run summary rather than left implicit.

**`statusCheckedAt` stamp** (`in-force-enrich.js`) — written only when a status was actually confirmed against Cellar on that run. A journal replay is a prior confirmation, not a fresh one, so it deliberately leaves no stamp; otherwise the rotation would consider replayed records fresh and never re-ask them. This is also the freshness signal that would later let the Docker guards assert currency instead of presence — those guards are untouched here.

**Flip reporting** — the run reports how many statuses actually changed (in-force → repealed and back), separately from how many were re-queried. A re-check that silently stops re-checking looks identical to a quiet month unless flips are counted apart from work done.

## Scope

- `.github/workflows/` is untouched — the scheduling decision is yours. Proposed invocation, documented in `backend/README.md` but not wired: `node search/in-force-recheck.js --batch-size 2000 --cycle-days 30`
- `--sweep` is the only unbounded path and is explicit opt-in; ~80k acts must not be re-queried by default.
- Writing the cache mirrors `fetch-in-force.js` exactly, including its `assertEnrichmentIntact` guard, so a run against the wrong cache refuses to write rather than silently dropping `date` / `eurovoc` coverage.

## Version constants

No bump. `statusCheckedAt` is additive to the JSON record, and `SQLITE_SCHEMA_VERSION` guards table and index structure rather than JSON-blob content. The field is deliberately kept out of `compactSqliteRecord` and the `searchLaws()` whitelist — it is build-time bookkeeping for this tool, never served to the API or UI, so it does not need to survive JSON → SQLite compaction. Reasoning is recorded in the commit message.

## Verification

Re-run independently of the implementation, on this branch:

- `cd backend && node --test search/*.test.js` — 225 tests, 223 pass, 0 fail, 2 skipped (pre-existing, unrelated).
- `cd backend && node --test shared/*.test.js routes/*.test.js bin/*.test.js mcp/*.test.js` — 242 tests, 242 pass, 0 fail.
- `npm run lint` (root) — clean.
- 9 new tests in `in-force-recheck.test.js` cover slice priority and `--sweep`, journal-entry scoping, non-slice isolation, flip-vs-re-query counting, and the `statusCheckedAt` stamp. All stub the SPARQL runner; nothing in the suite touches the live endpoint.

## Known limitation

A mid-slice Cellar failure leaves the journal partially updated (existing `finally`-block behaviour in `enrichRecordsWithInForce`), and `runRecheck` does not special-case a thrown error for its own summary — a failed run's flip count reflects only what completed before the throw. The next run re-selects the unfinished records, since they are left unstamped, so nothing is permanently missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjrWUMV9oCNvqdgsywh7nS

---
_Generated by [Claude Code](https://claude.ai/code/session_01EjrWUMV9oCNvqdgsywh7nS)_