### PR TITLE
Re-check in-force status in refresh-data, as a full sweep of what can still change

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -179,6 +179,24 @@ jobs:
             : > ../refresh-output/backfill.log
           fi
 
+      # `inForce` is time-varying, but nothing else in this pipeline re-asks for
+      # it: the backfill above enriches only acts new to the cache, and
+      # in-force-enrich skips any record that already carries the field, so an
+      # act repealed since its first harvest keeps reading `inForce: true`
+      # indefinitely (issue #167). This re-queries every act not already known
+      # to be out of force — ~30k of the ~80k, ~301 SPARQL batches, about two
+      # minutes — and rewrites the cache only when a status actually moved, so a
+      # quiet month still hashes identical below and publishes no release.
+      - name: Re-check in-force status against Cellar
+        working-directory: backend
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --max-old-space-size=8192 search/in-force-recheck.js \
+            --cache-path search/data/search-cache.json \
+            --no-gz \
+            2>&1 | tee ../refresh-output/in-force-recheck.log
+
       - name: Parse case-law corpus
         working-directory: backend
         shell: bash

--- a/backend/README.md
+++ b/backend/README.md
@@ -668,6 +668,25 @@ node --max-old-space-size=8192 search/fetch-eurovoc.js
 node --max-old-space-size=8192 search/fetch-in-force.js
 ```
 
+`fetch-in-force.js` only ever fills a gap: it skips any record that already
+carries `inForce` and any celex already answered in `data/in-force.json`, so it
+never re-asks Cellar about a status once known. Because `inForce` is
+time-varying (an act can be repealed after its first harvest), that first-ever
+value would otherwise be carried forward indefinitely. `search/in-force-recheck.js`
+is the periodic counterpart: it clears both skips for a bounded slice — acts
+whose `endOfValidity` has passed but still read `inForce: true` first, then a
+rotating age-based batch ordered by `statusCheckedAt` — and re-queries just
+that slice, so the whole cache turns over on a known cycle without re-querying
+all ~80k acts on every run (issue #167). Not wired into any workflow — the
+schedule is a deploy decision, not a code one:
+
+```bash
+node --max-old-space-size=8192 search/in-force-recheck.js --batch-size 2000 --cycle-days 30
+```
+
+`--sweep` re-checks the entire cache in one run and must be passed explicitly;
+there is no unbounded default.
+
 If whole acts are missing rather than a field — a transient Cellar failure during
 the sweep, or an act Cellar had not indexed yet when it ran — add them by CELEX
 instead of re-sweeping the year around them:

--- a/backend/README.md
+++ b/backend/README.md
@@ -672,20 +672,50 @@ node --max-old-space-size=8192 search/fetch-in-force.js
 carries `inForce` and any celex already answered in `data/in-force.json`, so it
 never re-asks Cellar about a status once known. Because `inForce` is
 time-varying (an act can be repealed after its first harvest), that first-ever
-value would otherwise be carried forward indefinitely. `search/in-force-recheck.js`
-is the periodic counterpart: it clears both skips for a bounded slice — acts
-whose `endOfValidity` has passed but still read `inForce: true` first, then a
-rotating age-based batch ordered by `statusCheckedAt` — and re-queries just
-that slice, so the whole cache turns over on a known cycle without re-querying
-all ~80k acts on every run (issue #167). Not wired into any workflow — the
-schedule is a deploy decision, not a code one:
+value would otherwise be carried forward indefinitely.
+`search/in-force-recheck.js` is the periodic counterpart: it clears both skips
+and re-queries Cellar (issue #167). It runs automatically as a step of
+`refresh-data.yml`; run it by hand only to patch a published cache out of band:
 
 ```bash
-node --max-old-space-size=8192 search/in-force-recheck.js --batch-size 2000 --cycle-days 30
+node --max-old-space-size=8192 search/in-force-recheck.js
 ```
 
-`--sweep` re-checks the entire cache in one run and must be passed explicitly;
-there is no unbounded default.
+It re-checks everything **not already known to be out of force**. `inForce:
+false` is effectively terminal — an act that has fallen out of force does not
+come back — and that is 50,393 of the 80,469 acts in `data-v11`, so skipping
+them cuts the sweep to ~30k records (19,588 in force, 10,488 whose status
+Cellar has never answered and may yet). At 100 CELEX ids per SPARQL batch and
+200–400 ms per batch that is ~301 requests, about two minutes: there is
+deliberately no rotation, batch budget or turnover cycle, because at that cost a
+partial re-check would only buy staleness back.
+
+Both this and `fetch-in-force.js` query Cellar **unaggregated**, collapsing
+fan-out client-side in `reduceBindings`. The earlier
+`SELECT ... (SAMPLE(?inForceValue) AS ?inForce) (MIN(?endValue) AS ?endOfValidity)
+... GROUP BY ?celex` mis-assigned values across groups at batch scale: in a real
+100-CELEX batch, 32006R0988 (end-of-validity 2020-12-31) and 32006R1066 (the
+9999-12-31 sentinel) both came back as 2020-12-31, while the same batch
+unaggregated — and 32006R1066 queried alone — returned the sentinel correctly.
+The wrong value is stable for a given batch and moves when the batch composition
+moves, so it cannot be retried away; it silently writes one act's expiry date
+onto another. Do not reintroduce a server-side `GROUP BY` here.
+
+Two properties matter to the pipeline it runs in:
+
+- **It rewrites the cache only if a status actually moved.** Confirming 30k
+  unchanged statuses leaves the file byte-identical, so `refresh-data.yml`'s
+  change digest still reports "unchanged" and no `data-vN` release — and no
+  Docker tag PR — is cut on a quiet month.
+- **It refuses to write a degraded result.** If more than `--max-null-ratio`
+  (default 5%) of the re-checked records lose a previously known status, Cellar
+  is answering but degraded, and publishing would erode the status coverage
+  `backend-docker.yml` asserts (>80%, currently 87%). The run fails instead.
+
+Flags: `--all` re-checks out-of-force acts too, for the rare case (annulment,
+corrigendum) where one is restored; `--limit N` caps the sweep for a smoke test,
+keeping the known-wrong records first; `--no-gz` skips the `.gz` sidecar when
+the caller gzips the JSON itself, as the workflow does.
 
 If whole acts are missing rather than a field — a transient Cellar failure during
 the sweep, or an act Cellar had not indexed yet when it ran — add them by CELEX

--- a/backend/README.md
+++ b/backend/README.md
@@ -673,7 +673,7 @@ carries `inForce` and any celex already answered in `data/in-force.json`, so it
 never re-asks Cellar about a status once known. Because `inForce` is
 time-varying (an act can be repealed after its first harvest), that first-ever
 value would otherwise be carried forward indefinitely.
-`search/in-force-recheck.js` is the periodic counterpart: it clears both skips
+`search/in-force-recheck.js` is the periodic counterpart: it clears the field
 and re-queries Cellar (issue #167). It runs automatically as a step of
 `refresh-data.yml`; run it by hand only to patch a published cache out of band:
 
@@ -687,8 +687,14 @@ come back — and that is 50,393 of the 80,469 acts in `data-v11`, so skipping
 them cuts the sweep to ~30k records (19,588 in force, 10,488 whose status
 Cellar has never answered and may yet). At 100 CELEX ids per SPARQL batch and
 200–400 ms per batch that is ~301 requests, about two minutes: there is
-deliberately no rotation, batch budget or turnover cycle, because at that cost a
+deliberately no slicing, batch budget or turnover cycle, because at that cost a
 partial re-check would only buy staleness back.
+
+It also runs with `useJournal: false`, so `data/in-force.json` is neither read
+nor written. The run is all-or-nothing — the cache is written once, at the end —
+so there is nothing to resume from, and journalling would only rewrite a
+30k-entry file every few batches. The builders keep the journal; an interrupted
+multi-hour harvest genuinely needs it.
 
 Both this and `fetch-in-force.js` query Cellar **unaggregated**, collapsing
 fan-out client-side in `reduceBindings`. The earlier
@@ -713,9 +719,9 @@ Two properties matter to the pipeline it runs in:
   `backend-docker.yml` asserts (>80%, currently 87%). The run fails instead.
 
 Flags: `--all` re-checks out-of-force acts too, for the rare case (annulment,
-corrigendum) where one is restored; `--limit N` caps the sweep for a smoke test,
-keeping the known-wrong records first; `--no-gz` skips the `.gz` sidecar when
-the caller gzips the JSON itself, as the workflow does.
+corrigendum) where one is restored; `--limit N` caps the run for a smoke test;
+`--no-gz` skips the `.gz` sidecar when the caller gzips the JSON itself, as the
+workflow does.
 
 If whole acts are missing rather than a field — a transient Cellar failure during
 the sweep, or an act Cellar had not indexed yet when it ran — add them by CELEX

--- a/backend/search/in-force-enrich.js
+++ b/backend/search/in-force-enrich.js
@@ -162,17 +162,10 @@ async function enrichRecordsWithInForce(records, options = {}) {
 
   const journal = readJournal(journalPath);
   const stats = { targeted: 0, fromJournal: 0, fetched: 0, withStatus: 0, inForce: 0, alreadyPresent: 0 };
-  // Stamped only when this call actually asked Cellar (the found/unknown
-  // branches below) — reused from the journal is replaying a prior
-  // confirmation, not a fresh one, so it is deliberately left unstamped. This
-  // is what search/in-force-recheck.js (issue #167) reads to pick its rotating
-  // slice: a record with no stamp, or the oldest stamp, is the most overdue.
-  const checkedAt = new Date().toISOString();
 
-  const applyEntry = (record, entry, { confirmed = false } = {}) => {
+  const applyEntry = (record, entry) => {
     record.inForce = entry.inForce ?? null;
     record.endOfValidity = entry.endOfValidity ?? null;
-    if (confirmed) record.statusCheckedAt = checkedAt;
     if (record.inForce !== null) {
       stats.withStatus += 1;
       if (record.inForce) stats.inForce += 1;
@@ -222,7 +215,7 @@ async function enrichRecordsWithInForce(records, options = {}) {
         };
         journal[celex] = entry;
         const record = byCelex.get(celex);
-        if (record) applyEntry(record, entry, { confirmed: true });
+        if (record) applyEntry(record, entry);
       }
 
       // An act Cellar has no status for is journaled as unknown so a rerun skips
@@ -233,7 +226,7 @@ async function enrichRecordsWithInForce(records, options = {}) {
         if (found.has(celex)) continue;
         journal[celex] = unknown;
         const record = byCelex.get(celex);
-        if (record) applyEntry(record, unknown, { confirmed: true });
+        if (record) applyEntry(record, unknown);
       }
 
       stats.fetched += batch.length;
@@ -259,5 +252,7 @@ module.exports = {
   parseEndOfValidity,
   parseInForce,
   readJournal,
+  // Exported for search/in-force-recheck.js, which rewrites the journal to drop
+  // the entries that would otherwise let a re-check answer from disk.
   writeJournal,
 };

--- a/backend/search/in-force-enrich.js
+++ b/backend/search/in-force-enrich.js
@@ -202,12 +202,21 @@ async function enrichRecordsWithInForce(records, options = {}) {
     saveEvery = 5,
     limit = 0,
     log = () => {},
+    // The journal is a resume aid for builders, whose harvests run for hours
+    // and must survive an interruption. A caller that writes its output once at
+    // the end, all-or-nothing, has nothing to resume from and gains nothing but
+    // a rewrite of a 30k-entry file every few batches — see
+    // search/in-force-recheck.js, which passes false.
+    useJournal = true,
     // Seam for tests: the SPARQL round-trip is the one part that can't be
     // exercised offline.
     runQueryFn = runQuery,
   } = options;
 
-  const journal = readJournal(journalPath);
+  const journal = useJournal ? readJournal(journalPath) : {};
+  const saveJournal = () => {
+    if (useJournal) writeJournal(journalPath, journal);
+  };
   const stats = { targeted: 0, fromJournal: 0, fetched: 0, withStatus: 0, inForce: 0, alreadyPresent: 0 };
 
   const applyEntry = (record, entry) => {
@@ -274,12 +283,12 @@ async function enrichRecordsWithInForce(records, options = {}) {
       batches += 1;
       log(`batch ${batches} (${batch.length} records, ${found.size} with status) — ${Math.min(offset + batch.length, targets.length)}/${targets.length}`);
 
-      if (batches % saveEvery === 0) writeJournal(journalPath, journal);
+      if (batches % saveEvery === 0) saveJournal();
     }
   } finally {
     // Persist whatever the run gathered even if a batch threw, so the next
     // attempt resumes from here rather than from zero.
-    writeJournal(journalPath, journal);
+    saveJournal();
   }
 
   return stats;
@@ -294,7 +303,4 @@ module.exports = {
   parseInForce,
   readJournal,
   reduceBindings,
-  // Exported for search/in-force-recheck.js, which rewrites the journal to drop
-  // the entries that would otherwise let a re-check answer from disk.
-  writeJournal,
 };

--- a/backend/search/in-force-enrich.js
+++ b/backend/search/in-force-enrich.js
@@ -76,23 +76,70 @@ function buildQuery(celexBatch) {
   // The ^^xsd:string typing on VALUES is load-bearing — see the long note in
   // eurovoc-enrich.js buildQuery(). Same endpoint, same join, same trap.
   //
-  // Both properties are OPTIONAL so an act that has one but not the other still
-  // returns a row. The aggregates collapse any residual fan-out to one row per
-  // CELEX; both fields are single-valued in practice, so which one SAMPLE picks
-  // never matters.
+  // Deliberately NOT aggregated. This query used to end in
+  //
+  //   SELECT ?celex (SAMPLE(?inForceValue) AS ?inForce) (MIN(?endValue) AS ?endOfValidity)
+  //   ... GROUP BY ?celex
+  //
+  // which collapsed fan-out server-side, and mis-assigned values across groups
+  // at batch scale. Reproduced against Cellar with a real 100-CELEX batch:
+  // 32006R0988 genuinely carries end-of-validity 2020-12-31 and 32006R1066
+  // carries the 9999-12-31 sentinel, yet the aggregated query returned
+  // 2020-12-31 for *both*. Queried alone, or with this same batch unaggregated,
+  // 32006R1066 correctly returns the sentinel. The wrong value is stable for a
+  // given batch and changes when the batch composition changes, so it does not
+  // look like a fluke and cannot be retried away — it silently writes another
+  // act's expiry date onto a record.
+  //
+  // So: project the raw rows and collapse them in reduceBindings() below, where
+  // the grouping is ours and deterministic. Both properties stay OPTIONAL so an
+  // act with one but not the other still returns a row, and residual fan-out
+  // (a handful of acts per batch) costs a few extra rows rather than a wrong
+  // answer.
   const values = celexBatch.map((c) => `"${c}"^^xsd:string`).join(" ");
   return `
 PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-SELECT ?celex (SAMPLE(?inForceValue) AS ?inForce) (MIN(?endValue) AS ?endOfValidity)
+SELECT ?celex ?inForceValue ?endValue
 WHERE {
   VALUES ?celex { ${values} }
   ?work cdm:resource_legal_id_celex ?celex .
   OPTIONAL { ?work cdm:resource_legal_in-force ?inForceValue }
   OPTIONAL { ?work cdm:resource_legal_date_end-of-validity ?endValue }
 }
-GROUP BY ?celex
 `.trim();
+}
+
+// Collapses the unaggregated rows to one entry per CELEX — the job GROUP BY
+// used to do, done where it can be trusted and unit-tested.
+//
+// `inForce` takes the first non-null value across the act's rows (it is
+// single-valued in practice, so this is SAMPLE without the cross-group leak).
+// `endOfValidity` takes the earliest real date, with the 9999-12-31 sentinel
+// and unparseable values already filtered out by parseEndOfValidity — so an act
+// whose only date is the sentinel correctly reduces to null rather than
+// inheriting a neighbour's.
+function reduceBindings(bindings) {
+  const byCelex = new Map();
+  for (const binding of bindings || []) {
+    const celex = binding.celex?.value;
+    if (!celex) continue;
+
+    let entry = byCelex.get(celex);
+    if (!entry) {
+      entry = { inForce: null, endOfValidity: null };
+      byCelex.set(celex, entry);
+    }
+
+    if (entry.inForce === null) {
+      entry.inForce = parseInForce(binding.inForceValue?.value);
+    }
+    const end = parseEndOfValidity(binding.endValue?.value);
+    if (end !== null && (entry.endOfValidity === null || end < entry.endOfValidity)) {
+      entry.endOfValidity = end;
+    }
+  }
+  return byCelex;
 }
 
 async function runQuery(query, log, attempt = 1) {
@@ -205,14 +252,8 @@ async function enrichRecordsWithInForce(records, options = {}) {
       const data = await runQueryFn(buildQuery(batch), log);
 
       const found = new Set();
-      for (const binding of data?.results?.bindings || []) {
-        const celex = binding.celex?.value;
-        if (!celex) continue;
+      for (const [celex, entry] of reduceBindings(data?.results?.bindings)) {
         found.add(celex);
-        const entry = {
-          inForce: parseInForce(binding.inForce?.value),
-          endOfValidity: parseEndOfValidity(binding.endOfValidity?.value),
-        };
         journal[celex] = entry;
         const record = byCelex.get(celex);
         if (record) applyEntry(record, entry);
@@ -252,6 +293,7 @@ module.exports = {
   parseEndOfValidity,
   parseInForce,
   readJournal,
+  reduceBindings,
   // Exported for search/in-force-recheck.js, which rewrites the journal to drop
   // the entries that would otherwise let a re-check answer from disk.
   writeJournal,

--- a/backend/search/in-force-enrich.js
+++ b/backend/search/in-force-enrich.js
@@ -162,10 +162,17 @@ async function enrichRecordsWithInForce(records, options = {}) {
 
   const journal = readJournal(journalPath);
   const stats = { targeted: 0, fromJournal: 0, fetched: 0, withStatus: 0, inForce: 0, alreadyPresent: 0 };
+  // Stamped only when this call actually asked Cellar (the found/unknown
+  // branches below) — reused from the journal is replaying a prior
+  // confirmation, not a fresh one, so it is deliberately left unstamped. This
+  // is what search/in-force-recheck.js (issue #167) reads to pick its rotating
+  // slice: a record with no stamp, or the oldest stamp, is the most overdue.
+  const checkedAt = new Date().toISOString();
 
-  const applyEntry = (record, entry) => {
+  const applyEntry = (record, entry, { confirmed = false } = {}) => {
     record.inForce = entry.inForce ?? null;
     record.endOfValidity = entry.endOfValidity ?? null;
+    if (confirmed) record.statusCheckedAt = checkedAt;
     if (record.inForce !== null) {
       stats.withStatus += 1;
       if (record.inForce) stats.inForce += 1;
@@ -215,7 +222,7 @@ async function enrichRecordsWithInForce(records, options = {}) {
         };
         journal[celex] = entry;
         const record = byCelex.get(celex);
-        if (record) applyEntry(record, entry);
+        if (record) applyEntry(record, entry, { confirmed: true });
       }
 
       // An act Cellar has no status for is journaled as unknown so a rerun skips
@@ -226,7 +233,7 @@ async function enrichRecordsWithInForce(records, options = {}) {
         if (found.has(celex)) continue;
         journal[celex] = unknown;
         const record = byCelex.get(celex);
-        if (record) applyEntry(record, unknown);
+        if (record) applyEntry(record, unknown, { confirmed: true });
       }
 
       stats.fetched += batch.length;
@@ -252,4 +259,5 @@ module.exports = {
   parseEndOfValidity,
   parseInForce,
   readJournal,
+  writeJournal,
 };

--- a/backend/search/in-force-enrich.test.js
+++ b/backend/search/in-force-enrich.test.js
@@ -235,3 +235,30 @@ test("reduceBindings ignores rows without a celex", () => {
   assert.equal(reduceBindings([{ inForceValue: { value: "1" } }]).size, 0);
   assert.equal(reduceBindings(undefined).size, 0);
 });
+
+// The re-check writes its cache once at the end, so it has nothing to resume
+// from; journalling would only rewrite a 30k-entry file every few batches.
+test("enrich with useJournal false neither reads nor writes the journal", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "in-force-nojournal-"));
+  const journalPath = path.join(dir, "in-force.json");
+  fs.writeFileSync(journalPath, JSON.stringify({ A: { inForce: false, endOfValidity: null } }), "utf8");
+
+  const records = [{ celex: "A" }];
+  const stats = await enrichRecordsWithInForce(records, {
+    journalPath,
+    useJournal: false,
+    runQueryFn: async () => ({
+      results: { bindings: [{ celex: { value: "A" }, inForceValue: { value: "1" } }] },
+    }),
+  });
+
+  // The on-disk answer was ignored in favour of a fresh query...
+  assert.equal(stats.fromJournal, 0);
+  assert.equal(stats.fetched, 1);
+  assert.equal(records[0].inForce, true);
+  // ...and the file is left exactly as it was.
+  assert.deepEqual(
+    JSON.parse(fs.readFileSync(journalPath, "utf8")),
+    { A: { inForce: false, endOfValidity: null } },
+  );
+});

--- a/backend/search/in-force-enrich.test.js
+++ b/backend/search/in-force-enrich.test.js
@@ -6,6 +6,7 @@ const path = require("node:path");
 
 const {
   buildQuery,
+  reduceBindings,
   enrichRecordsWithInForce,
   parseEndOfValidity,
   parseInForce,
@@ -26,11 +27,21 @@ function bindings(rows) {
 // Cellar only joins VALUES against explicitly-typed xsd:string literals; a bare
 // "..." silently returns nothing. Guard the typing so a refactor can't quietly
 // turn every batch into an empty result.
-test("buildQuery types CELEX values as xsd:string and aggregates per CELEX", () => {
+test("buildQuery types CELEX values as xsd:string", () => {
   const query = buildQuery(["32016R0679", "31995L0046"]);
   assert.match(query, /"32016R0679"\^\^xsd:string/);
   assert.match(query, /"31995L0046"\^\^xsd:string/);
-  assert.match(query, /GROUP BY \?celex/);
+});
+
+// Cellar's aggregation mis-assigns values across groups at batch scale (a real
+// 100-CELEX batch returned 32006R0988's end-of-validity for 32006R1066 as well).
+// The rows must come back raw and be collapsed by reduceBindings instead.
+test("buildQuery does not aggregate server-side", () => {
+  const query = buildQuery(["32016R0679"]);
+  assert.doesNotMatch(query, /GROUP BY/);
+  assert.doesNotMatch(query, /SAMPLE\(/);
+  assert.doesNotMatch(query, /MIN\(/);
+  assert.match(query, /SELECT \?celex \?inForceValue \?endValue/);
 });
 
 // entry-into-force is multi-valued (the GDPR has two), so joining it fans each
@@ -100,8 +111,8 @@ test("enrich writes status from a SPARQL response and journals it", async () => 
   const stats = await enrichRecordsWithInForce(records, {
     journalPath,
     runQueryFn: async () => bindings([
-      { celex: { value: "32016R0679" }, inForce: { value: "1" }, endOfValidity: { value: "9999-12-31" } },
-      { celex: { value: "31995L0046" }, inForce: { value: "0" }, endOfValidity: { value: "2018-05-24" } },
+      { celex: { value: "32016R0679" }, inForceValue: { value: "1" }, endValue: { value: "9999-12-31" } },
+      { celex: { value: "31995L0046" }, inForceValue: { value: "0" }, endValue: { value: "2018-05-24" } },
     ]),
   });
 
@@ -162,7 +173,7 @@ test("enrich honours --limit for smoke tests", async () => {
     limit: 1,
     runQueryFn: async () => {
       queries += 1;
-      return bindings([{ celex: { value: "32016R0679" }, inForce: { value: "1" } }]);
+      return bindings([{ celex: { value: "32016R0679" }, inForceValue: { value: "1" } }]);
     },
   });
 
@@ -186,11 +197,41 @@ test("enrich flushes the journal even when a batch throws", async () => {
         calls += 1;
         if (calls > 1) throw new Error("Cellar down");
         const celex = query.match(/"(3202\dR000\d)"/)[1];
-        return bindings([{ celex: { value: celex }, inForce: { value: "1" } }]);
+        return bindings([{ celex: { value: celex }, inForceValue: { value: "1" } }]);
       },
     }),
     /Cellar down/,
   );
 
   assert.equal(Object.keys(readJournal(journalPath)).length, 100);
+});
+
+test("reduceBindings collapses fan-out to one entry per CELEX", () => {
+  const reduced = reduceBindings([
+    { celex: { value: "A" }, inForceValue: { value: "1" }, endValue: { value: "2030-01-01" } },
+    { celex: { value: "A" }, inForceValue: { value: "1" }, endValue: { value: "2027-06-30" } },
+    { celex: { value: "B" }, inForceValue: { value: "0" } },
+  ]);
+
+  assert.equal(reduced.size, 2);
+  // Earliest real end-of-validity wins, as MIN() used to do.
+  assert.deepEqual(reduced.get("A"), { inForce: true, endOfValidity: "2027-06-30" });
+  assert.deepEqual(reduced.get("B"), { inForce: false, endOfValidity: null });
+});
+
+// The exact shape that made the aggregated query leak: an act whose only date is
+// the sentinel must reduce to null, never to a value from another row.
+test("reduceBindings keeps a sentinel-only act null and never borrows another act's date", () => {
+  const reduced = reduceBindings([
+    { celex: { value: "32006R0988" }, inForceValue: { value: "1" }, endValue: { value: "2020-12-31" } },
+    { celex: { value: "32006R1066" }, inForceValue: { value: "1" }, endValue: { value: "9999-12-31" } },
+  ]);
+
+  assert.deepEqual(reduced.get("32006R0988"), { inForce: true, endOfValidity: "2020-12-31" });
+  assert.deepEqual(reduced.get("32006R1066"), { inForce: true, endOfValidity: null });
+});
+
+test("reduceBindings ignores rows without a celex", () => {
+  assert.equal(reduceBindings([{ inForceValue: { value: "1" } }]).size, 0);
+  assert.equal(reduceBindings(undefined).size, 0);
 });

--- a/backend/search/in-force-recheck.js
+++ b/backend/search/in-force-recheck.js
@@ -1,37 +1,34 @@
 "use strict";
 
-// Periodic in-force RE-check (issue #167).
+// Periodic in-force re-check (issue #167).
 //
 // in-force-enrich.js only ever fills a *gap*: it skips any record that already
-// carries `inForce`, and separately skips any celex already answered in
-// data/in-force.json. Every record restored from the published search cache
-// carries the field, and the journal survives every rebuild, so in practice no
-// act's status is ever re-asked after its first harvest — a repealed act keeps
-// reading `inForce: true` forever.
+// carries `inForce`. Every record restored from the published search cache
+// carries it, so no act's status is ever re-asked after its first harvest — a
+// repealed act keeps reading `inForce: true` forever.
 //
-// This module defeats both skips: it clears `inForce` / `endOfValidity` on the
-// records it is re-checking AND drops their journal entries, then hands them to
-// enrichRecordsWithInForce, which then has no choice but to ask Cellar again.
-//
-// Scope: everything NOT already known to be out of force. `inForce: false` is
-// effectively terminal — an act that has fallen out of force does not come back
-// — so re-asking those 50k records buys nothing. What is left is small enough to
-// sweep whole on every run:
+// This tool clears the field and asks Cellar again. It re-checks everything NOT
+// already known to be out of force: `inForce: false` is effectively terminal —
+// an act that has fallen out of force does not come back — and that is 50,393
+// of the 80,469 acts in data-v11. What is left is small enough to sweep whole
+// on every run:
 //
 //   inForce: true    19,588   can be repealed or expire     -> swept
 //   inForce: null    10,488   Cellar had no status yet      -> swept (may gain one)
 //   inForce: false   50,393   terminal                      -> skipped (--all to include)
 //
 // ~30k records is ~301 SPARQL batches at 100 ids each, measured at 200-400ms per
-// batch against Cellar — about two minutes. There is deliberately no rotation,
-// batch budget or turnover cycle: at this cost, a partial re-check would only
-// buy staleness back. `--all` re-checks the out-of-force records too, for the
-// rare case (annulment, corrigendum) where one is restored.
+// batch against Cellar: about two minutes, most of it spent parsing and
+// re-serialising the cache rather than on the network. There is deliberately no
+// slicing, batch budget or turnover cycle — at this cost, a partial re-check
+// would only buy staleness back.
 //
-// The cache is rewritten ONLY if a status actually moved. A run that confirms
-// 30k unchanged statuses must leave the file byte-identical, or refresh-data.yml
-// would cut a new data-vN release — and a Docker tag PR — every single month on
-// no substantive change.
+// Nor is there a resume journal. The run is all-or-nothing: it writes the cache
+// once, at the end, only if a status actually moved, so a run that fails
+// partway leaves nothing behind to resume from and is simply re-run. Passing
+// `useJournal: false` also spares ~60 rewrites of a 30k-entry file per run.
+// (The builders that call the same enrichment keep the journal — an interrupted
+// multi-hour harvest genuinely needs to resume.)
 //
 // Usage:
 //   node --max-old-space-size=8192 search/in-force-recheck.js
@@ -41,81 +38,21 @@ const fs = require("fs");
 const zlib = require("zlib");
 
 const { JsonLegalCacheStore } = require("./legal-cache-store");
-const {
-  DEFAULT_JOURNAL_PATH,
-  enrichRecordsWithInForce,
-  readJournal,
-  writeJournal,
-} = require("./in-force-enrich");
+const { enrichRecordsWithInForce } = require("./in-force-enrich");
 
 const LABEL = "in-force-recheck";
 
-// Cellar answering "no status" for a swept record that previously had one is
-// indistinguishable, per record, from a genuine retraction. In bulk it is not:
-// it means the endpoint is degraded but still returning 200s. Refuse to write
-// past this fraction of the slice rather than let a bad afternoon at Cellar
-// erase the status coverage the Docker guard checks for (>80%, currently 87%).
+// Cellar answering "no status" for a re-checked record that previously had one
+// is indistinguishable, per record, from a genuine retraction. In bulk it is
+// not: it means the endpoint is degraded but still returning 200s. Refuse to
+// write past this fraction rather than let a bad afternoon at Cellar erase the
+// status coverage the Docker guard checks for (>80%, currently 87%).
 const DEFAULT_MAX_NULL_RATIO = 0.05;
-
-function todayIso() {
-  return new Date().toISOString().slice(0, 10);
-}
-
-function isExpiredButInForce(record, today) {
-  return record.inForce === true
-    && typeof record.endOfValidity === "string"
-    && record.endOfValidity < today;
-}
 
 // `false` is terminal; everything else (true, null, or a record that predates
 // the field entirely) is a status that can still move.
 function isRecheckable(record) {
   return record.inForce !== false;
-}
-
-// Order matters only for a run that dies halfway: the records already known to
-// be wrong — flagged in force past their own end-of-validity — are re-asked
-// first so a partial run still fixes the most confidently stale entries.
-// `limit` exists for smoke tests; a real run is unbounded by design.
-function selectRecheckSlice(records, options = {}) {
-  const { today = todayIso(), all = false, limit = 0 } = options;
-  const eligible = records.filter((record) => record.celex && (all || isRecheckable(record)));
-
-  const expired = [];
-  const rest = [];
-  for (const record of eligible) {
-    (isExpiredButInForce(record, today) ? expired : rest).push(record);
-  }
-  const ordered = expired.concat(rest);
-
-  return limit > 0 ? ordered.slice(0, limit) : ordered;
-}
-
-// Defeats both in-force-enrich.js skips for exactly this slice: the in-memory
-// field guard (`record.inForce !== undefined`) and the on-disk journal entry
-// keyed by celex. Mutates `slice` members in place and rewrites the journal
-// file with the slice's entries removed; everything else in the journal (and
-// every record outside the slice) is left alone.
-//
-// Deleting the two fields and letting enrichment re-add them re-appends them at
-// the end of each record object. That is where they already are in the
-// published cache (verified: 80,469/80,469 records carry inForce/endOfValidity
-// as their last two keys, because enrichment is what appended them), so key
-// order — and therefore the serialised bytes of an unchanged record — survives
-// the round trip.
-function primeSliceForRecheck(slice, journalPath) {
-  const journal = readJournal(journalPath);
-  let journalEntriesDropped = 0;
-  for (const record of slice) {
-    delete record.inForce;
-    delete record.endOfValidity;
-    if (Object.prototype.hasOwnProperty.call(journal, record.celex)) {
-      delete journal[record.celex];
-      journalEntriesDropped += 1;
-    }
-  }
-  writeJournal(journalPath, journal);
-  return { journalEntriesDropped };
 }
 
 function classifyFlip(before, after) {
@@ -137,31 +74,34 @@ function lostStatus(before, after) {
   return (before.inForce === true || before.inForce === false) && after.inForce === null;
 }
 
-// Orchestrates one recheck run over `records` (mutated in place, same contract
-// as enrichRecordsWithInForce). Reports what was re-queried, what actually
-// changed, and — separately — the flips, because a re-check that silently stops
+// Orchestrates one re-check over `records` (mutated in place, same contract as
+// enrichRecordsWithInForce). Reports what was re-queried, what actually changed,
+// and — separately — the flips, because a re-check that silently stops
 // re-checking looks identical to a quiet month unless flips are counted apart
 // from work done.
+//
+// `limit` is applied when choosing the targets, never passed down to the
+// enrichment: clearing a record the enrichment then declines to refill would
+// leave it with no `inForce` key at all, which is exactly what the Docker guard
+// fails the build over.
 async function runRecheck(records, options = {}) {
-  const {
-    journalPath = DEFAULT_JOURNAL_PATH,
-    all = false,
-    limit = 0,
-    today = todayIso(),
-    log = () => {},
-    runQueryFn,
-  } = options;
+  const { all = false, limit = 0, log = () => {}, runQueryFn } = options;
 
-  const slice = selectRecheckSlice(records, { today, all, limit });
+  const eligible = records.filter((record) => record.celex && (all || isRecheckable(record)));
+  const targets = limit > 0 ? eligible.slice(0, limit) : eligible;
+
   const before = new Map(
-    slice.map((record) => [record.celex, { inForce: record.inForce, endOfValidity: record.endOfValidity }]),
+    targets.map((record) => [record.celex, { inForce: record.inForce, endOfValidity: record.endOfValidity }]),
   );
+  // Defeats the enrichment's "already knows this one" skip.
+  for (const record of targets) {
+    delete record.inForce;
+    delete record.endOfValidity;
+  }
+  log(`re-checking ${targets.length} records (all=${all})`);
 
-  const { journalEntriesDropped } = primeSliceForRecheck(slice, journalPath);
-  log(`slice=${slice.length} all=${all} journalEntriesDropped=${journalEntriesDropped}`);
-
-  const enrichStats = await enrichRecordsWithInForce(slice, {
-    journalPath,
+  const enrichStats = await enrichRecordsWithInForce(targets, {
+    useJournal: false,
     log,
     ...(runQueryFn ? { runQueryFn } : {}),
   });
@@ -170,7 +110,7 @@ async function runRecheck(records, options = {}) {
   let flippedToInForce = 0;
   let changed = 0;
   let lostStatusCount = 0;
-  for (const record of slice) {
+  for (const record of targets) {
     const prev = before.get(record.celex);
     const flip = classifyFlip(prev, record);
     if (flip === "toRepealed") flippedToRepealed += 1;
@@ -180,8 +120,7 @@ async function runRecheck(records, options = {}) {
   }
 
   return {
-    sliceSize: slice.length,
-    journalEntriesDropped,
+    rechecked: targets.length,
     requeried: enrichStats.fetched,
     changed,
     lostStatus: lostStatusCount,
@@ -192,15 +131,15 @@ async function runRecheck(records, options = {}) {
   };
 }
 
-// Throws when too much of the slice lost a previously-known status at once.
-// Bounded by the slice, not the whole cache, so it stays meaningful under
-// --limit as well as on a full sweep.
+// Throws when too much of the run lost a previously known status at once.
+// Bounded by what was re-checked, not by the whole cache, so it stays
+// meaningful under --limit as well as on a full sweep.
 function assertStatusNotDegraded(result, maxNullRatio = DEFAULT_MAX_NULL_RATIO) {
-  if (result.sliceSize === 0) return 0;
-  const ratio = result.lostStatus / result.sliceSize;
+  if (result.rechecked === 0) return 0;
+  const ratio = result.lostStatus / result.rechecked;
   if (ratio > maxNullRatio) {
     throw new Error(
-      `refusing to write: ${result.lostStatus}/${result.sliceSize} re-checked records `
+      `refusing to write: ${result.lostStatus}/${result.rechecked} re-checked records `
       + `(${(ratio * 100).toFixed(1)}%) lost a previously known status, above the `
       + `${(maxNullRatio * 100).toFixed(1)}% threshold. Cellar is answering but degraded; `
       + "re-run rather than publish this.",
@@ -302,8 +241,8 @@ async function main() {
   });
 
   console.log(
-    `[${LABEL}] re-checked ${result.sliceSize} records`
-    + ` (${result.journalEntriesDropped} journal entries dropped, ${result.requeried} re-queried against Cellar)`,
+    `[${LABEL}] re-checked ${result.rechecked} records`
+    + ` (${result.requeried} re-queried against Cellar)`,
   );
   console.log(
     `[${LABEL}] status flips: ${result.flipped} total`
@@ -341,9 +280,6 @@ module.exports = {
   assertStatusNotDegraded,
   classifyFlip,
   hasChanged,
-  isExpiredButInForce,
   isRecheckable,
-  primeSliceForRecheck,
   runRecheck,
-  selectRecheckSlice,
 };

--- a/backend/search/in-force-recheck.js
+++ b/backend/search/in-force-recheck.js
@@ -1,0 +1,286 @@
+"use strict";
+
+// Periodic in-force RE-check (issue #167).
+//
+// in-force-enrich.js only ever fills a *gap*: it skips any record that already
+// carries `inForce`, and separately skips any celex already answered in
+// data/in-force.json. Every record restored from the published search cache
+// carries the field, and the journal survives every rebuild, so in practice no
+// act's status is ever re-asked after its first harvest — a repealed act keeps
+// reading `inForce: true` forever.
+//
+// This module defeats both skips for a bounded slice only: it clears
+// `inForce` / `endOfValidity` on the slice's records AND drops the matching
+// journal entries, then hands the slice to enrichRecordsWithInForce, which
+// then has no choice but to ask Cellar again. Everything outside the slice is
+// untouched — this is not a rebuild and not a sweep.
+//
+// Slice selection (in priority order):
+//   1. Records whose `endOfValidity` has already passed but which still read
+//      `inForce: true` — these are known-wrong regardless of when they were
+//      last checked, so they always make the slice first.
+//   2. A rotating age-based fill, oldest `statusCheckedAt` first (a record
+//      that predates the field sorts as infinitely stale), up to --batch-size.
+// That rotation is what gives the cache a known, stated turnover cycle: at
+// batch-size B against N eligible records, a full sweep takes ceil(N / B) runs.
+//
+// Not invoked by any workflow — the scheduling decision is a human's. Proposed
+// invocation (NOT wired here, see the PR description):
+//   node search/in-force-recheck.js --batch-size 2000 --cycle-days 30
+//
+// Usage:
+//   node search/in-force-recheck.js [--batch-size N] [--cycle-days N]
+//     [--cache-path path] [--sweep]
+//   --sweep treats the whole cache as the slice (explicit opt-in only — an
+//   ~80k-act corpus must not be re-queried by default).
+
+const fs = require("fs");
+const zlib = require("zlib");
+
+const { JsonLegalCacheStore } = require("./legal-cache-store");
+const {
+  DEFAULT_JOURNAL_PATH,
+  enrichRecordsWithInForce,
+  readJournal,
+  writeJournal,
+} = require("./in-force-enrich");
+
+const LABEL = "in-force-recheck";
+const DEFAULT_BATCH_SIZE = 2000;
+const DEFAULT_CYCLE_DAYS = 30;
+
+function todayIso() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function isExpiredButInForce(record, today) {
+  return record.inForce === true
+    && typeof record.endOfValidity === "string"
+    && record.endOfValidity < today;
+}
+
+// Missing or unparseable statusCheckedAt sorts as "oldest": a record that
+// predates the field is at least as overdue as one checked at the dawn of time.
+function statusAgeKey(record) {
+  const parsed = record.statusCheckedAt ? Date.parse(record.statusCheckedAt) : NaN;
+  return Number.isNaN(parsed) ? -Infinity : parsed;
+}
+
+// Priority 1 (expired-but-in-force) always makes the slice, even if it alone
+// exceeds batchSize — these are the cheapest, most confidently wrong records
+// in the cache and should never be starved by the rotation. Priority 2 fills
+// whatever budget is left, oldest-checked first.
+function selectRecheckSlice(records, options = {}) {
+  const { batchSize = DEFAULT_BATCH_SIZE, today = todayIso(), sweep = false } = options;
+  const eligible = records.filter((record) => record.celex);
+
+  if (sweep) return eligible.slice();
+
+  const expired = eligible.filter((record) => isExpiredButInForce(record, today));
+  const expiredCelex = new Set(expired.map((record) => record.celex));
+
+  const remaining = Math.max(0, batchSize - expired.length);
+  const rotationPool = eligible
+    .filter((record) => !expiredCelex.has(record.celex))
+    .sort((a, b) => statusAgeKey(a) - statusAgeKey(b));
+
+  return expired.concat(rotationPool.slice(0, remaining));
+}
+
+// Defeats both in-force-enrich.js skips for exactly this slice: the in-memory
+// field guard (`record.inForce !== undefined`) and the on-disk journal entry
+// keyed by celex. Mutates `slice` members in place and rewrites the journal
+// file with the slice's entries removed; everything else in the journal (and
+// every record outside the slice) is left alone.
+function primeSliceForRecheck(slice, journalPath) {
+  const journal = readJournal(journalPath);
+  let journalEntriesDropped = 0;
+  for (const record of slice) {
+    delete record.inForce;
+    delete record.endOfValidity;
+    if (Object.prototype.hasOwnProperty.call(journal, record.celex)) {
+      delete journal[record.celex];
+      journalEntriesDropped += 1;
+    }
+  }
+  writeJournal(journalPath, journal);
+  return { journalEntriesDropped };
+}
+
+function classifyFlip(before, after) {
+  if (before.inForce === true && after.inForce === false) return "toRepealed";
+  if (before.inForce === false && after.inForce === true) return "toInForce";
+  return null;
+}
+
+// Orchestrates one bounded recheck run over `records` (mutated in place, same
+// contract as enrichRecordsWithInForce). Returns how many records were
+// touched, how many were actually re-queried (vs. answered from a still-valid
+// journal entry for some *other* celex — should be ~0 for the slice since we
+// just dropped its own entries), and — the number that matters for catching a
+// silent no-op regression — how many statuses actually flipped.
+async function runRecheck(records, options = {}) {
+  const {
+    journalPath = DEFAULT_JOURNAL_PATH,
+    batchSize = DEFAULT_BATCH_SIZE,
+    sweep = false,
+    today = todayIso(),
+    log = () => {},
+    runQueryFn,
+  } = options;
+
+  const slice = selectRecheckSlice(records, { batchSize, today, sweep });
+  const before = new Map(
+    slice.map((record) => [record.celex, { inForce: record.inForce, endOfValidity: record.endOfValidity }]),
+  );
+
+  const { journalEntriesDropped } = primeSliceForRecheck(slice, journalPath);
+  log(`slice=${slice.length} sweep=${sweep} journalEntriesDropped=${journalEntriesDropped}`);
+
+  const enrichStats = await enrichRecordsWithInForce(slice, {
+    journalPath,
+    log,
+    ...(runQueryFn ? { runQueryFn } : {}),
+  });
+
+  let flippedToRepealed = 0;
+  let flippedToInForce = 0;
+  for (const record of slice) {
+    const prev = before.get(record.celex);
+    const flip = classifyFlip(prev, record);
+    if (flip === "toRepealed") flippedToRepealed += 1;
+    else if (flip === "toInForce") flippedToInForce += 1;
+  }
+
+  return {
+    sliceSize: slice.length,
+    journalEntriesDropped,
+    requeried: enrichStats.fetched,
+    flippedToRepealed,
+    flippedToInForce,
+    flipped: flippedToRepealed + flippedToInForce,
+    enrichStats,
+  };
+}
+
+function parseArgs(argv) {
+  const options = {
+    cachePath: undefined,
+    batchSize: DEFAULT_BATCH_SIZE,
+    cycleDays: DEFAULT_CYCLE_DAYS,
+    sweep: false,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--batch-size" && argv[index + 1]) {
+      options.batchSize = Number.parseInt(argv[++index], 10) || DEFAULT_BATCH_SIZE;
+    } else if (token === "--cycle-days" && argv[index + 1]) {
+      options.cycleDays = Number.parseInt(argv[++index], 10) || DEFAULT_CYCLE_DAYS;
+    } else if (token === "--cache-path" && argv[index + 1]) {
+      options.cachePath = argv[++index];
+    } else if (token === "--sweep") {
+      options.sweep = true;
+    }
+  }
+  return options;
+}
+
+// store.payload.records are the untouched parsed records — see the identical
+// note in fetch-in-force.js. Writing the payload back keeps every other field
+// (date, eurovoc, excerpt, ...) byte-for-byte as the builder wrote it.
+function writeCache(store) {
+  const json = `${JSON.stringify(store.payload)}\n`;
+  const cachePath = store.cachePath;
+  const gzPath = `${cachePath}.gz`;
+
+  const tempJson = `${cachePath}.${process.pid}.tmp`;
+  fs.writeFileSync(tempJson, json, "utf8");
+  fs.renameSync(tempJson, cachePath);
+
+  const tempGz = `${gzPath}.${process.pid}.tmp`;
+  fs.writeFileSync(tempGz, zlib.gzipSync(Buffer.from(json, "utf8")));
+  fs.renameSync(tempGz, gzPath);
+
+  return { cachePath, gzPath };
+}
+
+// Same regression guard as fetch-in-force.js: this tool only ever touches
+// inForce/endOfValidity/statusCheckedAt on a slice, so date/eurovoc coverage
+// must never move. A drop means this ran against the wrong cache.
+function assertEnrichmentIntact(records, before) {
+  const dated = records.filter((r) => r.date).length;
+  const topiced = records.filter((r) => Array.isArray(r.eurovoc)).length;
+  if (dated < before.dated || topiced < before.topiced) {
+    throw new Error(
+      `refusing to write: enrichment regressed (dates ${before.dated} -> ${dated}, `
+      + `eurovoc ${before.topiced} -> ${topiced}). The cache this ran against is not the enriched one.`,
+    );
+  }
+  return { dated, topiced };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+
+  const store = new JsonLegalCacheStore(options.cachePath, { preferJson: true });
+  if (!store.load()) {
+    throw new Error(`Failed to load search cache: ${store.loadError}`);
+  }
+
+  const records = store.payload.records;
+  const before = {
+    dated: records.filter((r) => r.date).length,
+    topiced: records.filter((r) => Array.isArray(r.eurovoc)).length,
+  };
+  console.log(`[${LABEL}] loaded ${records.length} records from ${store.cachePath}`);
+  if (options.sweep) {
+    console.log(`[${LABEL}] --sweep: treating the ENTIRE cache as the slice, ignoring --batch-size`);
+  } else {
+    console.log(`[${LABEL}] batch-size=${options.batchSize} cycle-days=${options.cycleDays}`
+      + ` (at this batch size, a full rotation takes ceil(eligible / batch-size) runs,`
+      + ` i.e. roughly every ${options.cycleDays} x ceil(eligible / batch-size) days if run on that cadence)`);
+  }
+
+  const result = await runRecheck(records, {
+    batchSize: options.batchSize,
+    sweep: options.sweep,
+    log: (message) => console.log(`[${LABEL}] ${message}`),
+  });
+
+  console.log(
+    `[${LABEL}] rechecked ${result.sliceSize} records`
+    + ` (${result.journalEntriesDropped} journal entries dropped, ${result.requeried} re-queried against Cellar)`,
+  );
+  console.log(
+    `[${LABEL}] status flips: ${result.flipped} total`
+    + ` (${result.flippedToRepealed} in-force -> repealed, ${result.flippedToInForce} repealed -> in-force)`,
+  );
+  if (result.flipped === 0 && result.requeried > 0) {
+    console.log(`[${LABEL}] note: 0 flips out of ${result.requeried} re-queried records is expected on most runs — status rarely changes day to day.`);
+  }
+
+  const after = assertEnrichmentIntact(records, before);
+  console.log(`[${LABEL}] enrichment intact: ${after.dated} dated, ${after.topiced} with topics`);
+
+  const { cachePath, gzPath } = writeCache(store);
+  console.log(`[${LABEL}] wrote ${cachePath} and ${gzPath}`);
+  console.log(`[${LABEL}] next: publish the .gz as the data-vN release asset and bump DATA_RELEASE_TAG in backend/Dockerfile`);
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`[${LABEL}] fatal:`, error.message);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_CYCLE_DAYS,
+  classifyFlip,
+  isExpiredButInForce,
+  primeSliceForRecheck,
+  runRecheck,
+  selectRecheckSlice,
+  statusAgeKey,
+};

--- a/backend/search/in-force-recheck.js
+++ b/backend/search/in-force-recheck.js
@@ -9,30 +9,33 @@
 // act's status is ever re-asked after its first harvest — a repealed act keeps
 // reading `inForce: true` forever.
 //
-// This module defeats both skips for a bounded slice only: it clears
-// `inForce` / `endOfValidity` on the slice's records AND drops the matching
-// journal entries, then hands the slice to enrichRecordsWithInForce, which
-// then has no choice but to ask Cellar again. Everything outside the slice is
-// untouched — this is not a rebuild and not a sweep.
+// This module defeats both skips: it clears `inForce` / `endOfValidity` on the
+// records it is re-checking AND drops their journal entries, then hands them to
+// enrichRecordsWithInForce, which then has no choice but to ask Cellar again.
 //
-// Slice selection (in priority order):
-//   1. Records whose `endOfValidity` has already passed but which still read
-//      `inForce: true` — these are known-wrong regardless of when they were
-//      last checked, so they always make the slice first.
-//   2. A rotating age-based fill, oldest `statusCheckedAt` first (a record
-//      that predates the field sorts as infinitely stale), up to --batch-size.
-// That rotation is what gives the cache a known, stated turnover cycle: at
-// batch-size B against N eligible records, a full sweep takes ceil(N / B) runs.
+// Scope: everything NOT already known to be out of force. `inForce: false` is
+// effectively terminal — an act that has fallen out of force does not come back
+// — so re-asking those 50k records buys nothing. What is left is small enough to
+// sweep whole on every run:
 //
-// Not invoked by any workflow — the scheduling decision is a human's. Proposed
-// invocation (NOT wired here, see the PR description):
-//   node search/in-force-recheck.js --batch-size 2000 --cycle-days 30
+//   inForce: true    19,588   can be repealed or expire     -> swept
+//   inForce: null    10,488   Cellar had no status yet      -> swept (may gain one)
+//   inForce: false   50,393   terminal                      -> skipped (--all to include)
+//
+// ~30k records is ~301 SPARQL batches at 100 ids each, measured at 200-400ms per
+// batch against Cellar — about two minutes. There is deliberately no rotation,
+// batch budget or turnover cycle: at this cost, a partial re-check would only
+// buy staleness back. `--all` re-checks the out-of-force records too, for the
+// rare case (annulment, corrigendum) where one is restored.
+//
+// The cache is rewritten ONLY if a status actually moved. A run that confirms
+// 30k unchanged statuses must leave the file byte-identical, or refresh-data.yml
+// would cut a new data-vN release — and a Docker tag PR — every single month on
+// no substantive change.
 //
 // Usage:
-//   node search/in-force-recheck.js [--batch-size N] [--cycle-days N]
-//     [--cache-path path] [--sweep]
-//   --sweep treats the whole cache as the slice (explicit opt-in only — an
-//   ~80k-act corpus must not be re-queried by default).
+//   node --max-old-space-size=8192 search/in-force-recheck.js
+//     [--cache-path path] [--all] [--limit N] [--max-null-ratio R] [--no-gz]
 
 const fs = require("fs");
 const zlib = require("zlib");
@@ -46,8 +49,13 @@ const {
 } = require("./in-force-enrich");
 
 const LABEL = "in-force-recheck";
-const DEFAULT_BATCH_SIZE = 2000;
-const DEFAULT_CYCLE_DAYS = 30;
+
+// Cellar answering "no status" for a swept record that previously had one is
+// indistinguishable, per record, from a genuine retraction. In bulk it is not:
+// it means the endpoint is degraded but still returning 200s. Refuse to write
+// past this fraction of the slice rather than let a bad afternoon at Cellar
+// erase the status coverage the Docker guard checks for (>80%, currently 87%).
+const DEFAULT_MAX_NULL_RATIO = 0.05;
 
 function todayIso() {
   return new Date().toISOString().slice(0, 10);
@@ -59,32 +67,28 @@ function isExpiredButInForce(record, today) {
     && record.endOfValidity < today;
 }
 
-// Missing or unparseable statusCheckedAt sorts as "oldest": a record that
-// predates the field is at least as overdue as one checked at the dawn of time.
-function statusAgeKey(record) {
-  const parsed = record.statusCheckedAt ? Date.parse(record.statusCheckedAt) : NaN;
-  return Number.isNaN(parsed) ? -Infinity : parsed;
+// `false` is terminal; everything else (true, null, or a record that predates
+// the field entirely) is a status that can still move.
+function isRecheckable(record) {
+  return record.inForce !== false;
 }
 
-// Priority 1 (expired-but-in-force) always makes the slice, even if it alone
-// exceeds batchSize — these are the cheapest, most confidently wrong records
-// in the cache and should never be starved by the rotation. Priority 2 fills
-// whatever budget is left, oldest-checked first.
+// Order matters only for a run that dies halfway: the records already known to
+// be wrong — flagged in force past their own end-of-validity — are re-asked
+// first so a partial run still fixes the most confidently stale entries.
+// `limit` exists for smoke tests; a real run is unbounded by design.
 function selectRecheckSlice(records, options = {}) {
-  const { batchSize = DEFAULT_BATCH_SIZE, today = todayIso(), sweep = false } = options;
-  const eligible = records.filter((record) => record.celex);
+  const { today = todayIso(), all = false, limit = 0 } = options;
+  const eligible = records.filter((record) => record.celex && (all || isRecheckable(record)));
 
-  if (sweep) return eligible.slice();
+  const expired = [];
+  const rest = [];
+  for (const record of eligible) {
+    (isExpiredButInForce(record, today) ? expired : rest).push(record);
+  }
+  const ordered = expired.concat(rest);
 
-  const expired = eligible.filter((record) => isExpiredButInForce(record, today));
-  const expiredCelex = new Set(expired.map((record) => record.celex));
-
-  const remaining = Math.max(0, batchSize - expired.length);
-  const rotationPool = eligible
-    .filter((record) => !expiredCelex.has(record.celex))
-    .sort((a, b) => statusAgeKey(a) - statusAgeKey(b));
-
-  return expired.concat(rotationPool.slice(0, remaining));
+  return limit > 0 ? ordered.slice(0, limit) : ordered;
 }
 
 // Defeats both in-force-enrich.js skips for exactly this slice: the in-memory
@@ -92,6 +96,13 @@ function selectRecheckSlice(records, options = {}) {
 // keyed by celex. Mutates `slice` members in place and rewrites the journal
 // file with the slice's entries removed; everything else in the journal (and
 // every record outside the slice) is left alone.
+//
+// Deleting the two fields and letting enrichment re-add them re-appends them at
+// the end of each record object. That is where they already are in the
+// published cache (verified: 80,469/80,469 records carry inForce/endOfValidity
+// as their last two keys, because enrichment is what appended them), so key
+// order — and therefore the serialised bytes of an unchanged record — survives
+// the round trip.
 function primeSliceForRecheck(slice, journalPath) {
   const journal = readJournal(journalPath);
   let journalEntriesDropped = 0;
@@ -113,29 +124,41 @@ function classifyFlip(before, after) {
   return null;
 }
 
-// Orchestrates one bounded recheck run over `records` (mutated in place, same
-// contract as enrichRecordsWithInForce). Returns how many records were
-// touched, how many were actually re-queried (vs. answered from a still-valid
-// journal entry for some *other* celex — should be ~0 for the slice since we
-// just dropped its own entries), and — the number that matters for catching a
-// silent no-op regression — how many statuses actually flipped.
+// Any difference in either field, not just a true<->false flip: a status going
+// to or from `null`, or an end-of-validity date being corrected, is a real
+// change to the published data and must be written.
+function hasChanged(before, after) {
+  return before.inForce !== after.inForce || before.endOfValidity !== after.endOfValidity;
+}
+
+// A record that had a decided status and came back without one. Counted apart
+// from ordinary changes because in bulk it means Cellar, not the law, moved.
+function lostStatus(before, after) {
+  return (before.inForce === true || before.inForce === false) && after.inForce === null;
+}
+
+// Orchestrates one recheck run over `records` (mutated in place, same contract
+// as enrichRecordsWithInForce). Reports what was re-queried, what actually
+// changed, and — separately — the flips, because a re-check that silently stops
+// re-checking looks identical to a quiet month unless flips are counted apart
+// from work done.
 async function runRecheck(records, options = {}) {
   const {
     journalPath = DEFAULT_JOURNAL_PATH,
-    batchSize = DEFAULT_BATCH_SIZE,
-    sweep = false,
+    all = false,
+    limit = 0,
     today = todayIso(),
     log = () => {},
     runQueryFn,
   } = options;
 
-  const slice = selectRecheckSlice(records, { batchSize, today, sweep });
+  const slice = selectRecheckSlice(records, { today, all, limit });
   const before = new Map(
     slice.map((record) => [record.celex, { inForce: record.inForce, endOfValidity: record.endOfValidity }]),
   );
 
   const { journalEntriesDropped } = primeSliceForRecheck(slice, journalPath);
-  log(`slice=${slice.length} sweep=${sweep} journalEntriesDropped=${journalEntriesDropped}`);
+  log(`slice=${slice.length} all=${all} journalEntriesDropped=${journalEntriesDropped}`);
 
   const enrichStats = await enrichRecordsWithInForce(slice, {
     journalPath,
@@ -145,17 +168,23 @@ async function runRecheck(records, options = {}) {
 
   let flippedToRepealed = 0;
   let flippedToInForce = 0;
+  let changed = 0;
+  let lostStatusCount = 0;
   for (const record of slice) {
     const prev = before.get(record.celex);
     const flip = classifyFlip(prev, record);
     if (flip === "toRepealed") flippedToRepealed += 1;
     else if (flip === "toInForce") flippedToInForce += 1;
+    if (hasChanged(prev, record)) changed += 1;
+    if (lostStatus(prev, record)) lostStatusCount += 1;
   }
 
   return {
     sliceSize: slice.length,
     journalEntriesDropped,
     requeried: enrichStats.fetched,
+    changed,
+    lostStatus: lostStatusCount,
     flippedToRepealed,
     flippedToInForce,
     flipped: flippedToRepealed + flippedToInForce,
@@ -163,23 +192,44 @@ async function runRecheck(records, options = {}) {
   };
 }
 
+// Throws when too much of the slice lost a previously-known status at once.
+// Bounded by the slice, not the whole cache, so it stays meaningful under
+// --limit as well as on a full sweep.
+function assertStatusNotDegraded(result, maxNullRatio = DEFAULT_MAX_NULL_RATIO) {
+  if (result.sliceSize === 0) return 0;
+  const ratio = result.lostStatus / result.sliceSize;
+  if (ratio > maxNullRatio) {
+    throw new Error(
+      `refusing to write: ${result.lostStatus}/${result.sliceSize} re-checked records `
+      + `(${(ratio * 100).toFixed(1)}%) lost a previously known status, above the `
+      + `${(maxNullRatio * 100).toFixed(1)}% threshold. Cellar is answering but degraded; `
+      + "re-run rather than publish this.",
+    );
+  }
+  return ratio;
+}
+
 function parseArgs(argv) {
   const options = {
     cachePath: undefined,
-    batchSize: DEFAULT_BATCH_SIZE,
-    cycleDays: DEFAULT_CYCLE_DAYS,
-    sweep: false,
+    all: false,
+    limit: 0,
+    maxNullRatio: DEFAULT_MAX_NULL_RATIO,
+    gz: true,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const token = argv[index];
-    if (token === "--batch-size" && argv[index + 1]) {
-      options.batchSize = Number.parseInt(argv[++index], 10) || DEFAULT_BATCH_SIZE;
-    } else if (token === "--cycle-days" && argv[index + 1]) {
-      options.cycleDays = Number.parseInt(argv[++index], 10) || DEFAULT_CYCLE_DAYS;
-    } else if (token === "--cache-path" && argv[index + 1]) {
+    if (token === "--cache-path" && argv[index + 1]) {
       options.cachePath = argv[++index];
-    } else if (token === "--sweep") {
-      options.sweep = true;
+    } else if (token === "--limit" && argv[index + 1]) {
+      options.limit = Number.parseInt(argv[++index], 10) || 0;
+    } else if (token === "--max-null-ratio" && argv[index + 1]) {
+      const parsed = Number.parseFloat(argv[++index]);
+      if (Number.isFinite(parsed)) options.maxNullRatio = parsed;
+    } else if (token === "--all") {
+      options.all = true;
+    } else if (token === "--no-gz") {
+      options.gz = false;
     }
   }
   return options;
@@ -188,15 +238,21 @@ function parseArgs(argv) {
 // store.payload.records are the untouched parsed records — see the identical
 // note in fetch-in-force.js. Writing the payload back keeps every other field
 // (date, eurovoc, excerpt, ...) byte-for-byte as the builder wrote it.
-function writeCache(store) {
+//
+// The .gz sidecar is skippable: refresh-data.yml gzips search-cache.json itself
+// as a later step, so writing it here would be ~50 MB of redundant compression
+// on a runner that also holds the corpus.
+function writeCache(store, { gz = true } = {}) {
   const json = `${JSON.stringify(store.payload)}\n`;
   const cachePath = store.cachePath;
-  const gzPath = `${cachePath}.gz`;
 
   const tempJson = `${cachePath}.${process.pid}.tmp`;
   fs.writeFileSync(tempJson, json, "utf8");
   fs.renameSync(tempJson, cachePath);
 
+  if (!gz) return { cachePath, gzPath: null };
+
+  const gzPath = `${cachePath}.gz`;
   const tempGz = `${gzPath}.${process.pid}.tmp`;
   fs.writeFileSync(tempGz, zlib.gzipSync(Buffer.from(json, "utf8")));
   fs.renameSync(tempGz, gzPath);
@@ -205,8 +261,8 @@ function writeCache(store) {
 }
 
 // Same regression guard as fetch-in-force.js: this tool only ever touches
-// inForce/endOfValidity/statusCheckedAt on a slice, so date/eurovoc coverage
-// must never move. A drop means this ran against the wrong cache.
+// inForce/endOfValidity, so date/eurovoc coverage must never move. A drop means
+// this ran against the wrong cache.
 function assertEnrichmentIntact(records, before) {
   const dated = records.filter((r) => r.date).length;
   const topiced = records.filter((r) => Array.isArray(r.eurovoc)).length;
@@ -232,38 +288,44 @@ async function main() {
     dated: records.filter((r) => r.date).length,
     topiced: records.filter((r) => Array.isArray(r.eurovoc)).length,
   };
+  const outOfForce = records.filter((r) => r.inForce === false).length;
   console.log(`[${LABEL}] loaded ${records.length} records from ${store.cachePath}`);
-  if (options.sweep) {
-    console.log(`[${LABEL}] --sweep: treating the ENTIRE cache as the slice, ignoring --batch-size`);
-  } else {
-    console.log(`[${LABEL}] batch-size=${options.batchSize} cycle-days=${options.cycleDays}`
-      + ` (at this batch size, a full rotation takes ceil(eligible / batch-size) runs,`
-      + ` i.e. roughly every ${options.cycleDays} x ceil(eligible / batch-size) days if run on that cadence)`);
-  }
+  console.log(
+    `[${LABEL}] ${outOfForce} records are already out of force`
+    + `${options.all ? " (re-checked anyway: --all)" : " and are not re-checked"}`,
+  );
 
   const result = await runRecheck(records, {
-    batchSize: options.batchSize,
-    sweep: options.sweep,
+    all: options.all,
+    limit: options.limit,
     log: (message) => console.log(`[${LABEL}] ${message}`),
   });
 
   console.log(
-    `[${LABEL}] rechecked ${result.sliceSize} records`
+    `[${LABEL}] re-checked ${result.sliceSize} records`
     + ` (${result.journalEntriesDropped} journal entries dropped, ${result.requeried} re-queried against Cellar)`,
   );
   console.log(
     `[${LABEL}] status flips: ${result.flipped} total`
-    + ` (${result.flippedToRepealed} in-force -> repealed, ${result.flippedToInForce} repealed -> in-force)`,
+    + ` (${result.flippedToRepealed} in-force -> repealed, ${result.flippedToInForce} repealed -> in-force);`
+    + ` ${result.changed} records changed in all, ${result.lostStatus} lost a known status`,
   );
-  if (result.flipped === 0 && result.requeried > 0) {
-    console.log(`[${LABEL}] note: 0 flips out of ${result.requeried} re-queried records is expected on most runs — status rarely changes day to day.`);
-  }
+
+  const ratio = assertStatusNotDegraded(result, options.maxNullRatio);
+  console.log(`[${LABEL}] status loss ${(ratio * 100).toFixed(2)}% is within the ${(options.maxNullRatio * 100).toFixed(1)}% threshold`);
 
   const after = assertEnrichmentIntact(records, before);
   console.log(`[${LABEL}] enrichment intact: ${after.dated} dated, ${after.topiced} with topics`);
 
-  const { cachePath, gzPath } = writeCache(store);
-  console.log(`[${LABEL}] wrote ${cachePath} and ${gzPath}`);
+  // The no-op short circuit. refresh-data.yml publishes a release iff the cache
+  // bytes changed, so confirming 30k unchanged statuses must not touch the file.
+  if (result.changed === 0) {
+    console.log(`[${LABEL}] no status changed; leaving ${store.cachePath} untouched (no release needed)`);
+    return;
+  }
+
+  const { cachePath, gzPath } = writeCache(store, { gz: options.gz });
+  console.log(`[${LABEL}] wrote ${cachePath}${gzPath ? ` and ${gzPath}` : ""}`);
   console.log(`[${LABEL}] next: publish the .gz as the data-vN release asset and bump DATA_RELEASE_TAG in backend/Dockerfile`);
 }
 
@@ -275,12 +337,13 @@ if (require.main === module) {
 }
 
 module.exports = {
-  DEFAULT_BATCH_SIZE,
-  DEFAULT_CYCLE_DAYS,
+  DEFAULT_MAX_NULL_RATIO,
+  assertStatusNotDegraded,
   classifyFlip,
+  hasChanged,
   isExpiredButInForce,
+  isRecheckable,
   primeSliceForRecheck,
   runRecheck,
   selectRecheckSlice,
-  statusAgeKey,
 };

--- a/backend/search/in-force-recheck.test.js
+++ b/backend/search/in-force-recheck.test.js
@@ -137,7 +137,7 @@ test("runRecheck leaves an out-of-force record entirely untouched", async () => 
   await runRecheck([stale, terminal], {
     journalPath,
     today: "2026-08-20",
-    runQueryFn: async () => bindings([{ celex: { value: "STALE" }, inForce: { value: "0" } }]),
+    runQueryFn: async () => bindings([{ celex: { value: "STALE" }, inForceValue: { value: "0" } }]),
   });
 
   assert.equal(terminal.inForce, false);
@@ -157,9 +157,9 @@ test("runRecheck counts actual flips and changes, not the number re-queried", as
     journalPath,
     today: "2026-08-20",
     runQueryFn: async () => bindings([
-      { celex: { value: "REPEALED" }, inForce: { value: "0" } },
-      { celex: { value: "STILL_TRUE" }, inForce: { value: "1" }, endOfValidity: { value: "2020-01-01" } },
-      { celex: { value: "GAINED" }, inForce: { value: "1" } },
+      { celex: { value: "REPEALED" }, inForceValue: { value: "0" } },
+      { celex: { value: "STILL_TRUE" }, inForceValue: { value: "1" }, endValue: { value: "2020-01-01" } },
+      { celex: { value: "GAINED" }, inForceValue: { value: "1" } },
     ]),
   });
 
@@ -177,7 +177,7 @@ test("runRecheck reports no change when every status is confirmed as-is", async 
   const result = await runRecheck(records, {
     journalPath,
     today: "2026-08-20",
-    runQueryFn: async () => bindings([{ celex: { value: "A" }, inForce: { value: "1" } }]),
+    runQueryFn: async () => bindings([{ celex: { value: "A" }, inForceValue: { value: "1" } }]),
   });
 
   assert.equal(result.changed, 0);

--- a/backend/search/in-force-recheck.test.js
+++ b/backend/search/in-force-recheck.test.js
@@ -6,8 +6,11 @@ const path = require("node:path");
 
 const { readJournal } = require("./in-force-enrich");
 const {
+  assertStatusNotDegraded,
   classifyFlip,
+  hasChanged,
   isExpiredButInForce,
+  isRecheckable,
   primeSliceForRecheck,
   runRecheck,
   selectRecheckSlice,
@@ -31,39 +34,57 @@ test("isExpiredButInForce flags an act flagged in force past its own endOfValidi
   assert.equal(isExpiredButInForce({ inForce: true, endOfValidity: null }, "2026-08-20"), false);
 });
 
-test("selectRecheckSlice puts expired-but-in-force records first, ahead of the rotation", () => {
-  const records = [
-    { celex: "A", inForce: true, endOfValidity: "2020-01-01", statusCheckedAt: "2026-01-01T00:00:00.000Z" }, // expired, known-wrong
-    { celex: "B", inForce: true, endOfValidity: "2030-01-01", statusCheckedAt: "2020-01-01T00:00:00.000Z" }, // oldest checked, not expired
-    { celex: "C", inForce: false, endOfValidity: "2018-05-24" }, // never checked (predates field)
-    { celex: "D", inForce: true, endOfValidity: "2030-01-01", statusCheckedAt: "2026-06-01T00:00:00.000Z" }, // freshly checked
-  ];
-
-  const slice = selectRecheckSlice(records, { batchSize: 3, today: "2026-08-20" });
-  const celexes = slice.map((r) => r.celex);
-
-  // A is expired-but-in-force: must be first regardless of its (recent) stamp.
-  assert.equal(celexes[0], "A");
-  // Remaining budget (2) goes to the two oldest/unstamped records, C and B,
-  // ahead of the freshly-checked D.
-  assert.deepEqual(new Set(celexes.slice(1)), new Set(["B", "C"]));
-  assert.equal(celexes.includes("D"), false);
+test("isRecheckable treats out-of-force as terminal and everything else as open", () => {
+  assert.equal(isRecheckable({ inForce: true }), true);
+  assert.equal(isRecheckable({ inForce: null }), true);
+  assert.equal(isRecheckable({}), true); // predates the field
+  assert.equal(isRecheckable({ inForce: false }), false);
 });
 
-test("selectRecheckSlice includes every expired-but-in-force record even beyond batchSize", () => {
+test("selectRecheckSlice sweeps everything not already out of force", () => {
   const records = [
-    { celex: "A", inForce: true, endOfValidity: "2020-01-01" },
-    { celex: "B", inForce: true, endOfValidity: "2020-01-01" },
-    { celex: "C", inForce: true, endOfValidity: "2030-01-01" },
+    { celex: "IN_FORCE", inForce: true, endOfValidity: null },
+    { celex: "UNKNOWN", inForce: null, endOfValidity: null },
+    { celex: "NO_FIELD" },
+    { celex: "OUT_OF_FORCE", inForce: false, endOfValidity: "2018-05-24" },
   ];
-  const slice = selectRecheckSlice(records, { batchSize: 1, today: "2026-08-20" });
-  assert.deepEqual(new Set(slice.map((r) => r.celex)), new Set(["A", "B"]));
+
+  const slice = selectRecheckSlice(records, { today: "2026-08-20" });
+
+  assert.deepEqual(
+    new Set(slice.map((r) => r.celex)),
+    new Set(["IN_FORCE", "UNKNOWN", "NO_FIELD"]),
+  );
 });
 
-test("selectRecheckSlice --sweep returns the whole eligible set, ignoring batchSize", () => {
-  const records = [{ celex: "A" }, { celex: "B" }, { celex: "C" }, { celex: "D" }];
-  const slice = selectRecheckSlice(records, { batchSize: 1, sweep: true });
-  assert.equal(slice.length, 4);
+test("selectRecheckSlice --all also re-checks out-of-force records", () => {
+  const records = [
+    { celex: "IN_FORCE", inForce: true },
+    { celex: "OUT_OF_FORCE", inForce: false },
+  ];
+  assert.equal(selectRecheckSlice(records, { all: true }).length, 2);
+});
+
+test("selectRecheckSlice orders known-wrong records first so a partial run fixes those", () => {
+  const records = [
+    { celex: "FINE", inForce: true, endOfValidity: "2030-01-01" },
+    { celex: "EXPIRED", inForce: true, endOfValidity: "2020-01-01" },
+    { celex: "UNKNOWN", inForce: null },
+  ];
+
+  const slice = selectRecheckSlice(records, { today: "2026-08-20" });
+
+  assert.equal(slice[0].celex, "EXPIRED");
+  assert.equal(slice.length, 3);
+});
+
+test("selectRecheckSlice --limit caps the sweep, keeping the known-wrong ones", () => {
+  const records = [
+    { celex: "FINE", inForce: true, endOfValidity: "2030-01-01" },
+    { celex: "EXPIRED", inForce: true, endOfValidity: "2020-01-01" },
+  ];
+  const slice = selectRecheckSlice(records, { today: "2026-08-20", limit: 1 });
+  assert.deepEqual(slice.map((r) => r.celex), ["EXPIRED"]);
 });
 
 test("primeSliceForRecheck clears the record fields and drops only the slice's journal entries", () => {
@@ -99,58 +120,91 @@ test("classifyFlip only reports true in-force <-> repealed transitions", () => {
   assert.equal(classifyFlip({ inForce: true }, { inForce: null }), null);
 });
 
-test("runRecheck leaves a non-slice record entirely untouched", async () => {
-  const journalPath = tempJournal({});
-  const stale = { celex: "STALE", inForce: true, endOfValidity: "2020-01-01" }; // expired, will be selected
-  const fresh = { celex: "FRESH", inForce: true, endOfValidity: "2030-01-01", statusCheckedAt: "2026-08-19T00:00:00.000Z" };
-  const records = [stale, fresh];
+test("hasChanged catches null transitions and end-of-validity corrections a flip misses", () => {
+  assert.equal(hasChanged({ inForce: true, endOfValidity: null }, { inForce: true, endOfValidity: null }), false);
+  assert.equal(hasChanged({ inForce: null, endOfValidity: null }, { inForce: true, endOfValidity: null }), true);
+  assert.equal(hasChanged(
+    { inForce: true, endOfValidity: null },
+    { inForce: true, endOfValidity: "2027-01-01" },
+  ), true);
+});
 
-  await runRecheck(records, {
+test("runRecheck leaves an out-of-force record entirely untouched", async () => {
+  const journalPath = tempJournal({});
+  const stale = { celex: "STALE", inForce: true, endOfValidity: "2020-01-01" };
+  const terminal = { celex: "TERMINAL", inForce: false, endOfValidity: "2018-05-24" };
+
+  await runRecheck([stale, terminal], {
     journalPath,
-    batchSize: 1, // only room for the one expired record; FRESH must not be pulled into the rotation
     today: "2026-08-20",
     runQueryFn: async () => bindings([{ celex: { value: "STALE" }, inForce: { value: "0" } }]),
   });
 
-  assert.equal(fresh.inForce, true);
-  assert.equal(fresh.endOfValidity, "2030-01-01");
-  assert.equal(fresh.statusCheckedAt, "2026-08-19T00:00:00.000Z");
+  assert.equal(terminal.inForce, false);
+  assert.equal(terminal.endOfValidity, "2018-05-24");
+  assert.equal(stale.inForce, false);
 });
 
-test("runRecheck's flip counter counts actual flips, not the number re-queried", async () => {
+test("runRecheck counts actual flips and changes, not the number re-queried", async () => {
   const journalPath = tempJournal({});
   const records = [
-    { celex: "REPEALED", inForce: true, endOfValidity: "2020-01-01" }, // will flip to false
-    { celex: "STILL_TRUE", inForce: true, endOfValidity: "2020-01-01" }, // stays true (Cellar disagrees with the date)
+    { celex: "REPEALED", inForce: true, endOfValidity: "2020-01-01" }, // flips to false
+    { celex: "STILL_TRUE", inForce: true, endOfValidity: "2020-01-01" }, // unchanged
+    { celex: "GAINED", inForce: null, endOfValidity: null }, // changes, but is not a flip
   ];
 
   const result = await runRecheck(records, {
     journalPath,
-    batchSize: 10,
     today: "2026-08-20",
     runQueryFn: async () => bindings([
       { celex: { value: "REPEALED" }, inForce: { value: "0" } },
-      { celex: { value: "STILL_TRUE" }, inForce: { value: "1" } },
+      { celex: { value: "STILL_TRUE" }, inForce: { value: "1" }, endOfValidity: { value: "2020-01-01" } },
+      { celex: { value: "GAINED" }, inForce: { value: "1" } },
     ]),
   });
 
-  assert.equal(result.requeried, 2);
+  assert.equal(result.requeried, 3);
   assert.equal(result.flipped, 1);
   assert.equal(result.flippedToRepealed, 1);
   assert.equal(result.flippedToInForce, 0);
+  assert.equal(result.changed, 2);
 });
 
-test("runRecheck stamps statusCheckedAt on every slice member it actually re-queried", async () => {
+test("runRecheck reports no change when every status is confirmed as-is", async () => {
   const journalPath = tempJournal({});
-  const records = [{ celex: "A", inForce: true, endOfValidity: "2020-01-01" }];
+  const records = [{ celex: "A", inForce: true, endOfValidity: null }];
 
-  await runRecheck(records, {
+  const result = await runRecheck(records, {
     journalPath,
-    batchSize: 10,
     today: "2026-08-20",
     runQueryFn: async () => bindings([{ celex: { value: "A" }, inForce: { value: "1" } }]),
   });
 
-  assert.equal(typeof records[0].statusCheckedAt, "string");
-  assert.ok(!Number.isNaN(Date.parse(records[0].statusCheckedAt)));
+  assert.equal(result.changed, 0);
+  assert.equal(records[0].inForce, true);
+  assert.equal(records[0].endOfValidity, null);
+});
+
+test("assertStatusNotDegraded refuses a run that erased known statuses in bulk", () => {
+  assert.throws(
+    () => assertStatusNotDegraded({ sliceSize: 100, lostStatus: 20 }, 0.05),
+    /lost a previously known status/,
+  );
+  // A handful of genuine retractions stays under the threshold.
+  assert.equal(assertStatusNotDegraded({ sliceSize: 100, lostStatus: 2 }, 0.05), 0.02);
+  assert.equal(assertStatusNotDegraded({ sliceSize: 0, lostStatus: 0 }, 0.05), 0);
+});
+
+test("runRecheck counts a status that Cellar no longer answers for as lost", async () => {
+  const journalPath = tempJournal({});
+  const records = [{ celex: "A", inForce: true, endOfValidity: null }];
+
+  const result = await runRecheck(records, {
+    journalPath,
+    today: "2026-08-20",
+    runQueryFn: async () => bindings([]),
+  });
+
+  assert.equal(result.lostStatus, 1);
+  assert.throws(() => assertStatusNotDegraded(result, 0.05), /refusing to write/);
 });

--- a/backend/search/in-force-recheck.test.js
+++ b/backend/search/in-force-recheck.test.js
@@ -1,0 +1,156 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const { readJournal } = require("./in-force-enrich");
+const {
+  classifyFlip,
+  isExpiredButInForce,
+  primeSliceForRecheck,
+  runRecheck,
+  selectRecheckSlice,
+} = require("./in-force-recheck");
+
+function tempJournal(contents) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "in-force-recheck-"));
+  const journalPath = path.join(dir, "in-force.json");
+  if (contents !== undefined) fs.writeFileSync(journalPath, JSON.stringify(contents), "utf8");
+  return journalPath;
+}
+
+function bindings(rows) {
+  return { results: { bindings: rows } };
+}
+
+test("isExpiredButInForce flags an act flagged in force past its own endOfValidity", () => {
+  assert.equal(isExpiredButInForce({ inForce: true, endOfValidity: "2020-01-01" }, "2026-08-20"), true);
+  assert.equal(isExpiredButInForce({ inForce: true, endOfValidity: "2030-01-01" }, "2026-08-20"), false);
+  assert.equal(isExpiredButInForce({ inForce: false, endOfValidity: "2020-01-01" }, "2026-08-20"), false);
+  assert.equal(isExpiredButInForce({ inForce: true, endOfValidity: null }, "2026-08-20"), false);
+});
+
+test("selectRecheckSlice puts expired-but-in-force records first, ahead of the rotation", () => {
+  const records = [
+    { celex: "A", inForce: true, endOfValidity: "2020-01-01", statusCheckedAt: "2026-01-01T00:00:00.000Z" }, // expired, known-wrong
+    { celex: "B", inForce: true, endOfValidity: "2030-01-01", statusCheckedAt: "2020-01-01T00:00:00.000Z" }, // oldest checked, not expired
+    { celex: "C", inForce: false, endOfValidity: "2018-05-24" }, // never checked (predates field)
+    { celex: "D", inForce: true, endOfValidity: "2030-01-01", statusCheckedAt: "2026-06-01T00:00:00.000Z" }, // freshly checked
+  ];
+
+  const slice = selectRecheckSlice(records, { batchSize: 3, today: "2026-08-20" });
+  const celexes = slice.map((r) => r.celex);
+
+  // A is expired-but-in-force: must be first regardless of its (recent) stamp.
+  assert.equal(celexes[0], "A");
+  // Remaining budget (2) goes to the two oldest/unstamped records, C and B,
+  // ahead of the freshly-checked D.
+  assert.deepEqual(new Set(celexes.slice(1)), new Set(["B", "C"]));
+  assert.equal(celexes.includes("D"), false);
+});
+
+test("selectRecheckSlice includes every expired-but-in-force record even beyond batchSize", () => {
+  const records = [
+    { celex: "A", inForce: true, endOfValidity: "2020-01-01" },
+    { celex: "B", inForce: true, endOfValidity: "2020-01-01" },
+    { celex: "C", inForce: true, endOfValidity: "2030-01-01" },
+  ];
+  const slice = selectRecheckSlice(records, { batchSize: 1, today: "2026-08-20" });
+  assert.deepEqual(new Set(slice.map((r) => r.celex)), new Set(["A", "B"]));
+});
+
+test("selectRecheckSlice --sweep returns the whole eligible set, ignoring batchSize", () => {
+  const records = [{ celex: "A" }, { celex: "B" }, { celex: "C" }, { celex: "D" }];
+  const slice = selectRecheckSlice(records, { batchSize: 1, sweep: true });
+  assert.equal(slice.length, 4);
+});
+
+test("primeSliceForRecheck clears the record fields and drops only the slice's journal entries", () => {
+  const journalPath = tempJournal({
+    A: { inForce: true, endOfValidity: null },
+    B: { inForce: false, endOfValidity: "2018-05-24" },
+    UNRELATED: { inForce: true, endOfValidity: null },
+  });
+  const slice = [
+    { celex: "A", inForce: true, endOfValidity: null },
+    { celex: "B", inForce: false, endOfValidity: "2018-05-24" },
+  ];
+
+  const { journalEntriesDropped } = primeSliceForRecheck(slice, journalPath);
+
+  assert.equal(journalEntriesDropped, 2);
+  assert.equal(slice[0].inForce, undefined);
+  assert.equal(slice[0].endOfValidity, undefined);
+  assert.equal(slice[1].inForce, undefined);
+
+  const journal = readJournal(journalPath);
+  assert.equal(journal.A, undefined);
+  assert.equal(journal.B, undefined);
+  // The unrelated entry, for a celex outside the slice, must survive untouched.
+  assert.deepEqual(journal.UNRELATED, { inForce: true, endOfValidity: null });
+});
+
+test("classifyFlip only reports true in-force <-> repealed transitions", () => {
+  assert.equal(classifyFlip({ inForce: true }, { inForce: false }), "toRepealed");
+  assert.equal(classifyFlip({ inForce: false }, { inForce: true }), "toInForce");
+  assert.equal(classifyFlip({ inForce: true }, { inForce: true }), null);
+  assert.equal(classifyFlip({ inForce: null }, { inForce: true }), null);
+  assert.equal(classifyFlip({ inForce: true }, { inForce: null }), null);
+});
+
+test("runRecheck leaves a non-slice record entirely untouched", async () => {
+  const journalPath = tempJournal({});
+  const stale = { celex: "STALE", inForce: true, endOfValidity: "2020-01-01" }; // expired, will be selected
+  const fresh = { celex: "FRESH", inForce: true, endOfValidity: "2030-01-01", statusCheckedAt: "2026-08-19T00:00:00.000Z" };
+  const records = [stale, fresh];
+
+  await runRecheck(records, {
+    journalPath,
+    batchSize: 1, // only room for the one expired record; FRESH must not be pulled into the rotation
+    today: "2026-08-20",
+    runQueryFn: async () => bindings([{ celex: { value: "STALE" }, inForce: { value: "0" } }]),
+  });
+
+  assert.equal(fresh.inForce, true);
+  assert.equal(fresh.endOfValidity, "2030-01-01");
+  assert.equal(fresh.statusCheckedAt, "2026-08-19T00:00:00.000Z");
+});
+
+test("runRecheck's flip counter counts actual flips, not the number re-queried", async () => {
+  const journalPath = tempJournal({});
+  const records = [
+    { celex: "REPEALED", inForce: true, endOfValidity: "2020-01-01" }, // will flip to false
+    { celex: "STILL_TRUE", inForce: true, endOfValidity: "2020-01-01" }, // stays true (Cellar disagrees with the date)
+  ];
+
+  const result = await runRecheck(records, {
+    journalPath,
+    batchSize: 10,
+    today: "2026-08-20",
+    runQueryFn: async () => bindings([
+      { celex: { value: "REPEALED" }, inForce: { value: "0" } },
+      { celex: { value: "STILL_TRUE" }, inForce: { value: "1" } },
+    ]),
+  });
+
+  assert.equal(result.requeried, 2);
+  assert.equal(result.flipped, 1);
+  assert.equal(result.flippedToRepealed, 1);
+  assert.equal(result.flippedToInForce, 0);
+});
+
+test("runRecheck stamps statusCheckedAt on every slice member it actually re-queried", async () => {
+  const journalPath = tempJournal({});
+  const records = [{ celex: "A", inForce: true, endOfValidity: "2020-01-01" }];
+
+  await runRecheck(records, {
+    journalPath,
+    batchSize: 10,
+    today: "2026-08-20",
+    runQueryFn: async () => bindings([{ celex: { value: "A" }, inForce: { value: "1" } }]),
+  });
+
+  assert.equal(typeof records[0].statusCheckedAt, "string");
+  assert.ok(!Number.isNaN(Date.parse(records[0].statusCheckedAt)));
+});

--- a/backend/search/in-force-recheck.test.js
+++ b/backend/search/in-force-recheck.test.js
@@ -1,115 +1,23 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
-const fs = require("node:fs");
-const os = require("node:os");
-const path = require("node:path");
 
-const { readJournal } = require("./in-force-enrich");
 const {
   assertStatusNotDegraded,
   classifyFlip,
   hasChanged,
-  isExpiredButInForce,
   isRecheckable,
-  primeSliceForRecheck,
   runRecheck,
-  selectRecheckSlice,
 } = require("./in-force-recheck");
-
-function tempJournal(contents) {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "in-force-recheck-"));
-  const journalPath = path.join(dir, "in-force.json");
-  if (contents !== undefined) fs.writeFileSync(journalPath, JSON.stringify(contents), "utf8");
-  return journalPath;
-}
 
 function bindings(rows) {
   return { results: { bindings: rows } };
 }
-
-test("isExpiredButInForce flags an act flagged in force past its own endOfValidity", () => {
-  assert.equal(isExpiredButInForce({ inForce: true, endOfValidity: "2020-01-01" }, "2026-08-20"), true);
-  assert.equal(isExpiredButInForce({ inForce: true, endOfValidity: "2030-01-01" }, "2026-08-20"), false);
-  assert.equal(isExpiredButInForce({ inForce: false, endOfValidity: "2020-01-01" }, "2026-08-20"), false);
-  assert.equal(isExpiredButInForce({ inForce: true, endOfValidity: null }, "2026-08-20"), false);
-});
 
 test("isRecheckable treats out-of-force as terminal and everything else as open", () => {
   assert.equal(isRecheckable({ inForce: true }), true);
   assert.equal(isRecheckable({ inForce: null }), true);
   assert.equal(isRecheckable({}), true); // predates the field
   assert.equal(isRecheckable({ inForce: false }), false);
-});
-
-test("selectRecheckSlice sweeps everything not already out of force", () => {
-  const records = [
-    { celex: "IN_FORCE", inForce: true, endOfValidity: null },
-    { celex: "UNKNOWN", inForce: null, endOfValidity: null },
-    { celex: "NO_FIELD" },
-    { celex: "OUT_OF_FORCE", inForce: false, endOfValidity: "2018-05-24" },
-  ];
-
-  const slice = selectRecheckSlice(records, { today: "2026-08-20" });
-
-  assert.deepEqual(
-    new Set(slice.map((r) => r.celex)),
-    new Set(["IN_FORCE", "UNKNOWN", "NO_FIELD"]),
-  );
-});
-
-test("selectRecheckSlice --all also re-checks out-of-force records", () => {
-  const records = [
-    { celex: "IN_FORCE", inForce: true },
-    { celex: "OUT_OF_FORCE", inForce: false },
-  ];
-  assert.equal(selectRecheckSlice(records, { all: true }).length, 2);
-});
-
-test("selectRecheckSlice orders known-wrong records first so a partial run fixes those", () => {
-  const records = [
-    { celex: "FINE", inForce: true, endOfValidity: "2030-01-01" },
-    { celex: "EXPIRED", inForce: true, endOfValidity: "2020-01-01" },
-    { celex: "UNKNOWN", inForce: null },
-  ];
-
-  const slice = selectRecheckSlice(records, { today: "2026-08-20" });
-
-  assert.equal(slice[0].celex, "EXPIRED");
-  assert.equal(slice.length, 3);
-});
-
-test("selectRecheckSlice --limit caps the sweep, keeping the known-wrong ones", () => {
-  const records = [
-    { celex: "FINE", inForce: true, endOfValidity: "2030-01-01" },
-    { celex: "EXPIRED", inForce: true, endOfValidity: "2020-01-01" },
-  ];
-  const slice = selectRecheckSlice(records, { today: "2026-08-20", limit: 1 });
-  assert.deepEqual(slice.map((r) => r.celex), ["EXPIRED"]);
-});
-
-test("primeSliceForRecheck clears the record fields and drops only the slice's journal entries", () => {
-  const journalPath = tempJournal({
-    A: { inForce: true, endOfValidity: null },
-    B: { inForce: false, endOfValidity: "2018-05-24" },
-    UNRELATED: { inForce: true, endOfValidity: null },
-  });
-  const slice = [
-    { celex: "A", inForce: true, endOfValidity: null },
-    { celex: "B", inForce: false, endOfValidity: "2018-05-24" },
-  ];
-
-  const { journalEntriesDropped } = primeSliceForRecheck(slice, journalPath);
-
-  assert.equal(journalEntriesDropped, 2);
-  assert.equal(slice[0].inForce, undefined);
-  assert.equal(slice[0].endOfValidity, undefined);
-  assert.equal(slice[1].inForce, undefined);
-
-  const journal = readJournal(journalPath);
-  assert.equal(journal.A, undefined);
-  assert.equal(journal.B, undefined);
-  // The unrelated entry, for a celex outside the slice, must survive untouched.
-  assert.deepEqual(journal.UNRELATED, { inForce: true, endOfValidity: null });
 });
 
 test("classifyFlip only reports true in-force <-> repealed transitions", () => {
@@ -129,24 +37,42 @@ test("hasChanged catches null transitions and end-of-validity corrections a flip
   ), true);
 });
 
-test("runRecheck leaves an out-of-force record entirely untouched", async () => {
-  const journalPath = tempJournal({});
+test("runRecheck re-checks everything not already out of force, and leaves the rest untouched", async () => {
   const stale = { celex: "STALE", inForce: true, endOfValidity: "2020-01-01" };
+  const unknown = { celex: "UNKNOWN", inForce: null, endOfValidity: null };
   const terminal = { celex: "TERMINAL", inForce: false, endOfValidity: "2018-05-24" };
 
-  await runRecheck([stale, terminal], {
-    journalPath,
-    today: "2026-08-20",
-    runQueryFn: async () => bindings([{ celex: { value: "STALE" }, inForceValue: { value: "0" } }]),
+  const asked = [];
+  const result = await runRecheck([stale, unknown, terminal], {
+    runQueryFn: async (query) => {
+      asked.push(query);
+      return bindings([{ celex: { value: "STALE" }, inForceValue: { value: "0" } }]);
+    },
   });
 
+  assert.equal(result.rechecked, 2);
+  assert.equal(stale.inForce, false);
+  assert.equal(unknown.inForce, null);
+  // The terminal record is neither cleared nor re-queried.
   assert.equal(terminal.inForce, false);
   assert.equal(terminal.endOfValidity, "2018-05-24");
-  assert.equal(stale.inForce, false);
+  assert.doesNotMatch(asked.join(""), /TERMINAL/);
+});
+
+test("runRecheck --all re-checks the out-of-force records too", async () => {
+  const terminal = { celex: "TERMINAL", inForce: false, endOfValidity: "2018-05-24" };
+
+  const result = await runRecheck([terminal], {
+    all: true,
+    runQueryFn: async () => bindings([{ celex: { value: "TERMINAL" }, inForceValue: { value: "1" } }]),
+  });
+
+  assert.equal(result.rechecked, 1);
+  assert.equal(result.flippedToInForce, 1);
+  assert.equal(terminal.inForce, true);
 });
 
 test("runRecheck counts actual flips and changes, not the number re-queried", async () => {
-  const journalPath = tempJournal({});
   const records = [
     { celex: "REPEALED", inForce: true, endOfValidity: "2020-01-01" }, // flips to false
     { celex: "STILL_TRUE", inForce: true, endOfValidity: "2020-01-01" }, // unchanged
@@ -154,8 +80,6 @@ test("runRecheck counts actual flips and changes, not the number re-queried", as
   ];
 
   const result = await runRecheck(records, {
-    journalPath,
-    today: "2026-08-20",
     runQueryFn: async () => bindings([
       { celex: { value: "REPEALED" }, inForceValue: { value: "0" } },
       { celex: { value: "STILL_TRUE" }, inForceValue: { value: "1" }, endValue: { value: "2020-01-01" } },
@@ -171,12 +95,9 @@ test("runRecheck counts actual flips and changes, not the number re-queried", as
 });
 
 test("runRecheck reports no change when every status is confirmed as-is", async () => {
-  const journalPath = tempJournal({});
   const records = [{ celex: "A", inForce: true, endOfValidity: null }];
 
   const result = await runRecheck(records, {
-    journalPath,
-    today: "2026-08-20",
     runQueryFn: async () => bindings([{ celex: { value: "A" }, inForceValue: { value: "1" } }]),
   });
 
@@ -185,25 +106,38 @@ test("runRecheck reports no change when every status is confirmed as-is", async 
   assert.equal(records[0].endOfValidity, null);
 });
 
+// A record cleared but never refilled would serialise with no `inForce` key at
+// all, which is precisely what backend-docker.yml fails the build over. --limit
+// must therefore bound the targets, not the enrichment.
+test("runRecheck --limit leaves unre-checked records fully intact", async () => {
+  const first = { celex: "FIRST", inForce: true, endOfValidity: null };
+  const second = { celex: "SECOND", inForce: true, endOfValidity: "2030-01-01" };
+
+  const result = await runRecheck([first, second], {
+    limit: 1,
+    runQueryFn: async () => bindings([{ celex: { value: "FIRST" }, inForceValue: { value: "1" } }]),
+  });
+
+  assert.equal(result.rechecked, 1);
+  assert.equal(second.inForce, true);
+  assert.equal(second.endOfValidity, "2030-01-01");
+  assert.ok("inForce" in second);
+});
+
 test("assertStatusNotDegraded refuses a run that erased known statuses in bulk", () => {
   assert.throws(
-    () => assertStatusNotDegraded({ sliceSize: 100, lostStatus: 20 }, 0.05),
+    () => assertStatusNotDegraded({ rechecked: 100, lostStatus: 20 }, 0.05),
     /lost a previously known status/,
   );
   // A handful of genuine retractions stays under the threshold.
-  assert.equal(assertStatusNotDegraded({ sliceSize: 100, lostStatus: 2 }, 0.05), 0.02);
-  assert.equal(assertStatusNotDegraded({ sliceSize: 0, lostStatus: 0 }, 0.05), 0);
+  assert.equal(assertStatusNotDegraded({ rechecked: 100, lostStatus: 2 }, 0.05), 0.02);
+  assert.equal(assertStatusNotDegraded({ rechecked: 0, lostStatus: 0 }, 0.05), 0);
 });
 
 test("runRecheck counts a status that Cellar no longer answers for as lost", async () => {
-  const journalPath = tempJournal({});
   const records = [{ celex: "A", inForce: true, endOfValidity: null }];
 
-  const result = await runRecheck(records, {
-    journalPath,
-    today: "2026-08-20",
-    runQueryFn: async () => bindings([]),
-  });
+  const result = await runRecheck(records, { runQueryFn: async () => bindings([]) });
 
   assert.equal(result.lostStatus, 1);
   assert.throws(() => assertStatusNotDegraded(result, 0.05), /refusing to write/);


### PR DESCRIPTION
Supersedes #169 (same issue, #167). Carries its two commits rebased onto current `main`, then applies the review fixes and wires it into CI. **#169 can be closed in favour of this.**

## What changed relative to #169

**The rotation is gone.** #169 re-checked 2000 acts per run on a `statusCheckedAt` rotation — a ~40-month turnover against ~80k acts. Measured, that bound was priced against a cost that does not exist:

- Cellar answers a 100-CELEX batch in 200–400 ms.
- `inForce: false` is terminal, and that is **50,393 of the 80,469** acts in `data-v11`. Only 30,076 can still change (19,588 in force + 10,488 whose status Cellar has never answered and may yet).
- A full sweep of that pool is ~301 batches: **2m12s wall**, most of it spent parsing and re-serialising the 293 MB cache rather than on the network.

So it re-checks everything not already out of force, every run. `--all` opts into the terminal records too (annulment, corrigendum), `--limit` caps a smoke test, `--no-gz` skips the sidecar.

**Nothing is left of the bounded-job scaffolding.** With an unconditional sweep there is nothing to select and nothing to resume:

- **No slicing.** Selection is one filter. `selectRecheckSlice`, `isExpiredButInForce` and the known-wrong-first ordering are gone — that ordering only mattered for salvaging a partial run, and nothing is salvaged from one. `--limit` is applied when choosing targets, never passed down to the enrichment: a record cleared and then not refilled would serialise with no `inForce` key at all, which is precisely what the Docker guard fails the build over. There is a test for that.
- **No journal.** `primeSliceForRecheck` existed to delete the entries that would otherwise answer a re-check from disk. But the run writes its cache once, at the end, only when a status moved — a failed run leaves nothing to resume from and is simply re-run. Dropping 30k entries and immediately rewriting them was pure I/O (~60 rewrites of a 30k-entry file per run). `enrichRecordsWithInForce` takes `useJournal` instead, defaulting to `true` so the four builders — whose harvests run for hours and must survive interruption — are untouched.
- **No `statusCheckedAt`.** It existed only to order the rotation, and persisting a fresh timestamp every run would have rewritten the cache bytes every month, defeating `refresh-data.yml`'s unchanged-digest short circuit and cutting a `data-vN` release plus a Docker tag PR on every quiet month.

The tool and its tests are 130 lines lighter than in #169, and `in-force-enrich.js` is back to its original behaviour apart from the query fix below and the new `useJournal` option.

**Two guards replace the bound the rotation provided:**
- The cache is rewritten **only when a status actually moved**, comparing values rather than bytes. Confirming 30k unchanged statuses leaves the file byte-identical — the two fields are the last two keys on all 80,469 published records, so delete-and-re-add preserves key order (verified: 0 records reordered).
- `--max-null-ratio` (default 5%) refuses to write when too much of the run loses a previously known status at once. Per record that is indistinguishable from a genuine retraction; in bulk it means Cellar is answering but degraded, and publishing it would erode the >80% coverage `backend-docker.yml` asserts.

## The CI wiring

`refresh-data.yml` is the only workflow that can carry this — it restores `search-cache.json.gz` from the current `data-vN` tag, mutates it, and republishes it. `refresh-corpus.yml` looks like a candidate (it is where `data/in-force.json` is restored and republished) but it backfills with `--no-in-force` and never publishes `search-cache`, so a re-check there would be thrown away.

The step sits after *Add corpus acts missing from the cache* (which enriches only acts new to the cache) and before *Capture search and case-law counts*, which computes the digest deciding whether a release is cut.

## A pre-existing correctness bug this surfaced

Two identical sweeps disagreed on 40 records. The cause is not the re-check — it is the shared status query, which has been corrupting the published cache:

```
32006R0988  end-of-validity 2020-12-31   (genuine)
32006R1066  end-of-validity 9999-12-31   (the "no end of validity" sentinel → null)
```

In a real 100-CELEX batch the aggregated query — `(SAMPLE(?inForceValue) AS ?inForce) (MIN(?endValue) AS ?endOfValidity) … GROUP BY ?celex` — returned **2020-12-31 for both**. The same 100 ids unaggregated, and `32006R1066` queried alone, both return the sentinel correctly. The wrong value is *stable for a given batch* and moves when the batch composition moves, so retrying cannot clear it: one act's expiry date is silently written onto another. Only groups where the `OPTIONAL` failed to match are affected — i.e. exactly the acts that should have come back `null`, which is why it went unnoticed. The implausible `1002-02-02` seen on several acts is the batch-wide `MIN` leaking.

Fixed by projecting the raw rows and reducing them in `reduceBindings()`, where the grouping is ours, deterministic and unit-tested. `eurovoc-enrich.js` keeps its `GROUP_CONCAT`: every triple in that query is required, so it has no unbound groups to leak into, and a 30-act spot check against solo queries found no mismatch.

**Suggested follow-up, not done here:** a one-off `--all` run when this lands, to repair whatever the aggregation bug wrote onto the 50k out-of-force records that a normal sweep does not revisit.

## Verification

Against live Cellar and the real `data-v11` cache (80,469 records):

| | records re-checked | result |
|---|---|---|
| Sweep, buggy query | 30,076 | 88 changed — 20 of them the aggregation bug, and two identical runs disagreed on 40 |
| Sweep, fixed query (run A) | 30,076 | **18 acts flipped in force → no longer in force**, 68 changed in all, 1 lost a status (0.003%) |
| Immediate re-run (run B) | 30,058 | **0 changed, file left untouched, md5 identical to run A** |
| `--limit 500`, after cleanup | 500 | 3 flipped, **no journal written**, 0 records missing an `inForce` key, coverage unmoved at 87.0% |

Run A's 18 flips are real staleness in the shipped cache today; the rotation in #169 would have taken ~40 months to reach them. Run B is the property the CI wiring depends on: a quiet month re-queries 30k statuses, confirms them all, and publishes nothing.

- `cd backend && node --test search/*.test.js` — 231 tests, 229 pass, 0 fail, 2 skipped (pre-existing).
- `cd backend && node --test shared/*.test.js routes/*.test.js bin/*.test.js mcp/*.test.js` — 248 pass, 0 fail.
- `npm run test:web` — 480 pass. `npm run lint` — clean.
- `refresh-data.yml` parses and the new step lands between the two it must.

## Version constants

No bump. `inForce` / `endOfValidity` are existing fields, no schema moves, and the corrected values ship the ordinary way — as a new `data-vN` release with `DATA_RELEASE_TAG` bumped in `backend/Dockerfile`.