### PR TITLE
Read a law as amended, behind ?version=current

### DIFF
--- a/backend/mcp/register-tools.js
+++ b/backend/mcp/register-tools.js
@@ -129,6 +129,11 @@ function buildStructure(law, recitalTitles) {
       number: art.article_number,
       title: art.article_title || null,
       ...(section ? { section: { number: section.number, title: section.title } } : {}),
+      // Only present when reading a version (see `version` on get_law_part):
+      // this article has no counterpart in the act as adopted, so case-law
+      // and citation lookups keyed to the original text will find nothing
+      // for it.
+      ...(art.insertedInVersion ? { insertedInVersion: true } : {}),
     });
   }
 
@@ -299,7 +304,7 @@ function registerTools(server, deps) {
     {
       title: 'Read part of an EU law',
       description:
-        'Read a slice of a law by CELEX id. Call with part="structure" FIRST to get the table of contents (chapters, article numbers + titles, recital list, annex ids, definition terms), then request individual pieces. Never returns the whole law at once. Parts: "structure" (the map), "article" (one article, requires number), "recital" (one recital, requires number), "annex" (one annex, requires the annex id in number), "definitions" (all defined terms, optional number filters by substring). NOTE: the first fetch of a law that is not yet cached can take up to ~30 seconds while it is downloaded from EUR-Lex; subsequent calls are fast.',
+        'Read a slice of a law by CELEX id. Call with part="structure" FIRST to get the table of contents (chapters, article numbers + titles, recital list, annex ids, definition terms), then request individual pieces. Never returns the whole law at once. By default this is the act AS ADOPTED; pass version="current" to read it as amended. Parts: "structure" (the map), "article" (one article, requires number), "recital" (one recital, requires number), "annex" (one annex, requires the annex id in number), "definitions" (all defined terms, optional number filters by substring). NOTE: the first fetch of a law that is not yet cached can take up to ~30 seconds while it is downloaded from EUR-Lex; subsequent calls are fast.',
       inputSchema: {
         celex: z.string().describe('CELEX id, e.g. 32016R0679'),
         part: z.enum(['structure', 'article', 'recital', 'annex', 'definitions'])
@@ -307,15 +312,26 @@ function registerTools(server, deps) {
         number: z.string().optional()
           .describe('Article/recital number or annex id (required for article/recital/annex); optional substring filter for definitions'),
         lang: z.string().optional().describe('3-letter language code (default ENG)'),
+        version: z.literal('current').optional()
+          .describe('Pass "current" to read the act as amended (the latest consolidated version) instead of as adopted. The CELEX stays the same — a consolidated text is another version of the act, not a different act. Articles, annexes and definitions then come from the consolidated text while recitals stay as adopted (consolidation does not amend recitals), and articles added by a later amendment are marked insertedInVersion. If no consolidated version can be served, the act as adopted is returned with versionUnavailable: true rather than an error.'),
       },
     },
-    makeHandler(async ({ celex, part, number, lang }) => {
+    makeHandler(async ({ celex, part, number, lang, version }) => {
       requireCelex(celex);
       const language = requireLang(lang);
       record('get_law_part', { celex });
 
-      const law = await resolveParsedLaw(celex, language, {});
+      const law = await resolveParsedLaw(celex, language, version ? { version } : {});
       const base = { celex, lang: language, title: law.title, langCode: law.langCode, source: law.source };
+      // Only surface the version fields when a version was asked for, so the
+      // as-adopted response shape is byte-for-byte what it was before.
+      if (version) {
+        base.version = law.version || null;
+        base.versionCelex = law.versionCelex || null;
+        base.versionDate = law.versionDate || null;
+        if (law.versionUnavailable) base.versionUnavailable = true;
+        if (law.recitalsSource) base.recitalsSource = law.recitalsSource;
+      }
 
       if (part === 'structure') {
         const cached = getCachedRecitalTitles({

--- a/backend/mcp/register-tools.test.js
+++ b/backend/mcp/register-tools.test.js
@@ -327,6 +327,65 @@ test('get_law_part structure returns the table of contents', async () => {
   });
 });
 
+test('get_law_part passes version=current through and reports the version it served', async () => {
+  let seenOptions = null;
+  const deps = makeDeps({
+    resolveParsedLaw: async (celex, lang, options) => {
+      seenOptions = options;
+      return {
+        ...FIXTURE_LAW,
+        source: 'fmx-consolidated',
+        version: 'current',
+        versionCelex: '02016R0679-20160504',
+        versionDate: '2016-05-04',
+        recitalsSource: 'as-adopted',
+        articles: [
+          FIXTURE_LAW.articles[0],
+          { ...FIXTURE_LAW.articles[1], insertedInVersion: true },
+        ],
+      };
+    },
+  });
+
+  await withClient(deps, async (client) => {
+    const body = parseResult(await client.callTool({
+      name: 'get_law_part',
+      arguments: { celex: '32016R0679', part: 'structure', version: 'current' },
+    }));
+
+    assert.deepEqual(seenOptions, { version: 'current' });
+    assert.equal(body.version, 'current');
+    assert.equal(body.versionCelex, '02016R0679-20160504');
+    assert.equal(body.versionDate, '2016-05-04');
+    assert.equal(body.recitalsSource, 'as-adopted');
+    // The article added by a later amendment is flagged, so a caller knows
+    // not to expect case law or citations for it.
+    const flagged = body.chapters
+      .flatMap((chapter) => chapter.articles)
+      .filter((article) => article.insertedInVersion);
+    assert.equal(flagged.length, 1);
+  });
+});
+
+test('get_law_part omits the version fields entirely when no version is requested', async () => {
+  let seenOptions = null;
+  const deps = makeDeps({
+    resolveParsedLaw: async (celex, lang, options) => { seenOptions = options; return FIXTURE_LAW; },
+  });
+
+  await withClient(deps, async (client) => {
+    const body = parseResult(await client.callTool({
+      name: 'get_law_part',
+      arguments: { celex: '32016R0679', part: 'structure' },
+    }));
+
+    assert.deepEqual(seenOptions, {});
+    assert.ok(!('version' in body), 'as-adopted responses keep their previous shape');
+    assert.ok(!('versionCelex' in body));
+    assert.ok(!('recitalsSource' in body));
+  });
+});
+
 test('get_law_part article returns plain text and cross-references', async () => {
   await withClient(makeDeps(), async (client) => {
     const body = parseResult(await client.callTool({ name: 'get_law_part', arguments: { celex: '32016R0679', part: 'article', number: '17' } }));

--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -299,7 +299,18 @@ function registerApiRoutes(app, deps) {
         return res.status(400).json({ error: `Invalid language code: ${rawLang}` });
       }
 
-      const parsed = await resolveParsedLaw(celex, lang, { skipFmxProbe });
+      // Only the literal `current` is supported today (#149 slice 1).
+      // Arbitrary `?version=YYYY-MM-DD` is a planned later slice — rejecting
+      // it now, rather than silently ignoring it, keeps that addition
+      // additive instead of a silent behaviour change on URLs already in
+      // the wild.
+      const rawVersion = req.query.version;
+      if (rawVersion !== undefined && rawVersion !== 'current') {
+        return res.status(400).json({ error: 'Unsupported version. Expected: current' });
+      }
+      const version = rawVersion === 'current' ? 'current' : null;
+
+      const parsed = await resolveParsedLaw(celex, lang, { skipFmxProbe, version });
       res.json(parsed);
     } catch (err) {
       if (!res.headersSent) {

--- a/backend/routes/api-routes.test.js
+++ b/backend/routes/api-routes.test.js
@@ -459,6 +459,41 @@ test("GET /api/laws/:celex/parsed skips the FMX probe when requested", async () 
   assert.equal(prepareCalled, false);
 });
 
+test("GET /api/laws/:celex/parsed rejects an unsupported version value", async () => {
+  const { app } = registerTestRoutes();
+  const handler = app.routes.get("/api/laws/:celex/parsed");
+  const res = createResponseRecorder();
+
+  await handler({
+    params: { celex: "32013R0575" },
+    query: { lang: "ENG", version: "2024-01-01" },
+  }, res);
+
+  assert.equal(res.statusCode, 400);
+  assert.equal(res.payload.error, "Unsupported version. Expected: current");
+});
+
+test("GET /api/laws/:celex/parsed accepts ?version=current and forwards it to resolveParsedLaw", async () => {
+  const calls = [];
+  const { app } = registerTestRoutes({
+    resolveParsedLaw: async (celex, lang, options) => {
+      calls.push({ celex, lang, options });
+      return { celex, lang, source: "fmx-consolidated", version: "current", format: "combined-v1" };
+    },
+  });
+  const handler = app.routes.get("/api/laws/:celex/parsed");
+  const res = createResponseRecorder();
+
+  await handler({
+    params: { celex: "32013R0575" },
+    query: { lang: "ENG", version: "current" },
+  }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.payload.version, "current");
+  assert.deepEqual(calls, [{ celex: "32013R0575", lang: "ENG", options: { skipFmxProbe: false, version: "current" } }]);
+});
+
 test("GET /api/laws/:celex/case-law uses a short cache ttl", async () => {
   const resolutionCache = new Map();
   const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "case-law-route-"));

--- a/backend/shared/formex-parser/fmxParser.mjs
+++ b/backend/shared/formex-parser/fmxParser.mjs
@@ -13,7 +13,7 @@
  *  3. Textual:    Recital reference patterns in each language
  */
 
-import { getLangConfig, buildMeansRegex, buildFallbackDefRegex } from "./languages.mjs";
+import { getLangConfig, buildMeansRegex, buildFallbackDefRegex, buildUnquotedMeansRegex } from "./languages.mjs";
 import { buildEurlexSearchUrl } from "./url.mjs";
 import {
   ACT_CELEX_MAP,
@@ -33,7 +33,7 @@ import {
  * Bump this whenever the parser output changes (new fields, bug fixes, etc.)
  * so that cached parsed results are automatically re-parsed from raw XML.
  */
-export const PARSER_VERSION = 22;
+export const PARSER_VERSION = 23;
 
 // ---------------------------------------------------------------------------
 // FMX → HTML conversion helpers
@@ -1516,6 +1516,11 @@ export function parseFmxToCombined(xmlText) {
   const lang = getLangConfig(langCode);
   const meansRegex = buildMeansRegex(lang);
   const fallbackDefRegex = buildFallbackDefRegex(lang);
+  // Last-resort, unquoted-but-verb-anchored pattern (REACH, 32006R1907,
+  // Article 3: "substance: means a chemical element …" — no quote marks
+  // anywhere). Null for verb-first languages (FR, IT, ES, PT), whose
+  // drafting can never produce this shape.
+  const unquotedMeansRegex = buildUnquotedMeansRegex(lang);
 
   // --- Title ---
   // FMX <TI> contains multiple <P> elements; join them with spaces
@@ -1714,7 +1719,7 @@ export function parseFmxToCombined(xmlText) {
   // <CONTENTS>. Fall back to that so their articles aren't dropped; exclude any
   // <CONTENTS> that belongs to an <ANNEX> (annexes carry their own).
   const enactingTerms = root.querySelector("ENACTING\\.TERMS")
-    || Array.from(root.querySelectorAll("CONTENTS")).find((el) => !el.closest("ANNEX"));
+    || Array.from(root.querySelectorAll("CONTENTS")).find((el) => !el.closest("ANNEX, CONS\\.ANNEX"));
   if (enactingTerms) {
     // The container sits one level above the first real DIVISION, so start one
     // level higher to make the first nested DIVISION a chapter.
@@ -1733,7 +1738,7 @@ export function parseFmxToCombined(xmlText) {
     // rendered and indexed several times.
     const unnumberedRoot = legalRoots[0] || root;
     const unnumberedBody = Array.from(unnumberedRoot.children).find((child) => child.tagName === "PROLOG")
-      || Array.from(unnumberedRoot.children).find((child) => child.tagName === "CONTENTS" && !child.closest("ANNEX"))
+      || Array.from(unnumberedRoot.children).find((child) => child.tagName === "CONTENTS" && !child.closest("ANNEX, CONS\\.ANNEX"))
       || Array.from(unnumberedRoot.querySelectorAll("ENACTING\\.TERMS")).find((element) => allText(element))
       // Older competition-decision summaries place every substantive section
       // under PREAMBLE/GR.CONSID and leave ENACTING.TERMS empty. Selecting the
@@ -1784,7 +1789,11 @@ export function parseFmxToCombined(xmlText) {
   // same number, mis-attributing the annex's definitions to the act body.
   const articleElementsByNumber = new Map();
   for (const element of root.querySelectorAll("ARTICLE")) {
-    if (element.closest("QUOT\\.S") || element.closest("ANNEX")) continue;
+    // Consolidated documents name their annexes <CONS.ANNEX> rather than
+    // <ANNEX> (see the annex-extraction comment above); exclude both so a
+    // consolidated annex's restarted "Article 1" cannot shadow the same
+    // number in the enacting terms.
+    if (element.closest("QUOT\\.S") || element.closest("ANNEX, CONS\\.ANNEX")) continue;
     const id = (element.getAttribute("IDENTIFIER") || "").replace(/^0+/, "").toUpperCase();
     if (id && !articleElementsByNumber.has(id)) articleElementsByNumber.set(id, element);
   }
@@ -1923,17 +1932,36 @@ export function parseFmxToCombined(xmlText) {
 
       // Verb-first languages (GA, IT, ES, PT): meansVerb 'term' definition.
       // Term-first languages: 'term' meansVerb definition.
-      // Either way, try the configured meansVerb first, then fall back to the
-      // quoted-term pattern for languages where the verb appears only in the
-      // article intro (DE, FR, CS, SK, HU, FI, ET, LV, LT, EL, NL, DA, SV …).
-      // The verb-first languages need that fallback too: FR/IT/ES/PT state
-      // the verb once ("on entend par:") and then list «terme», définition.
+      // Try the configured meansVerb first, then — before giving up on a
+      // verb entirely — the unquoted-but-verb-anchored shape (REACH's
+      // "substance: means …", see buildUnquotedMeansRegex), then finally
+      // fall back to the quoted-term pattern for languages where the verb
+      // appears only in the article intro (DE, FR, CS, SK, HU, FI, ET, LV,
+      // LT, EL, NL, DA, SV …). The verb-first languages need that last
+      // fallback too: FR/IT/ES/PT state the verb once ("on entend par:")
+      // and then list «terme», définition.
       const termMatch = text.match(meansRegex);
       if (termMatch?.[1]) {
         const term = termMatch[1].trim();
         const definition = text.slice(termMatch[0].length).trim();
         // meansRegex always requires a quote character around the term.
         matched = makeDefinition(term, definition, true);
+      } else if (unquotedMeansRegex && unquotedMeansRegex.test(text)) {
+        const uqMatch = text.match(unquotedMeansRegex);
+        const term = uqMatch[1].trim();
+        const definition = text.slice(uqMatch[0].length).trim();
+        // REACH-style unquoted term with the meansVerb immediately after the
+        // colon ("substance: means a chemical element …"). Flagged NOT
+        // `quoted`, like LT/SV's quote-less fallback below: the meansVerb
+        // anchor is good evidence, but no quote character was seen, and the
+        // `quoted` flag governs exactly one thing — whether matches count in
+        // an article that does *not* title itself "Definitions" (see the
+        // corroboration bar near the end of this function). Acts drafted this
+        // way put their definitions in a titled article (REACH's Article 3
+        // does, so all 44 are kept), so restricting this pattern to titled
+        // articles costs nothing real and keeps a quote-less shape from
+        // clearing the bar in ordinary operative text.
+        matched = makeDefinition(term, definition, false);
       } else {
         const fbMatch = text.match(fallbackDefRegex);
         if (fbMatch?.[1]) {
@@ -2059,7 +2087,12 @@ export function parseFmxToCombined(xmlText) {
   const validArticleNumbers = new Set(articles.map((article) => article.article_number));
   // In combined documents, ANNEX elements are siblings of ACT
   const annexContainer = docRoot.tagName === "COMBINED.FMX" ? docRoot : root;
-  for (const annexEl of annexContainer.querySelectorAll("ANNEX")) {
+  // Consolidated ("as amended") documents root at <CONS.ACT> and name their
+  // annexes <CONS.ANNEX> instead of <ANNEX> — a distinct element, not a variant
+  // matched by the plain "ANNEX" selector. Left unhandled, every consolidated
+  // text (e.g. REACH, 32006R1907) parsed with annexes: [] despite the annex
+  // content being present in the source and structurally identical to <ANNEX>.
+  for (const annexEl of annexContainer.querySelectorAll("ANNEX, CONS\\.ANNEX")) {
     const annexTi = annexEl.querySelector("TITLE > TI");
     const annexSti = annexEl.querySelector("TITLE > STI");
     const tiText = annexTi ? allText(annexTi) : "";

--- a/backend/shared/formex-parser/fmxParser.test.js
+++ b/backend/shared/formex-parser/fmxParser.test.js
@@ -1599,6 +1599,108 @@ describe("definition extraction beyond the titled definitions article", () => {
     expect(result.definitions).toEqual([]);
   });
 
+  it("extracts annexes from consolidated (CONS.ACT / CONS.ANNEX) documents", () => {
+    // Consolidated ("as amended") EUR-Lex documents root at <CONS.ACT> and name
+    // their annexes <CONS.ANNEX> rather than <ANNEX> — a distinct element name,
+    // not a variant the plain "ANNEX" selector matches. Unhandled, this parsed
+    // every consolidated document (REACH, the consolidated CRR, etc.) with
+    // annexes: [] even though the annex content was present in the source.
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<COMBINED.FMX>
+  <CONS.ACT>
+    <TITLE><TI><P>Consolidated text of Regulation (EU) No 575/2013</P></TI></TITLE>
+    <ENACTING.TERMS>
+      <ARTICLE>
+        <TI.ART>Article 1</TI.ART>
+        <ALINEA><P>This Regulation lays down uniform rules.</P></ALINEA>
+      </ARTICLE>
+    </ENACTING.TERMS>
+  </CONS.ACT>
+  <CONS.ANNEX>
+    <TITLE>
+      <TI><P>ANNEX I</P></TI>
+      <STI><P>Classification of off-balance-sheet items</P></STI>
+    </TITLE>
+    <CONTENTS><P>Full risk items.</P></CONTENTS>
+  </CONS.ANNEX>
+  <CONS.ANNEX>
+    <TITLE>
+      <TI><P>ANNEX II</P></TI>
+      <STI><P>Types of derivatives</P></STI>
+    </TITLE>
+    <CONTENTS><P>Interest-rate contracts.</P></CONTENTS>
+  </CONS.ANNEX>
+</COMBINED.FMX>`;
+
+    const result = parseFmxToCombined(xml);
+    expect(result.annexes).toHaveLength(2);
+    expect(result.annexes[0].annex_id).toBe("I");
+    expect(result.annexes[0].annex_title).toBe("ANNEX I — Classification of off-balance-sheet items");
+    expect(result.annexes[0].annex_html.length).toBeGreaterThan(0);
+    expect(result.annexes[1].annex_id).toBe("II");
+    expect(result.annexes[1].annex_title).toBe("ANNEX II — Types of derivatives");
+    expect(result.annexes[1].annex_html.length).toBeGreaterThan(0);
+  });
+
+  it("does not let a CONS.ANNEX article shadow an enacting article of the same number", () => {
+    // Same shadowing bug as "does not let an annex article shadow an enacting
+    // article of the same number" above, but for consolidated documents. A
+    // <CONS.ANNEX> routinely restarts its own "Article 1", just like a plain
+    // <ANNEX> — but before this fix, articleElementsByNumber's exclusion only
+    // checked closest("ANNEX"), so a CONS.ANNEX article was never excluded.
+    // Because *every* consolidated document roots its annexes at CONS.ANNEX,
+    // this made the shadowing bug reachable in every single one of them, not
+    // just the odd malformed document.
+    //
+    // articleElementsByNumber resolves each identifier first-wins in document
+    // order, so the CONS.ANNEX is placed before CONS.ACT here to put its
+    // restarted <ARTICLE IDENTIFIER="001"> ahead of the real one — the exact
+    // ordering that would let it win the map slot were it not excluded, so
+    // this genuinely exercises the guard rather than merely repeating an
+    // identifier the map would resolve correctly by document order alone.
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<COMBINED.FMX>
+  <CONS.ANNEX>
+    <TITLE><TI>ANNEX</TI></TITLE>
+    <CONTENTS>
+      <ARTICLE IDENTIFIER="001">
+        <TI.ART>Article 1</TI.ART>
+        <ALINEA>
+          <P>For the purposes of this Annex, the following definitions apply:</P>
+          <LIST TYPE="ARAB">
+            <ITEM><NP><NO.P>(a)</NO.P><TXT>${quoted("annex term")} means something specific to the annex.</TXT></NP></ITEM>
+          </LIST>
+        </ALINEA>
+      </ARTICLE>
+    </CONTENTS>
+  </CONS.ANNEX>
+  <CONS.ACT>
+    <TITLE><TI><P>Consolidated text of Regulation (EU) No 575/2013</P></TI></TITLE>
+    <ENACTING.TERMS>
+      <ARTICLE IDENTIFIER="001">
+        <TI.ART>Article 1</TI.ART>
+        <STI.ART>Definitions</STI.ART>
+        <ALINEA>
+          <P>For the purposes of this Regulation, the following definitions apply:</P>
+          <LIST TYPE="ARAB">
+            <ITEM><NP><NO.P>(a)</NO.P><TXT>${quoted("own funds")} means the sum of Tier 1 capital and Tier 2 capital;</TXT></NP></ITEM>
+          </LIST>
+        </ALINEA>
+      </ARTICLE>
+    </ENACTING.TERMS>
+  </CONS.ACT>
+</COMBINED.FMX>`;
+
+    const result = parseFmxToCombined(xml);
+
+    // The enacting Article 1's own definition must come through untouched...
+    expect(result.definitions).toHaveLength(1);
+    expect(result.definitions[0]).toMatchObject({ term: "own funds", sourceArticle: "1" });
+    // ...and the CONS.ANNEX article's "Article 1" must never be the one that
+    // articleElementsByNumber resolves "1" to, so its term must not surface.
+    expect(result.definitions.some((d) => d.term === "annex term")).toBe(false);
+  });
+
   it("does not corroborate an untitled article from SV's quote-less colon fallback", () => {
     // 32013R0575 SWE gained ~31 junk definitions this way in production: the
     // SV fallback pattern (buildFallbackDefRegex) needs no quote characters
@@ -1647,6 +1749,76 @@ describe("definition extraction beyond the titled definitions article", () => {
       </ARTICLE>`));
 
     expect(result.definitions.map((d) => d.term)).toEqual(["kreditinstitut"]);
+  });
+
+  it("reads an unquoted 'term: means …' definition (REACH's own drafting style)", () => {
+    // Regulation (EC) No 1907/2006 (REACH), Article 3: every one of its 44
+    // definitions states an unquoted term followed by a colon and "means" —
+    // no QUOT.START/QUOT.END anywhere in the article — which both
+    // buildMeansRegex and buildFallbackDefRegex miss entirely because they
+    // require quote characters around the term.
+    const result = parseFmxToCombined(actWithArticles(`
+      <ARTICLE IDENTIFIER="003">
+        <TI.ART>Article 3</TI.ART>
+        <STI.ART>Definitions</STI.ART>
+        <ALINEA>
+          <P>For the purposes of this Regulation:</P>
+          <LIST TYPE="ARAB">
+            <ITEM><NP><NO.P>1.</NO.P><TXT>substance: means a chemical element and its compounds in the natural state or obtained by any manufacturing process.</TXT></NP></ITEM>
+            <ITEM><NP><NO.P>3.</NO.P><TXT>article: means an object which during production is given a special shape, surface or design.</TXT></NP></ITEM>
+          </LIST>
+        </ALINEA>
+      </ARTICLE>`));
+
+    expect(result.definitions.map((d) => d.term)).toEqual(["substance", "article"]);
+    expect(result.definitions[0].definition).toBe(
+      "a chemical element and its compounds in the natural state or obtained by any manufacturing process."
+    );
+  });
+
+  it("does not treat a bare unquoted 'term: definition' with no verb as a definition", () => {
+    // The guard against over-matching: an unquoted term is only trusted when
+    // the meansVerb immediately follows the colon. Without it, this shape is
+    // indistinguishable from ordinary prose ("Member States shall ensure
+    // that: …") and must not become a definition, even in a titled
+    // definitions article where the corroboration bar would otherwise wave
+    // it through.
+    const result = parseFmxToCombined(actWithArticles(`
+      <ARTICLE IDENTIFIER="003">
+        <TI.ART>Article 3</TI.ART>
+        <STI.ART>Definitions</STI.ART>
+        <ALINEA>
+          <P>For the purposes of this Regulation:</P>
+          <LIST TYPE="ARAB">
+            <ITEM><NP><NO.P>1.</NO.P><TXT>substance: a chemical element and its compounds in the natural state.</TXT></NP></ITEM>
+          </LIST>
+        </ALINEA>
+      </ARTICLE>`));
+
+    expect(result.definitions).toEqual([]);
+  });
+
+  it("does not read unquoted 'term: means …' in an article that is not titled Definitions", () => {
+    // Deliberately conservative: the unquoted shape is flagged NOT `quoted`,
+    // so — exactly like LT/SV's quote-less fallback — it cannot clear the
+    // corroboration bar in an article that does not declare itself a
+    // definitions article. Acts drafted this way (REACH) title the article,
+    // so nothing real is lost, and ordinary operative text that happens to
+    // put a meansVerb after a colon twice cannot manufacture definitions.
+    const result = parseFmxToCombined(actWithArticles(`
+      <ARTICLE IDENTIFIER="012">
+        <TI.ART>Article 12</TI.ART>
+        <STI.ART>Obligations of manufacturers</STI.ART>
+        <ALINEA>
+          <P>For the purposes of this Article:</P>
+          <LIST TYPE="ARAB">
+            <ITEM><NP><NO.P>1.</NO.P><TXT>substance: means a chemical element and its compounds in the natural state.</TXT></NP></ITEM>
+            <ITEM><NP><NO.P>2.</NO.P><TXT>article: means an object which during production is given a special shape.</TXT></NP></ITEM>
+          </LIST>
+        </ALINEA>
+      </ARTICLE>`));
+
+    expect(result.definitions).toEqual([]);
   });
 });
 

--- a/backend/shared/formex-parser/languages.mjs
+++ b/backend/shared/formex-parser/languages.mjs
@@ -853,6 +853,55 @@ export function buildFallbackDefRegex(lang) {
 }
 
 /**
+ * Build a regex for the *unquoted, verb-anchored* "term: meansVerb …" shape,
+ * where the term carries no quote marks at all but the meansVerb immediately
+ * follows the colon:
+ *
+ *   substance: means a chemical element and its compounds in the natural
+ *   state or obtained by any manufacturing process, …
+ *   article: means an object which during production is given a special
+ *   shape, surface or design which determines its function …
+ *
+ * (Regulation (EC) No 1907/2006 — REACH — Article 3: all 44 of its
+ * definitions are drafted this way, with zero quoted terms anywhere in the
+ * article.) `buildColonDefRegex` above already matches an unquoted colon
+ * shape, but treats the meansVerb as an optional bonus and instead leans on
+ * its caller's own word-count/length corroboration (see
+ * eurlex-html-parser.js's `unquotedDefinitionEntry`) — appropriate there
+ * because that caller has no quote-based signal to fall back on at all. This
+ * function is for callers (fmxParser.mjs) that *do* have quote-based
+ * patterns to try first and only reach for the unquoted shape as a last
+ * resort, where a bare `term: definition` with no verb is far too weak a
+ * signal on its own — that shape is deliberately handled only for LT/SV's
+ * quote-less `buildFallbackDefRegex`, which documents itself as the most
+ * over-match-prone pattern here. Requiring the verb right after the colon is
+ * what makes this pattern safe to add: no verb after the colon, no match —
+ * ordinary prose containing an incidental colon ("Member States shall
+ * ensure that: …") never has "means"/"shall mean" immediately following it,
+ * so it is never mistaken for a definition.
+ *
+ * Verb-first languages (FR, IT, ES, PT) put the meansVerb *before* the term
+ * ("on entend par «terme»", "si intende per «termine»") — their drafting can
+ * never produce an unquoted "term: verb" shape, so this returns null for
+ * them rather than emitting a pattern that can never match.
+ *
+ * Capture group 1 = the term text; the trailing meansVerb (and an optional
+ * colon/comma before the definition continues under a nested list, the same
+ * empty-group-2 shape buildMeansRegex documents as expected) is consumed.
+ */
+export function buildUnquotedMeansRegex(lang) {
+  if (lang.definitionFormat === "verb_first") return null;
+  const verb = `(?:${lang.meansVerb})`;
+  // Term sanity mirrors buildColonDefRegex: no sentence punctuation inside
+  // the term, and a length cap so a stray colon deep in a long sentence that
+  // happens to contain the meansVerb can't retroactively become a "term".
+  return new RegExp(
+    `^([^:;.,\\u2013\\u2014]{2,60}?)\\s*:\\s*${verb}\\s*[:,]?(?:\\s+|$)`,
+    "i"
+  );
+}
+
+/**
  * Build a regex for the *unquoted* colon shape, where the term carries no
  * quotation marks at all and the colon is the only separator:
  *

--- a/backend/shared/parsed-law-service.js
+++ b/backend/shared/parsed-law-service.js
@@ -29,10 +29,39 @@ function createParsedLawResolver({
   fetchConsolidatedVersions,
   runSparqlQuery,
 }) {
-  const parsedCache = new Map(); // `${celex}:${lang}:${skipFmxProbe}` -> parsed law
+  const parsedCache = new Map(); // `${celex}:${lang}:${skipFmxProbe}:${version}` -> parsed law
 
-  async function resolveParsedLaw(celex, lang, { skipFmxProbe = false } = {}) {
-    const cacheKey = `${celex}:${lang}:${skipFmxProbe ? 1 : 0}`;
+  /**
+   * Fetches and parses the current consolidated ("as amended") EUR-Lex
+   * version of `celex`, or returns `null` when there isn't one worth
+   * serving: no consolidation mechanism wired up, no versions at all, only
+   * future-dated ones (`selectConsolidatedVersions` already excludes those —
+   * presenting an upcoming text as the one in force would be worse than
+   * saying nothing), or a consolidated Formex that itself parses to nothing
+   * (Cellar's `manifestation_type` occasionally points at a version whose
+   * article bodies are empty). Throws on network/SPARQL/Cellar failure —
+   * every call site is responsible for swallowing that back to its own
+   * fallback; this helper only decides *whether* a usable consolidated
+   * document exists, not what to do when it can't tell.
+   */
+  async function loadConsolidatedLaw(celex, lang) {
+    if (typeof fetchConsolidatedVersions !== 'function' || typeof runSparqlQuery !== 'function') {
+      return null;
+    }
+    const { versions } = await fetchConsolidatedVersions(celex, runSparqlQuery);
+    const { current } = selectConsolidatedVersions(versions);
+    if (!current) return null;
+
+    const { servePath } = await prepareLawPayload(current.celex, lang);
+    const xmlText = fs.readFileSync(servePath, 'utf8');
+    const consolidatedParsed = await parseFmxXml(xmlText);
+    if (!hasParsedLawContent(consolidatedParsed)) return null;
+
+    return { parsed: consolidatedParsed, version: { celex: current.celex, date: current.date } };
+  }
+
+  async function resolveParsedLaw(celex, lang, { skipFmxProbe = false, version = null } = {}) {
+    const cacheKey = `${celex}:${lang}:${skipFmxProbe ? 1 : 0}:${version || 'none'}`;
     const cached = cacheGet(parsedCache, cacheKey);
     if (cached) return cached;
 
@@ -60,6 +89,29 @@ function createParsedLawResolver({
       parsed = await parseFmxXml(xmlText);
     }
 
+    // Keep a handle on the as-adopted parse before anything below may
+    // replace `parsed` — the requested-version path composes against this,
+    // and it must be the act's own recitals, never a consolidated one's
+    // (EUR-Lex consolidations carry zero recitals to begin with).
+    const asAdoptedParsed = parsed;
+
+    // Both the empty-parse fallback and the requested-version path may need
+    // the same consolidated document; fetch it at most once per call and
+    // remember the outcome (including "nothing usable") for the second
+    // consumer.
+    let consolidatedAttempted = false;
+    let consolidatedResult = null;
+    async function getConsolidated() {
+      if (consolidatedAttempted) return consolidatedResult;
+      consolidatedAttempted = true;
+      try {
+        consolidatedResult = await loadConsolidatedLaw(celex, lang);
+      } catch {
+        consolidatedResult = null;
+      }
+      return consolidatedResult;
+    }
+
     let consolidatedVersion = null;
     if (!hasParsedLawContent(parsed)) {
       // The act as adopted parsed to nothing renderable (e.g. REACH, whose
@@ -72,24 +124,73 @@ function createParsedLawResolver({
       // consolidated versions at all) is swallowed back to the empty
       // as-adopted result — a fallback must never turn a rendering law into
       // an error.
-      try {
-        if (typeof fetchConsolidatedVersions === 'function' && typeof runSparqlQuery === 'function') {
-          const { versions } = await fetchConsolidatedVersions(celex, runSparqlQuery);
-          const { current } = selectConsolidatedVersions(versions);
-          if (current) {
-            const { servePath } = await prepareLawPayload(current.celex, lang);
-            const xmlText = fs.readFileSync(servePath, 'utf8');
-            const consolidatedParsed = await parseFmxXml(xmlText);
-            if (hasParsedLawContent(consolidatedParsed)) {
-              parsed = consolidatedParsed;
-              source = 'fmx-consolidated';
-              consolidatedVersion = { celex: current.celex, date: current.date };
-            }
-          }
-        }
-      } catch {
-        // Swallow: keep the empty as-adopted result rather than error out.
+      const loaded = await getConsolidated();
+      if (loaded) {
+        parsed = loaded.parsed;
+        source = 'fmx-consolidated';
+        consolidatedVersion = loaded.version;
       }
+    }
+
+    // The requested-version path: unlike the fallback above (which replaces
+    // an unrenderable as-adopted act wholesale), this always COMPOSES —
+    // consolidated articles/annexes/definitions/crossReferences paired with
+    // the as-adopted recitals, because consolidation never amends recitals,
+    // and EUR-Lex's consolidated Formex omits the <PREAMBLE.RECITALS> block
+    // entirely. Losing recitals would silently break the recital grid, the
+    // TF-IDF recital→article map, AI recital titles and the related-recitals
+    // rail — the whole reason this feature composes instead of just linking
+    // out to the consolidated text (see #144/#170).
+    let versionUnavailable = false;
+    if (version === 'current') {
+      let loaded = null;
+      try {
+        loaded = await getConsolidated();
+      } catch {
+        loaded = null;
+      }
+
+      if (loaded) {
+        const asAdoptedArticleNumbers = new Set(
+          (asAdoptedParsed?.articles || []).map((article) => article.article_number),
+        );
+        const composedArticles = (loaded.parsed.articles || []).map((article) => (
+          asAdoptedArticleNumbers.has(article.article_number)
+            ? article
+            : { ...article, insertedInVersion: true }
+        ));
+        const composedParsed = {
+          ...loaded.parsed,
+          articles: composedArticles,
+          recitals: asAdoptedParsed?.recitals || [],
+        };
+
+        const result = {
+          celex,
+          lang,
+          name: CELEX_NAMES[celex] || null,
+          format: 'combined-v1',
+          ...composedParsed,
+          source: 'fmx-consolidated',
+          version: 'current',
+          versionCelex: loaded.version.celex,
+          versionDate: loaded.version.date,
+          recitalsSource: 'as-adopted',
+          consolidatedVersion: loaded.version,
+        };
+        result.hasContent = hasParsedLawContent(composedParsed);
+
+        cacheSet(parsedCache, cacheKey, result, PARSED_LAW_CACHE_MS, MAX_PARSED_CACHE_ENTRIES);
+        return result;
+      }
+
+      // No consolidated version at all, only future-dated ones, an
+      // unresolvable version (Cellar 406s roughly 1 in 15 listed versions),
+      // or a Cellar/SPARQL outage — a requested version must never turn a
+      // rendering law into an error. Fall through and serve the normal
+      // as-adopted payload, flagged so the frontend can say so honestly
+      // instead of a toggle that silently did nothing.
+      versionUnavailable = true;
     }
 
     const result = {
@@ -102,6 +203,7 @@ function createParsedLawResolver({
     };
     result.hasContent = hasParsedLawContent(parsed);
     if (consolidatedVersion) result.consolidatedVersion = consolidatedVersion;
+    if (versionUnavailable) result.versionUnavailable = true;
 
     cacheSet(parsedCache, cacheKey, result, PARSED_LAW_CACHE_MS, MAX_PARSED_CACHE_ENTRIES);
     return result;

--- a/backend/shared/parsed-law-service.js
+++ b/backend/shared/parsed-law-service.js
@@ -151,11 +151,13 @@ function createParsedLawResolver({
       }
 
       if (loaded) {
+        const asAdoptedArticles = asAdoptedParsed?.articles || [];
+        const hasUsableAsAdoptedArticleBaseline = asAdoptedArticles.length > 0;
         const asAdoptedArticleNumbers = new Set(
-          (asAdoptedParsed?.articles || []).map((article) => article.article_number),
+          asAdoptedArticles.map((article) => article.article_number),
         );
         const composedArticles = (loaded.parsed.articles || []).map((article) => (
-          asAdoptedArticleNumbers.has(article.article_number)
+          !hasUsableAsAdoptedArticleBaseline || asAdoptedArticleNumbers.has(article.article_number)
             ? article
             : { ...article, insertedInVersion: true }
         ));

--- a/backend/shared/parsed-law-service.test.js
+++ b/backend/shared/parsed-law-service.test.js
@@ -29,6 +29,50 @@ const EMPTY_FMX = `<?xml version="1.0" encoding="UTF-8"?>
   <BIB.INSTANCE><LG.DOC>EN</LG.DOC></BIB.INSTANCE>
 </ACT>`;
 
+// An as-adopted document with both recitals and one article (Article 1),
+// used for the requested-version compose tests: the consolidated fixture
+// below carries Article 1 (unchanged) plus a new Article 2 that has no
+// as-adopted counterpart, so tests can assert both the recital pairing and
+// `insertedInVersion`.
+const AS_ADOPTED_FMX_WITH_RECITALS_AND_ARTICLE = `<?xml version="1.0" encoding="UTF-8"?>
+<ACT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://formex.publications.europa.eu/schema/formex-05.59-20170418.xd">
+  <BIB.INSTANCE><LG.DOC>EN</LG.DOC></BIB.INSTANCE>
+  <PREAMBLE>
+    <GR.CONSID>
+      <CONSID><NP><NO.P>(1)</NO.P><TXT>As-adopted recital text.</TXT></NP></CONSID>
+    </GR.CONSID>
+  </PREAMBLE>
+  <ENACTING.TERMS>
+    <DIVISION>
+      <ARTICLE IDENTIFIER="001">
+        <TI.ART>Article 1</TI.ART>
+        <ALINEA><P>As-adopted body text.</P></ALINEA>
+      </ARTICLE>
+    </DIVISION>
+  </ENACTING.TERMS>
+</ACT>`;
+
+// The consolidated ("as amended") version of the act above: Article 1 is
+// unchanged, and Article 2 was inserted by a later amendment — EUR-Lex's
+// consolidated Formex carries no <PREAMBLE.RECITALS>/<GR.CONSID> block at
+// all, which is exactly what the compose is for.
+const CONSOLIDATED_FMX_WITH_TWO_ARTICLES = `<?xml version="1.0" encoding="UTF-8"?>
+<ACT xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://formex.publications.europa.eu/schema/formex-05.59-20170418.xd">
+  <BIB.INSTANCE><LG.DOC>EN</LG.DOC></BIB.INSTANCE>
+  <ENACTING.TERMS>
+    <DIVISION>
+      <ARTICLE IDENTIFIER="001">
+        <TI.ART>Article 1</TI.ART>
+        <ALINEA><P>As-adopted body text.</P></ALINEA>
+      </ARTICLE>
+      <ARTICLE IDENTIFIER="002">
+        <TI.ART>Article 2</TI.ART>
+        <ALINEA><P>Inserted-by-amendment body text.</P></ALINEA>
+      </ARTICLE>
+    </DIVISION>
+  </ENACTING.TERMS>
+</ACT>`;
+
 function writeTempXml(content) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'parsed-law-service-test-'));
   const filePath = path.join(dir, 'law.xml');
@@ -235,4 +279,150 @@ test('consolidated fallback: does not run at all when content is already present
   assert.equal(result.source, 'fmx');
   assert.equal(result.hasContent, true);
   assert.equal(fallbackCalled, false);
+});
+
+test('requested version "current": composes consolidated articles with as-adopted recitals', async () => {
+  const asAdoptedPath = writeTempXml(AS_ADOPTED_FMX_WITH_RECITALS_AND_ARTICLE);
+  const consolidatedPath = writeTempXml(CONSOLIDATED_FMX_WITH_TWO_ARTICLES);
+
+  const resolveParsedLaw = createParsedLawResolver({
+    prepareLawPayload: async (celex) => ({
+      servePath: celex === '32013R0575' ? asAdoptedPath : consolidatedPath,
+    }),
+    fetchConsolidatedVersions: async (celex) => {
+      assert.equal(celex, '32013R0575');
+      return { versions: [{ celex: '02013R0575-20260626', date: '2026-06-26' }] };
+    },
+    runSparqlQuery: async () => ({}),
+  });
+
+  const result = await resolveParsedLaw('32013R0575', 'ENG', { version: 'current' });
+
+  assert.equal(result.source, 'fmx-consolidated');
+  assert.equal(result.version, 'current');
+  assert.equal(result.versionCelex, '02013R0575-20260626');
+  assert.equal(result.versionDate, '2026-06-26');
+  assert.equal(result.recitalsSource, 'as-adopted');
+  assert.deepEqual(result.consolidatedVersion, { celex: '02013R0575-20260626', date: '2026-06-26' });
+  assert.equal(result.versionUnavailable, undefined);
+
+  // Articles come from the consolidated document (both Article 1 and 2)…
+  assert.equal(result.articles.length, 2);
+  // …while recitals come from the as-adopted document, not the consolidated
+  // one (which carries none at all).
+  assert.equal(result.recitals.length, 1);
+  assert.equal(result.recitals[0].recital_text, 'As-adopted recital text.');
+});
+
+test('requested version "current": insertedInVersion is set only on articles with no as-adopted counterpart', async () => {
+  const asAdoptedPath = writeTempXml(AS_ADOPTED_FMX_WITH_RECITALS_AND_ARTICLE);
+  const consolidatedPath = writeTempXml(CONSOLIDATED_FMX_WITH_TWO_ARTICLES);
+
+  const resolveParsedLaw = createParsedLawResolver({
+    prepareLawPayload: async (celex) => ({
+      servePath: celex === '32013R0575' ? asAdoptedPath : consolidatedPath,
+    }),
+    fetchConsolidatedVersions: async () => ({ versions: [{ celex: '02013R0575-20260626', date: '2026-06-26' }] }),
+    runSparqlQuery: async () => ({}),
+  });
+
+  const result = await resolveParsedLaw('32013R0575', 'ENG', { version: 'current' });
+
+  const byNumber = Object.fromEntries(result.articles.map((a) => [a.article_number, a]));
+  assert.equal(byNumber['1'].insertedInVersion, undefined, 'Article 1 exists as-adopted, so it must not be flagged');
+  assert.equal(byNumber['2'].insertedInVersion, true, 'Article 2 has no as-adopted counterpart');
+});
+
+test('requested version "current": falls back with versionUnavailable when no consolidated version exists', async () => {
+  const asAdoptedPath = writeTempXml(AS_ADOPTED_FMX_WITH_RECITALS_AND_ARTICLE);
+
+  const resolveParsedLaw = createParsedLawResolver({
+    prepareLawPayload: async () => ({ servePath: asAdoptedPath }),
+    fetchConsolidatedVersions: async () => ({ versions: [] }),
+    runSparqlQuery: async () => ({}),
+  });
+
+  const result = await resolveParsedLaw('32013R0575', 'ENG', { version: 'current' });
+
+  assert.equal(result.versionUnavailable, true);
+  assert.equal(result.source, 'fmx');
+  assert.equal(result.version, undefined);
+  // The as-adopted content is served intact, not an empty stub.
+  assert.equal(result.articles.length, 1);
+  assert.equal(result.recitals.length, 1);
+});
+
+test('requested version "current": falls back with versionUnavailable when every consolidated version is future-dated', async () => {
+  const asAdoptedPath = writeTempXml(AS_ADOPTED_FMX_WITH_RECITALS_AND_ARTICLE);
+
+  const resolveParsedLaw = createParsedLawResolver({
+    prepareLawPayload: async () => ({ servePath: asAdoptedPath }),
+    fetchConsolidatedVersions: async () => ({ versions: [{ celex: '02013R0575-20990101', date: '2099-01-01' }] }),
+    runSparqlQuery: async () => ({}),
+  });
+
+  const result = await resolveParsedLaw('32013R0575', 'ENG', { version: 'current' });
+
+  assert.equal(result.versionUnavailable, true);
+  assert.equal(result.source, 'fmx');
+  assert.equal(result.articles.length, 1);
+});
+
+test('requested version "current": falls back with versionUnavailable when the consolidated fetch fails (Cellar/SPARQL outage or 406)', async () => {
+  const asAdoptedPath = writeTempXml(AS_ADOPTED_FMX_WITH_RECITALS_AND_ARTICLE);
+
+  const resolveParsedLaw = createParsedLawResolver({
+    prepareLawPayload: async () => ({ servePath: asAdoptedPath }),
+    fetchConsolidatedVersions: async () => { throw new Error('Cellar returned 406'); },
+    runSparqlQuery: async () => ({}),
+  });
+
+  const result = await resolveParsedLaw('32013R0575', 'ENG', { version: 'current' });
+
+  assert.equal(result.versionUnavailable, true);
+  assert.equal(result.source, 'fmx');
+  assert.equal(result.articles.length, 1);
+  assert.equal(result.recitals.length, 1);
+});
+
+test('as-adopted and requested-version "current" results are cached under distinct keys', async () => {
+  const asAdoptedPath = writeTempXml(AS_ADOPTED_FMX_WITH_RECITALS_AND_ARTICLE);
+  const consolidatedPath = writeTempXml(CONSOLIDATED_FMX_WITH_TWO_ARTICLES);
+  let prepareCalls = 0;
+  let fetchConsolidatedCalls = 0;
+
+  const resolveParsedLaw = createParsedLawResolver({
+    prepareLawPayload: async (celex) => {
+      prepareCalls += 1;
+      return { servePath: celex === '32013R0575' ? asAdoptedPath : consolidatedPath };
+    },
+    fetchConsolidatedVersions: async () => {
+      fetchConsolidatedCalls += 1;
+      return { versions: [{ celex: '02013R0575-20260626', date: '2026-06-26' }] };
+    },
+    runSparqlQuery: async () => ({}),
+  });
+
+  const asAdopted = await resolveParsedLaw('32013R0575', 'ENG', {});
+  assert.equal(asAdopted.source, 'fmx');
+  assert.equal(asAdopted.articles.length, 1);
+  assert.equal(fetchConsolidatedCalls, 0, 'the as-adopted parse has content, so no consolidated fetch is needed');
+
+  const current = await resolveParsedLaw('32013R0575', 'ENG', { version: 'current' });
+  assert.equal(current.source, 'fmx-consolidated');
+  assert.equal(current.articles.length, 2);
+  assert.equal(fetchConsolidatedCalls, 1);
+  // Each resolveParsedLaw call is cached under its own key, so the requested
+  // version's own call re-probes the as-adopted FMX (to get the recitals to
+  // compose with) in addition to fetching the consolidated document — that
+  // is the second and third prepareLawPayload calls.
+  assert.equal(prepareCalls, 3);
+
+  // Both are now served from cache without any further fetch/parse work.
+  const asAdoptedAgain = await resolveParsedLaw('32013R0575', 'ENG', {});
+  const currentAgain = await resolveParsedLaw('32013R0575', 'ENG', { version: 'current' });
+  assert.equal(asAdoptedAgain.articles.length, 1);
+  assert.equal(currentAgain.articles.length, 2);
+  assert.equal(prepareCalls, 3, 'cached calls must not re-fetch either version');
+  assert.equal(fetchConsolidatedCalls, 1);
 });

--- a/backend/shared/parsed-law-service.test.js
+++ b/backend/shared/parsed-law-service.test.js
@@ -333,6 +333,28 @@ test('requested version "current": insertedInVersion is set only on articles wit
   assert.equal(byNumber['2'].insertedInVersion, true, 'Article 2 has no as-adopted counterpart');
 });
 
+test('requested version "current": does not label every article inserted when the as-adopted baseline is empty', async () => {
+  const emptyAsAdoptedPath = writeTempXml(EMPTY_FMX);
+  const consolidatedPath = writeTempXml(CONSOLIDATED_FMX_WITH_TWO_ARTICLES);
+
+  const resolveParsedLaw = createParsedLawResolver({
+    prepareLawPayload: async (celex) => ({
+      servePath: celex === '32013R0575' ? emptyAsAdoptedPath : consolidatedPath,
+    }),
+    fetchConsolidatedVersions: async () => ({ versions: [{ celex: '02013R0575-20260626', date: '2026-06-26' }] }),
+    runSparqlQuery: async () => ({}),
+  });
+
+  const result = await resolveParsedLaw('32013R0575', 'ENG', { version: 'current' });
+
+  assert.equal(result.articles.length, 2);
+  assert.equal(
+    result.articles.some((article) => article.insertedInVersion),
+    false,
+    'an empty baseline cannot prove that any consolidated article was inserted',
+  );
+});
+
 test('requested version "current": falls back with versionUnavailable when no consolidated version exists', async () => {
   const asAdoptedPath = writeTempXml(AS_ADOPTED_FMX_WITH_RECITALS_AND_ARTICLE);
 

--- a/src/components/CitedByPanel.jsx
+++ b/src/components/CitedByPanel.jsx
@@ -9,7 +9,7 @@ import { buildCitedByDisplay, isCitedByUnavailableError } from "./citedByDisplay
 
 // `compact` renders the panel for the narrow context rail: no outer gutters
 // and no title row (the rail tab already says "Cited by").
-export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenLaw, compact = false }) {
+export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenLaw, compact = false, insertedInVersion = false }) {
   const { t } = useI18n();
   const [payload, setPayload] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -30,7 +30,11 @@ export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenL
   }, [celex, articleNumber]);
 
   useEffect(() => {
-    if (!celex || !articleNumber || loaded) return;
+    // An article inserted by amendment (`?version=current`, #149) has no
+    // as-adopted counterpart, so the citation graph — built from the
+    // as-adopted text — has nothing to map to it. Skip the fetch rather than
+    // ask an endpoint that can only ever answer "nothing".
+    if (!celex || !articleNumber || loaded || insertedInVersion) return;
     let cancelled = false;
     setLoading(true);
     setError(null);
@@ -59,7 +63,7 @@ export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenL
     return () => {
       cancelled = true;
     };
-  }, [articleNumber, celex, loaded]);
+  }, [articleNumber, celex, loaded, insertedInVersion]);
 
   const retry = useCallback(() => {
     setError(null);
@@ -85,6 +89,17 @@ export function CitedByPanel({ celex, articleNumber, currentLang = "EN", onOpenL
   }), [expanded, payload, t]);
 
   if (!celex || !articleNumber || suppressed) return null;
+
+  if (insertedInVersion) {
+    return (
+      <div className={outerClass}>
+        <div className={`flex items-center gap-2 py-3 text-sm text-gray-500 dark:text-gray-400 ${compact ? "" : "border-y border-gray-200 dark:border-gray-800"}`}>
+          <Link2 size={16} className="shrink-0 text-gray-400 dark:text-gray-500" />
+          <span>{t("citedBy.insertedInVersion")}</span>
+        </div>
+      </div>
+    );
+  }
 
   if (loading && !loaded) {
     if (compact) {

--- a/src/components/ConsolidationNotice.jsx
+++ b/src/components/ConsolidationNotice.jsx
@@ -172,12 +172,18 @@ export function ConsolidationNotice({
     </button>
   ) : null;
 
-  // No link means either: no consolidated version has ever been published
-  // (say so), only future-dated ones exist (say that instead, honestly), or
-  // the /consolidated fetch itself failed (say nothing — we don't know).
+  // No link means either: the query has not answered yet (say nothing), no
+  // consolidated version has ever been published (say so), only future-dated
+  // ones exist (say that instead, honestly), or the /consolidated fetch
+  // itself failed (say nothing — we don't know).
   let noVersionMessage = null;
   if (!link) {
-    if (status.consolidatedStatusUnknown) {
+    if (status.consolidatedStatusPending) {
+      // The query is still in flight — claiming either way would be a guess,
+      // and the wrong guess flashes on every amended act before the toggle
+      // appears.
+      noVersionMessage = null;
+    } else if (status.consolidatedStatusUnknown) {
       noVersionMessage = null;
     } else if (status.hasUpcomingConsolidation) {
       noVersionMessage = t("consolidation.consolidatedVersionPending");

--- a/src/components/ConsolidationNotice.jsx
+++ b/src/components/ConsolidationNotice.jsx
@@ -121,7 +121,52 @@ export function ConsolidationNotice({
   }
 
   if (isConsolidatedFallback) return null;
-  if (!status.isOutdated) return null;
+
+  // Never amended. Silence would be ambiguous — the reader cannot tell "we
+  // checked and it is current" from "we did not check" — so the overview says
+  // so positively. Only the overview: a reassurance repeated above every
+  // article is noise, and the inline variant exists to warn, not to chat.
+  if (!status.isOutdated) {
+    if (variant === "inline") return null;
+    // Say nothing until the history has actually answered. Claiming a law has
+    // never been amended on the strength of a failed or in-flight fetch is
+    // the same error as claiming no consolidated version exists.
+    if (status.amendmentStatusPending || status.amendmentStatusUnknown) return null;
+
+    const corrigenda = status.corrigendumCount;
+    // A corrigendum-only act (the GDPR) is the one case where "not amended"
+    // is true and still misleading: EUR-Lex applies corrigenda to the
+    // consolidated text but not to the act as published, so the text on
+    // screen really is uncorrected. Offer the same toggle, labelled for what
+    // it actually does here — nothing was amended, the text was corrected.
+    const correctionAction = (corrigenda > 0 && status.consolidated && onToggleVersion) ? (
+      <button
+        type="button"
+        onClick={() => onToggleVersion("current")}
+        className="inline-flex items-center gap-1 font-semibold text-slate-900 underline underline-offset-2 hover:no-underline dark:text-slate-100"
+      >
+        {t("consolidation.toggleReadCorrected")}
+      </button>
+    ) : null;
+
+    return (
+      <div className="mb-6 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 dark:border-slate-800 dark:bg-slate-900/40 dark:text-slate-300">
+        <div className="flex items-center gap-2 font-medium text-slate-900 dark:text-slate-100">
+          <History size={15} aria-hidden="true" />
+          {t("consolidation.upToDate")}
+        </div>
+        <p className="mt-1 leading-6">
+          {t("consolidation.neverAmended")}
+          {corrigenda > 0 ? (
+            <> {corrigenda === 1
+              ? t("consolidation.correctedOnce")
+              : t("consolidation.corrected", { count: corrigenda })}</>
+          ) : null}
+        </p>
+        {correctionAction ? <p className="mt-2 text-xs">{correctionAction}</p> : null}
+      </div>
+    );
+  }
 
   const amendedOn = formatMetaDate(status.latestAmendmentDate, locale);
   const consolidatedOn = formatMetaDate(status.consolidated?.date, locale);
@@ -167,7 +212,11 @@ export function ConsolidationNotice({
       onClick={() => onToggleVersion("current")}
       className="inline-flex items-center gap-1 font-semibold text-amber-950 underline underline-offset-2 hover:no-underline dark:text-amber-100"
     >
-      <History size={13} aria-hidden="true" />
+      {/* No icon: every branch of this notice already leads with a History
+          glyph, and repeating it on the action reads as a second, unrelated
+          marker rather than as emphasis. `backAction` carries an ArrowLeft
+          for the same reason — a distinct icon earns its place, a repeated
+          one does not. */}
       {t("consolidation.toggleReadAmended")}
     </button>
   ) : null;

--- a/src/components/ConsolidationNotice.jsx
+++ b/src/components/ConsolidationNotice.jsx
@@ -1,4 +1,4 @@
-import { ExternalLink, History } from "lucide-react";
+import { ArrowLeft, ExternalLink, History } from "lucide-react";
 
 import { useI18n } from "../i18n/useI18n.js";
 import { useConsolidationStatus } from "../hooks/useConsolidationStatus.js";
@@ -7,30 +7,118 @@ import { buildEurlexCelexUrl } from "../utils/url.js";
 
 /**
  * Tells the reader that the text on screen is the act as adopted, and that it
- * has since been amended.
+ * has since been amended — and, once a current consolidated version exists,
+ * lets them switch to reading it (`?version=current`, #149's first slice).
  *
- * Everything LegalViz renders is the original published text; for a heavily
- * amended act that is the wrong answer to most practical questions, and nothing
- * in the reader said so. The consolidated text itself is not rendered here (it
- * is a different Formex schema, and EUR-Lex strips the recitals this app is
- * built around) — so the notice links out to it rather than pretending.
+ * Everything LegalViz renders by default is the original published text; for
+ * a heavily amended act that is the wrong answer to most practical questions,
+ * and nothing in the reader said so before this notice. Historically the only
+ * remedy was linking out to EUR-Lex — the consolidated text is a different
+ * Formex schema this app didn't parse. It does now (the backend composes
+ * consolidated articles with the as-adopted recitals, since EUR-Lex publishes
+ * consolidated texts with none), so the toggle button is the primary action
+ * and the EUR-Lex link stays only as a secondary escape hatch.
  *
  * Renders nothing at all when the act has never been amended, which is the
  * common case, and while the amendment history is still loading.
  *
- * Also renders nothing when `source` is `"fmx-consolidated"` — that means the
- * reader is already looking at the consolidated text (the as-adopted act had
- * no renderable content, so `resolveParsedLaw` fell back to a consolidated
- * version; see `ConsolidatedFallbackNotice`). This notice's copy ("you are
- * reading this law as adopted") would be false in that case.
+ * `source: "fmx-consolidated"` is ambiguous by itself: it's stamped both by
+ * the #170 fallback (the as-adopted act has no renderable content at all —
+ * see `ConsolidatedFallbackNotice`) *and* by a reader-requested `?version=
+ * current` load. Those need opposite copy — this notice's "you are reading
+ * this law as adopted" is false in the first case and beside the point in the
+ * second — so `version` (not `source`) is what's checked to tell them apart:
+ * `version === "current"` means the reader asked for it and gets the reverse
+ * banner below; a bare `fmx-consolidated` source with no requested version is
+ * the forced #170 case and this notice stays silent, deferring to
+ * `ConsolidatedFallbackNotice`.
  */
-export function ConsolidationNotice({ celex, currentLang = "EN", locale = "en", variant = "banner", source = null }) {
+export function ConsolidationNotice({
+  celex,
+  currentLang = "EN",
+  locale = "en",
+  variant = "banner",
+  source = null,
+  version = null,
+  versionUnavailable = false,
+  versionDate = null,
+  onToggleVersion = null,
+}) {
   const { t } = useI18n();
-  const isConsolidatedFallback = source === "fmx-consolidated";
-  // Pass no celex when already reading the consolidated fallback, so the
-  // hook's amendment/consolidated-version fetches don't fire for a notice
-  // that is about to render nothing anyway.
-  const status = useConsolidationStatus(isConsolidatedFallback ? null : celex);
+  const isReadingRequestedVersion = version === "current";
+  const isConsolidatedFallback = source === "fmx-consolidated" && !isReadingRequestedVersion;
+  // Pass no celex when already reading the consolidated fallback or a
+  // requested version, so the hook's amendment/consolidated-version fetches
+  // don't fire for a notice that already knows what it's about to render.
+  const status = useConsolidationStatus(
+    isConsolidatedFallback || isReadingRequestedVersion ? null : celex
+  );
+
+  // Reverse state: the reader asked for the consolidated text and got it (or
+  // didn't — `versionUnavailable` is the backend's honest "I tried and
+  // couldn't", never a silent fallback). Neither branch touches
+  // `useConsolidationStatus` above, so this can't contradict it.
+  if (isReadingRequestedVersion) {
+    const backAction = (
+      <button
+        type="button"
+        onClick={() => onToggleVersion?.(null)}
+        className="inline-flex items-center gap-1 font-medium underline underline-offset-2 hover:no-underline"
+      >
+        <ArrowLeft size={13} aria-hidden="true" />
+        {t("consolidation.backToAsAdopted")}
+      </button>
+    );
+
+    if (versionUnavailable) {
+      const message = (
+        <>
+          <span>{t("consolidation.versionUnavailable")}</span> {backAction}
+        </>
+      );
+      if (variant === "inline") {
+        return (
+          <p className="mb-4 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-xs text-amber-800 dark:text-amber-300">
+            <History size={13} className="translate-y-px" aria-hidden="true" />
+            {message}
+          </p>
+        );
+      }
+      return (
+        <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-100">
+          <div className="flex items-center gap-2 font-medium">
+            <History size={15} aria-hidden="true" />
+            {t("consolidation.versionUnavailable")}
+          </div>
+          <p className="mt-1 leading-6">{backAction}</p>
+        </div>
+      );
+    }
+
+    const asOfDate = formatMetaDate(versionDate, locale);
+    const readingSummary = asOfDate
+      ? t("consolidation.readingAsAmendedWithDate", { date: asOfDate })
+      : t("consolidation.readingAsAmended");
+
+    if (variant === "inline") {
+      return (
+        <p className="mb-4 flex flex-wrap items-baseline gap-x-2 gap-y-1 text-xs text-teal-800 dark:text-teal-300">
+          <History size={13} className="translate-y-px" aria-hidden="true" />
+          <span>{readingSummary}</span>
+          {backAction}
+        </p>
+      );
+    }
+    return (
+      <div className="mb-6 rounded-xl border border-teal-200 bg-teal-50 px-4 py-3 text-sm text-teal-950 dark:border-teal-900/60 dark:bg-teal-950/20 dark:text-teal-100">
+        <div className="flex items-center gap-2 font-medium">
+          <History size={15} aria-hidden="true" />
+          {readingSummary}
+        </div>
+        <p className="mt-1 leading-6">{backAction}</p>
+      </div>
+    );
+  }
 
   if (isConsolidatedFallback) return null;
   if (!status.isOutdated) return null;
@@ -55,16 +143,33 @@ export function ConsolidationNotice({ celex, currentLang = "EN", locale = "en", 
       : "consolidation.amendedAtLeast");
   const summary = t(summaryKey, { count: status.amendmentCount, date: amendedOn });
 
+  // Secondary action: EUR-Lex still gets a direct link (no recital pairing,
+  // no in-app navigation, but it's EUR-Lex's own authoritative page).
   const link = consolidatedUrl ? (
     <a
       href={consolidatedUrl}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex items-center gap-1 font-medium underline underline-offset-2 hover:no-underline"
+      className="inline-flex items-center gap-1 text-amber-800/80 underline underline-offset-2 hover:no-underline dark:text-amber-300/70"
     >
       {t("consolidation.readConsolidated", { date: consolidatedOn })}
-      <ExternalLink size={13} aria-hidden="true" />
+      <ExternalLink size={12} aria-hidden="true" />
     </a>
+  ) : null;
+
+  // Primary action: read it in-app. Only offered when a current consolidated
+  // version actually exists to read (`consolidatedUrl`/`link`) — an act with
+  // no published consolidation, or only a future-dated one, gets no toggle at
+  // all, since `?version=current` would have nothing to switch to.
+  const toggleButton = (consolidatedUrl && onToggleVersion) ? (
+    <button
+      type="button"
+      onClick={() => onToggleVersion("current")}
+      className="inline-flex items-center gap-1 font-semibold text-amber-950 underline underline-offset-2 hover:no-underline dark:text-amber-100"
+    >
+      <History size={13} aria-hidden="true" />
+      {t("consolidation.toggleReadAmended")}
+    </button>
   ) : null;
 
   // No link means either: no consolidated version has ever been published
@@ -87,7 +192,9 @@ export function ConsolidationNotice({ celex, currentLang = "EN", locale = "en", 
         <History size={13} className="translate-y-px" aria-hidden="true" />
         <span>{t("consolidation.asAdopted")}</span>
         <span className="text-amber-700/80 dark:text-amber-300/70">{summary}</span>
+        {toggleButton}
         {link}
+        {!link && noVersionMessage ? <span className="text-amber-700/80 dark:text-amber-300/70">{noVersionMessage}</span> : null}
       </p>
     );
   }
@@ -100,8 +207,14 @@ export function ConsolidationNotice({ celex, currentLang = "EN", locale = "en", 
       </div>
       <p className="mt-1 leading-6">
         {summary}
-        {link ? <> {link}</> : (noVersionMessage ? <> {noVersionMessage}</> : null)}
+        {!link && noVersionMessage ? <> {noVersionMessage}</> : null}
       </p>
+      {toggleButton || link ? (
+        <p className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs">
+          {toggleButton}
+          {link}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/src/components/ConsolidationNotice.test.jsx
+++ b/src/components/ConsolidationNotice.test.jsx
@@ -101,6 +101,33 @@ describe("ConsolidationNotice", () => {
     expect(container.querySelector("a")).toBe(null);
   });
 
+  it("does not claim no consolidated version exists while the query is still in flight", async () => {
+    // The amendment history resolves first (it is the faster of the two
+    // queries), so without a pending state the notice renders its summary
+    // beside "EUR-Lex has not published a consolidated version" — a claim it
+    // has no basis for yet, and one that is wrong for most amended acts. It
+    // then flips to a toggle a moment later.
+    fetchAmendments.mockResolvedValue({
+      amendments: [{ celex: "32020R0001", date: "2020-01-01", type: "amendment" }],
+    });
+    let resolveVersions;
+    fetchConsolidatedVersions.mockReturnValue(
+      new Promise((resolve) => { resolveVersions = resolve; })
+    );
+
+    await render({ onToggleVersion: vi.fn() });
+
+    expect(container.textContent).toContain("amended once");
+    expect(container.textContent).not.toContain("has not published a consolidated version");
+
+    await act(async () => {
+      resolveVersions({ versions: [{ celex: "02013R0575-20200101", date: "2020-01-01" }] });
+    });
+
+    expect(container.textContent).not.toContain("has not published a consolidated version");
+    expect(container.textContent).toContain("Read this law as amended");
+  });
+
   it("stays silent when the amendment history cannot be fetched", async () => {
     fetchAmendments.mockRejectedValue(new Error("cellar down"));
     fetchConsolidatedVersions.mockRejectedValue(new Error("cellar down"));

--- a/src/components/ConsolidationNotice.test.jsx
+++ b/src/components/ConsolidationNotice.test.jsx
@@ -75,7 +75,11 @@ describe("ConsolidationNotice", () => {
     expect(link.getAttribute("rel")).toBe("noopener noreferrer");
   });
 
-  it("renders nothing for a law that only ever had corrigenda", async () => {
+  it("does not warn a law that only ever had corrigenda, but says the text is uncorrected", async () => {
+    // The GDPR. Not amended, so no warning — but nine of its articles read
+    // differently in the consolidated text, Article 37(1)(c)'s "and"/"or"
+    // among them, so silence would leave the reader on uncorrected text with
+    // no way to know.
     fetchAmendments.mockResolvedValue({
       amendments: [{ celex: "32016R0679R(01)", date: "2018-05-23", type: "corrigendum" }],
     });
@@ -83,7 +87,48 @@ describe("ConsolidationNotice", () => {
       versions: [{ celex: "02016R0679-20160504", date: "2016-05-04" }],
     });
 
-    await render({ celex: "32016R0679" });
+    await render({ celex: "32016R0679", onToggleVersion: vi.fn() });
+
+    expect(container.textContent).toContain("You are reading the current text");
+    expect(container.textContent).toContain("has not been amended");
+    expect(container.textContent).toContain("One corrigendum has been published");
+    expect(container.textContent).not.toContain("You are reading this law as adopted");
+    const toggle = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent.includes("corrections applied")
+    );
+    expect(toggle).toBeTruthy();
+  });
+
+  it("stays quiet above every article for a law that was never amended", async () => {
+    // The positive line belongs on the overview. Repeated above each article
+    // it is noise, and the inline variant exists to warn.
+    fetchAmendments.mockResolvedValue({ amendments: [] });
+    fetchConsolidatedVersions.mockResolvedValue({ versions: [] });
+
+    await render({ variant: "inline" });
+
+    expect(container.textContent).toBe("");
+  });
+
+  it("says a never-amended law is current, with no correction offer", async () => {
+    fetchAmendments.mockResolvedValue({ amendments: [] });
+    fetchConsolidatedVersions.mockResolvedValue({ versions: [] });
+
+    await render({ onToggleVersion: vi.fn() });
+
+    expect(container.textContent).toContain("You are reading the current text");
+    expect(container.textContent).toContain("has not been amended");
+    expect(container.textContent).not.toContain("corrigend");
+    expect(container.querySelector("button")).toBe(null);
+  });
+
+  it("claims nothing about a never-amended law when the history could not be fetched", async () => {
+    // `[]` on failure keeps the warning off, but it must not be read as
+    // evidence for the opposite claim.
+    fetchAmendments.mockRejectedValue(new Error("cellar down"));
+    fetchConsolidatedVersions.mockResolvedValue({ versions: [] });
+
+    await render();
 
     expect(container.textContent).toBe("");
   });

--- a/src/components/ConsolidationNotice.test.jsx
+++ b/src/components/ConsolidationNotice.test.jsx
@@ -156,6 +156,72 @@ describe("ConsolidationNotice", () => {
     expect(fetchAmendments).not.toHaveBeenCalled();
   });
 
+  it("offers a toggle to read the consolidated text when a current version exists", async () => {
+    fetchAmendments.mockResolvedValue({
+      amendments: [{ celex: "32019R0876", date: "2019-05-20", type: "amendment" }],
+    });
+    fetchConsolidatedVersions.mockResolvedValue({
+      versions: [{ celex: "02013R0575-20260626", date: "2026-06-26" }],
+    });
+    const onToggleVersion = vi.fn();
+
+    await render({ onToggleVersion });
+
+    const toggle = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent.includes("Read this law as amended")
+    );
+    expect(toggle).toBeTruthy();
+
+    await act(async () => { toggle.click(); });
+    expect(onToggleVersion).toHaveBeenCalledWith("current");
+  });
+
+  it("renders no toggle when no current consolidated version exists", async () => {
+    fetchAmendments.mockResolvedValue({
+      amendments: [{ celex: "32020R0001", date: "2020-01-01", type: "amendment" }],
+    });
+    fetchConsolidatedVersions.mockResolvedValue({ versions: [] });
+
+    await render({ onToggleVersion: vi.fn() });
+
+    expect(container.querySelector("button")).toBe(null);
+  });
+
+  it("shows the reverse state and an honest date once the reader is reading the requested version", async () => {
+    const onToggleVersion = vi.fn();
+
+    await render({
+      source: "fmx-consolidated",
+      version: "current",
+      versionDate: "2026-06-26",
+      onToggleVersion,
+    });
+
+    expect(container.textContent).toContain("You are reading this law as amended, as of");
+    expect(fetchAmendments).not.toHaveBeenCalled();
+
+    const back = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent.includes("Back to the text as adopted")
+    );
+    expect(back).toBeTruthy();
+
+    await act(async () => { back.click(); });
+    expect(onToggleVersion).toHaveBeenCalledWith(null);
+  });
+
+  it("says so honestly when the requested version could not be served", async () => {
+    await render({
+      source: "fmx-eurlex",
+      version: "current",
+      versionUnavailable: true,
+      onToggleVersion: vi.fn(),
+    });
+
+    expect(container.textContent).toContain("could not be loaded right now");
+    expect(container.textContent).not.toContain("You are reading this law as amended");
+    expect(fetchAmendments).not.toHaveBeenCalled();
+  });
+
   it("says 'at least N times' when the amendment count was truncated", async () => {
     fetchAmendments.mockResolvedValue({
       amendments: [

--- a/src/components/LawSummary.jsx
+++ b/src/components/LawSummary.jsx
@@ -44,11 +44,16 @@ function SectionLabel({ children }) {
   );
 }
 
-export function LawSummary({ celex, lang = "EN", onArticleClick, className = "rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900" }) {
+export function LawSummary({ celex, lang = "EN", version = null, onArticleClick, className = "rounded-2xl border border-gray-200 bg-white shadow-sm dark:border-gray-800 dark:bg-gray-900" }) {
   const { t, locale } = useI18n();
   const [open, setOpen] = useState(true);
   const { summary, metadata, loading, loaded, error, retry } = useLawSummary(celex);
   const showEnglishOnlyNote = (lang || "EN").toUpperCase() !== "EN";
+  // The summary endpoint has no version dimension: it is generated from the
+  // act as adopted and served unchanged whichever version is being read. That
+  // is only worth saying when the two diverge — labelling an as-adopted
+  // overview "as adopted" while reading the as-adopted text is noise.
+  const showAsAdoptedNote = Boolean(version);
 
   if (!celex) return null;
 
@@ -67,6 +72,11 @@ export function LawSummary({ celex, lang = "EN", onArticleClick, className = "ro
             {t("lawSummary.englishOnly")}
           </span>
         ) : null}
+        {showAsAdoptedNote ? (
+          <span className="shrink-0 rounded border border-amber-300 px-1.5 py-0.5 text-[11px] font-medium text-amber-700 dark:border-amber-800 dark:text-amber-400">
+            {t("lawSummary.asAdoptedBadge")}
+          </span>
+        ) : null}
         <span className="ml-auto hidden shrink-0 text-[11.5px] text-gray-400 dark:text-gray-500 sm:inline">
           {t("lawSummary.verifyNote")}
         </span>
@@ -77,6 +87,11 @@ export function LawSummary({ celex, lang = "EN", onArticleClick, className = "ro
 
       {open ? (
         <div className="space-y-4 px-5 py-4 text-sm leading-6 text-gray-700 dark:text-gray-300">
+          {showAsAdoptedNote ? (
+            <p className="rounded-lg bg-amber-50 px-3 py-2 text-[12.5px] leading-5 text-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+              {t("lawSummary.asAdoptedNote")}
+            </p>
+          ) : null}
           {loading && !loaded ? (
             <div className="flex items-center gap-2 text-gray-500 dark:text-gray-400">
               <Loader2 size={14} className="animate-spin" />

--- a/src/components/LawSummary.test.jsx
+++ b/src/components/LawSummary.test.jsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+
+const fetchLawSummary = vi.fn();
+
+vi.mock("../utils/formexApi.js", () => ({
+  fetchLawSummary: (...args) => fetchLawSummary(...args),
+}));
+
+const { LawSummary } = await import("./LawSummary.jsx");
+const { I18nProvider } = await import("../i18n/I18nProvider.jsx");
+
+const SUMMARY = {
+  summary: {
+    purpose: { text: "Sets uniform prudential requirements.", citations: [] },
+    scope: { text: "Applies to institutions.", citations: ["1"] },
+    keyPoints: [],
+    structure: "Ten parts.",
+  },
+  cacheVersion: 1,
+};
+
+let container;
+let root;
+
+async function render(props = {}) {
+  await act(async () => {
+    root = createRoot(container);
+    root.render(
+      createElement(
+        MemoryRouter,
+        null,
+        createElement(
+          I18nProvider,
+          null,
+          createElement(LawSummary, { celex: "32013R0575", ...props })
+        )
+      )
+    );
+  });
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  fetchLawSummary.mockReset();
+  fetchLawSummary.mockResolvedValue(SUMMARY);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  document.body.innerHTML = "";
+});
+
+describe("LawSummary", () => {
+  it("says the overview is only of the law as adopted when a version is being read", async () => {
+    // `/summary` has no version dimension — it is generated from the act as
+    // adopted and served unchanged. Reading the CRR as amended, that is an
+    // overview of 521 articles sitting above 786, so it has to say so.
+    await render({ version: "current" });
+
+    expect(container.textContent).toContain("As adopted");
+    expect(container.textContent).toContain("does not reflect later amendments");
+  });
+
+  it("says nothing about versions when the as-adopted text is what is being read", async () => {
+    // Labelling an as-adopted overview "as adopted" above the as-adopted text
+    // is noise: the caveat only earns its place when the two diverge.
+    await render();
+
+    expect(container.textContent).not.toContain("As adopted");
+    expect(container.textContent).not.toContain("does not reflect later amendments");
+  });
+});

--- a/src/components/LawViewer.jsx
+++ b/src/components/LawViewer.jsx
@@ -64,6 +64,10 @@ export function LawViewer() {
   const sourceUrl = searchParams.get("sourceUrl");
   const definitionTerm = searchParams.get("definition") || "";
   const definitionSource = searchParams.get("definitionSource") || "";
+  // Only the literal "current" is a recognised version (#149's first slice;
+  // the backend 400s on anything else) — treat any other value as unset
+  // rather than forwarding garbage to the document hooks.
+  const requestedVersion = searchParams.get("version") === "current" ? "current" : null;
   const { allLaws, libraryVersion } = useLandingLibrary();
 
   const preferences = useLawViewerPreferences({
@@ -95,11 +99,13 @@ export function LawViewer() {
     celex: source.effectiveCelex,
     lang: preferences.formexLang,
     t,
+    version: requestedVersion,
   });
   const secondaryDocument = useSecondaryLawDocument({
     celex: source.effectiveCelex,
     secondaryLang: preferences.secondaryLang,
     t,
+    version: requestedVersion,
   });
   const selection = useLawSelection({
     data: primaryDocument.data,
@@ -124,6 +130,12 @@ export function LawViewer() {
     () => getSelectedEntry(primaryDocument.data, selection.selected),
     [primaryDocument.data, selection.selected]
   );
+  // Set by the backend (`?version=current`) on an article inserted by
+  // amendment with no as-adopted counterpart: nothing has ever been mapped to
+  // it, so the case-law/cited-by rails must say why they're empty instead of
+  // rendering as if the article were simply unremarkable.
+  const isSelectedArticleInsertedInVersion = selection.selected.kind === "article"
+    && !!primarySelectedEntry?.insertedInVersion;
   const processedHtml = useProcessedLawHtml({
     data: primaryDocument.data,
     selected: selection.selected,
@@ -185,6 +197,18 @@ export function LawViewer() {
     nextParams.delete("definition");
     nextParams.delete("definitionSource");
     setSearchParams(nextParams, { replace: true });
+  }, [searchParams, setSearchParams]);
+
+  // Toggles `?version=current` on the URL, which is what makes a consolidated
+  // reading shareable/bookmarkable and lets it survive article navigation
+  // (state derived from the URL, not held in a component). Pushes a history
+  // entry (no `replace`) so the back button can undo the toggle, the same as
+  // navigating between articles does.
+  const setVersion = React.useCallback((nextVersion) => {
+    const nextParams = new URLSearchParams(searchParams);
+    if (nextVersion) nextParams.set("version", nextVersion);
+    else nextParams.delete("version");
+    setSearchParams(nextParams);
   }, [searchParams, setSearchParams]);
 
   const definitionComparison = definitionTerm ? {
@@ -393,6 +417,10 @@ export function LawViewer() {
                   onOpenCitedLaw={interactions.handleOpenLawByCelex}
                   isExternalReferencePending={interactions.isExternalReferencePending}
                   locale={locale}
+                  version={requestedVersion}
+                  versionUnavailable={derived.versionUnavailable}
+                  versionDate={derived.versionDate}
+                  onToggleVersion={setVersion}
                   t={t}
                 />
               ) : (
@@ -414,11 +442,16 @@ export function LawViewer() {
                     locale={locale}
                     variant="inline"
                     source={primaryDocument.data.source}
+                    version={requestedVersion}
+                    versionUnavailable={derived.versionUnavailable}
+                    versionDate={derived.versionDate}
+                    onToggleVersion={setVersion}
                   />
 
                   <ConsolidatedFallbackNotice
                     source={primaryDocument.data.source}
                     consolidatedVersion={derived.consolidatedVersion}
+                    version={requestedVersion}
                   />
 
                   {interactions.isResolvingExternalLaw ? (
@@ -499,6 +532,7 @@ export function LawViewer() {
                   celex={source.effectiveCelex}
                   articleNumber={selection.selected.id}
                   currentLang={displayedFormexLang}
+                  insertedInVersion={isSelectedArticleInsertedInVersion}
                 />
                 <CrossReferences
                   articleNumber={selection.selected.id}
@@ -514,6 +548,7 @@ export function LawViewer() {
                   articleNumber={selection.selected.id}
                   currentLang={displayedFormexLang}
                   onOpenLaw={interactions.handleOpenLawByCelex}
+                  insertedInVersion={isSelectedArticleInsertedInVersion}
                 />
               </div>
             ) : null}
@@ -585,6 +620,7 @@ export function LawViewer() {
                   isExternalReferencePending={interactions.isExternalReferencePending}
                   onOpenLaw={interactions.handleOpenLawByCelex}
                   definitionComparison={definitionComparison}
+                  insertedInVersion={isSelectedArticleInsertedInVersion}
                   t={t}
                 />
               </div>

--- a/src/components/RelatedCaseLaw.jsx
+++ b/src/components/RelatedCaseLaw.jsx
@@ -94,7 +94,7 @@ function CaseCard({ c, currentLang }) {
 // `compact` renders for the narrow context rail: no outer gutters, no title
 // row (the rail tab already says "Case law"), the judgment list open by
 // default and in a single column.
-export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN", compact = false }) {
+export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN", compact = false, insertedInVersion = false }) {
   const { t } = useI18n();
   const [isListOpen, setIsListOpen] = useState(compact);
   const [digestRequested, setDigestRequested] = useState(false);
@@ -113,6 +113,22 @@ export function RelatedCaseLaw({ celex, articleNumber, currentLang = "EN", compa
   }, [celex, articleNumber, currentLang]);
 
   if (!articleNumber) return null;
+
+  // An article inserted by amendment (`?version=current`, #149) has no
+  // as-adopted counterpart, so nothing has ever been matched to it — CJEU
+  // rulings are indexed against the as-adopted text. Saying so beats a rail
+  // that just isn't there, which reads as "no case law exists" rather than
+  // "not mapped yet".
+  if (insertedInVersion) {
+    return (
+      <div className={compact ? "" : "mt-6 px-6 md:px-12"}>
+        <div className={`flex items-center gap-2 py-3 text-sm ${compact ? "" : "border-y border-gray-200 dark:border-gray-800"}`}>
+          <Scale size={16} className="shrink-0 text-gray-400 dark:text-gray-500" />
+          <span className="text-gray-500 dark:text-gray-400">{t("relatedCaseLaw.insertedInVersion")}</span>
+        </div>
+      </div>
+    );
+  }
 
   if (loading && !loaded) {
     if (compact) {

--- a/src/components/law-viewer/ConsolidatedFallbackNotice.jsx
+++ b/src/components/law-viewer/ConsolidatedFallbackNotice.jsx
@@ -10,13 +10,22 @@ import { useI18n } from "../../i18n/useI18n.js";
  * texts carry no recitals at all, and without saying so the empty recital rail
  * reads as a bug rather than as what EUR-Lex published.
  *
+ * `source: "fmx-consolidated"` stopped being unambiguous once #149 let a
+ * reader *request* the consolidated text via `?version=current` — that path
+ * also composes a `fmx-consolidated` payload, but for a reason the reader
+ * chose rather than one EUR-Lex forced. `version` is what tells the two
+ * apart: this notice only concerns the forced case (no `version` requested),
+ * because a requested reading gets `ConsolidationNotice`'s own reverse-state
+ * banner instead — showing both would say the same thing twice.
+ *
  * `ConsolidationNotice` is the mirror image of this one and suppresses itself
- * for the same source, since "you are reading this law as adopted" is false here.
+ * for the same unrequested source, since "you are reading this law as
+ * adopted" is false here.
  */
-export function ConsolidatedFallbackNotice({ source, consolidatedVersion = null }) {
+export function ConsolidatedFallbackNotice({ source, consolidatedVersion = null, version = null }) {
   const { t } = useI18n();
 
-  if (source !== "fmx-consolidated") return null;
+  if (source !== "fmx-consolidated" || version) return null;
 
   return (
     <div className="mb-4 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-100">

--- a/src/components/law-viewer/LawOverviewPage.jsx
+++ b/src/components/law-viewer/LawOverviewPage.jsx
@@ -95,6 +95,10 @@ export function LawOverviewPage({
   onOpenCitedLaw,
   isExternalReferencePending,
   locale = "en",
+  version = null,
+  versionUnavailable = false,
+  versionDate = null,
+  onToggleVersion,
   t,
 }) {
   const meta = useLawMetadata(effectiveCelex);
@@ -184,11 +188,16 @@ export function LawOverviewPage({
         currentLang={formexLang}
         locale={locale}
         source={data?.source}
+        version={version}
+        versionUnavailable={versionUnavailable}
+        versionDate={versionDate}
+        onToggleVersion={onToggleVersion}
       />
 
       <ConsolidatedFallbackNotice
         source={data?.source}
         consolidatedVersion={data?.consolidatedVersion}
+        version={version}
       />
 
       {/* Actions */}

--- a/src/components/law-viewer/LawOverviewPage.jsx
+++ b/src/components/law-viewer/LawOverviewPage.jsx
@@ -223,7 +223,7 @@ export function LawOverviewPage({
         ) : null}
       </div>
 
-      <LawSummary celex={effectiveCelex} lang={formexLang} onArticleClick={onArticleClick} />
+      <LawSummary celex={effectiveCelex} lang={formexLang} version={version} onArticleClick={onArticleClick} />
 
       <MetadataPanel
         amendments={meta.amendments}

--- a/src/components/law-viewer/LawViewerContextRail.jsx
+++ b/src/components/law-viewer/LawViewerContextRail.jsx
@@ -123,6 +123,7 @@ export function LawViewerContextRail({
   isExternalReferencePending,
   onOpenLaw,
   definitionComparison,
+  insertedInVersion = false,
   t,
 }) {
   const [tab, setTab] = useState("recitals");
@@ -203,7 +204,7 @@ export function LawViewerContextRail({
         ) : null}
 
         {tab === "cases" ? (
-          <RelatedCaseLaw celex={celex} articleNumber={articleNumber} currentLang={currentLang} compact />
+          <RelatedCaseLaw celex={celex} articleNumber={articleNumber} currentLang={currentLang} insertedInVersion={insertedInVersion} compact />
         ) : null}
 
         {tab === "references" ? (
@@ -229,6 +230,7 @@ export function LawViewerContextRail({
             articleNumber={articleNumber}
             currentLang={currentLang}
             onOpenLaw={onOpenLaw}
+            insertedInVersion={insertedInVersion}
             compact
           />
         ) : null}

--- a/src/hooks/law-viewer/useLawDocument.js
+++ b/src/hooks/law-viewer/useLawDocument.js
@@ -22,7 +22,7 @@ function applyRecitalTitles(data, titles) {
   return changed ? { ...data, recitals } : data;
 }
 
-export function useLawDocument({ celex, lang, t, enabled = true }) {
+export function useLawDocument({ celex, lang, t, enabled = true, version = null }) {
   const [data, setData] = useState(EMPTY_LAW_DATA);
   const [loading, setLoading] = useState(false);
   const [recitalTitlesLoading, setRecitalTitlesLoading] = useState(false);
@@ -47,19 +47,29 @@ export function useLawDocument({ celex, lang, t, enabled = true }) {
 
     try {
       let nextData = null;
-      const cached = await getCachedLawPayload(celex, lang);
-      if (cached) {
-        nextData = parseLawPayloadToCombined(cached);
+      if (version) {
+        // A requested version (currently only "current", #149) has no raw-XML
+        // path to short-circuit through: `fetchFormex` fetches the act's base
+        // CELEX, which is the as-adopted document, and `isFmxDocument` rejects
+        // the consolidated `<CONS.ACT>` schema outright. Go straight to
+        // `/parsed?version=`, which composes the consolidated articles with
+        // the as-adopted recitals server-side.
+        nextData = parseLawPayloadToCombined(await fetchParsedLaw(celex, lang, { version }));
       } else {
-        try {
-          const xmlText = await fetchFormex(celex, lang);
-          nextData = parseLawPayloadToCombined(xmlText);
-          cacheParsedLaw(celex, lang, nextData, xmlText);
-        } catch (error) {
-          if (!isMissingStructuredLawText(error)) {
-            throw error;
+        const cached = await getCachedLawPayload(celex, lang);
+        if (cached) {
+          nextData = parseLawPayloadToCombined(cached);
+        } else {
+          try {
+            const xmlText = await fetchFormex(celex, lang);
+            nextData = parseLawPayloadToCombined(xmlText);
+            cacheParsedLaw(celex, lang, nextData, xmlText);
+          } catch (error) {
+            if (!isMissingStructuredLawText(error)) {
+              throw error;
+            }
+            nextData = parseLawPayloadToCombined(await fetchParsedLaw(celex, lang));
           }
-          nextData = parseLawPayloadToCombined(await fetchParsedLaw(celex, lang));
         }
       }
 
@@ -92,7 +102,7 @@ export function useLawDocument({ celex, lang, t, enabled = true }) {
     } finally {
       if (requestRef.current === requestId) setLoading(false);
     }
-  }, [celex, enabled, lang, t]);
+  }, [celex, enabled, lang, t, version]);
 
   useEffect(() => {
     reload();

--- a/src/hooks/law-viewer/useLawViewerDerivedState.js
+++ b/src/hooks/law-viewer/useLawViewerDerivedState.js
@@ -72,6 +72,8 @@ export function useLawViewerDerivedState({
     isLegacyHtmlFallback,
     isConsolidatedFallback,
     consolidatedVersion: primaryDocument.data.consolidatedVersion || null,
+    versionUnavailable: !!primaryDocument.data.versionUnavailable,
+    versionDate: primaryDocument.data.versionDate || null,
     hasLoadedContent,
     hasCelex,
     isSideBySide,

--- a/src/hooks/law-viewer/useSecondaryLawDocument.js
+++ b/src/hooks/law-viewer/useSecondaryLawDocument.js
@@ -22,7 +22,7 @@ function applyRecitalTitles(data, titles) {
   return changed ? { ...data, recitals } : data;
 }
 
-export function useSecondaryLawDocument({ celex, secondaryLang, t }) {
+export function useSecondaryLawDocument({ celex, secondaryLang, t, version = null }) {
   const [data, setData] = useState(EMPTY_LAW_DATA);
   const [loading, setLoading] = useState(false);
   const [recitalTitlesLoading, setRecitalTitlesLoading] = useState(false);
@@ -46,19 +46,27 @@ export function useSecondaryLawDocument({ celex, secondaryLang, t }) {
     (async () => {
       try {
         let nextData = null;
-        const cached = await getCachedLawPayload(celex, secondaryLang);
-        if (cached) {
-          nextData = parseLawPayloadToCombined(cached);
+        if (version) {
+          // Same one-line pass-through as the primary document: side-by-side
+          // must show the same requested version in both columns, and the
+          // requested-version path has no raw-XML short-circuit to take (see
+          // useLawDocument.js).
+          nextData = parseLawPayloadToCombined(await fetchParsedLaw(celex, secondaryLang, { version }));
         } else {
-          try {
-            const xmlText = await fetchFormex(celex, secondaryLang);
-            nextData = parseLawPayloadToCombined(xmlText);
-            cacheParsedLaw(celex, secondaryLang, nextData, xmlText);
-          } catch (error) {
-            if (!isMissingStructuredLawText(error)) {
-              throw error;
+          const cached = await getCachedLawPayload(celex, secondaryLang);
+          if (cached) {
+            nextData = parseLawPayloadToCombined(cached);
+          } else {
+            try {
+              const xmlText = await fetchFormex(celex, secondaryLang);
+              nextData = parseLawPayloadToCombined(xmlText);
+              cacheParsedLaw(celex, secondaryLang, nextData, xmlText);
+            } catch (error) {
+              if (!isMissingStructuredLawText(error)) {
+                throw error;
+              }
+              nextData = parseLawPayloadToCombined(await fetchParsedLaw(celex, secondaryLang));
             }
-            nextData = parseLawPayloadToCombined(await fetchParsedLaw(celex, secondaryLang));
           }
         }
 
@@ -94,7 +102,7 @@ export function useSecondaryLawDocument({ celex, secondaryLang, t }) {
     return () => {
       cancelled = true;
     };
-  }, [celex, secondaryLang, t]);
+  }, [celex, secondaryLang, t, version]);
 
   return {
     data,

--- a/src/hooks/law-viewer/useSecondaryLawDocument.js
+++ b/src/hooks/law-viewer/useSecondaryLawDocument.js
@@ -70,6 +70,23 @@ export function useSecondaryLawDocument({ celex, secondaryLang, t, version = nul
           }
         }
 
+        // The backend soft-falls to the as-adopted text when the requested
+        // consolidated version cannot be served. Do not show that fallback in
+        // a parallel-language column: the primary column may still be reading
+        // the current version, which would make the comparison silently mix
+        // two legal versions.
+        if (version && nextData.versionUnavailable) {
+          if (!cancelled) {
+            setLoadError({
+              title: t("lawViewer.structuredVersionUnavailable"),
+              message: t("lawViewer.lawContentUnavailable"),
+              tone: "notice",
+            });
+            setData(EMPTY_LAW_DATA);
+          }
+          return;
+        }
+
         if (!cancelled) setData(nextData);
 
         if (nextData.recitals?.length > 0) {

--- a/src/hooks/law-viewer/useSecondaryLawDocument.test.jsx
+++ b/src/hooks/law-viewer/useSecondaryLawDocument.test.jsx
@@ -1,0 +1,90 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useSecondaryLawDocument } from "./useSecondaryLawDocument.js";
+
+const {
+  mockFetchParsedLaw,
+  mockFetchRecitalTitles,
+  mockParseLawPayloadToCombined,
+} = vi.hoisted(() => ({
+  mockFetchParsedLaw: vi.fn(),
+  mockFetchRecitalTitles: vi.fn(),
+  mockParseLawPayloadToCombined: vi.fn(),
+}));
+
+vi.mock("../../utils/formexApi.js", async () => {
+  const actual = await vi.importActual("../../utils/formexApi.js");
+  return {
+    ...actual,
+    fetchParsedLaw: mockFetchParsedLaw,
+    fetchRecitalTitles: mockFetchRecitalTitles,
+  };
+});
+
+vi.mock("../../utils/parsers.js", () => ({
+  parseLawPayloadToCombined: mockParseLawPayloadToCombined,
+}));
+
+async function flushEffects() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("useSecondaryLawDocument", () => {
+  let container;
+  let root;
+  let latestValue;
+
+  function Probe(props) {
+    latestValue = useSecondaryLawDocument(props);
+    return null;
+  }
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    latestValue = null;
+    mockFetchParsedLaw.mockReset();
+    mockFetchRecitalTitles.mockReset().mockResolvedValue({ titles: {} });
+    mockParseLawPayloadToCombined.mockReset().mockImplementation((value) => value);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  it("does not show an as-adopted fallback in a current-version secondary column", async () => {
+    mockFetchParsedLaw.mockResolvedValue({
+      title: "Regulation 2013/575",
+      articles: [{ article_number: "1" }],
+      recitals: [],
+      annexes: [],
+      definitions: [],
+      versionUnavailable: true,
+    });
+
+    await act(async () => {
+      root.render(<Probe celex="32013R0575" secondaryLang="DE" t={(key) => key} version="current" />);
+      await flushEffects();
+    });
+
+    expect(mockFetchParsedLaw).toHaveBeenCalledWith(
+      "32013R0575",
+      "DE",
+      { version: "current" },
+    );
+    expect(latestValue.data.articles).toEqual([]);
+    expect(latestValue.loadError).toMatchObject({
+      title: "lawViewer.structuredVersionUnavailable",
+      message: "lawViewer.lawContentUnavailable",
+      tone: "notice",
+    });
+    expect(mockFetchRecitalTitles).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useConsolidationStatus.js
+++ b/src/hooks/useConsolidationStatus.js
@@ -18,14 +18,31 @@ import { selectConsolidatedVersions, summarizeAmendments } from "../utils/consol
  * Both endpoints are already IndexedDB-cached and de-duplicated in flight, so
  * sharing them with the metadata panel costs nothing.
  */
+/**
+ * Corrigenda are excluded from the amendment count on purpose (they correct
+ * the published text rather than amend the law), but they are not nothing:
+ * EUR-Lex applies them to the consolidated text and not to the act as
+ * published, so a corrigendum-only act genuinely reads differently in the two.
+ * The GDPR is the case in point — nine of its articles differ, including
+ * Article 37(1)(c), where the corrigendum turned "and" into "or" and with it
+ * the test for when a DPO must be appointed. Counting them lets the notice
+ * say so.
+ */
+function countCorrigenda(amendments) {
+  if (!Array.isArray(amendments)) return 0;
+  return amendments.filter((entry) => entry && entry.type === "corrigendum").length;
+}
+
 export function useConsolidationStatus(celex) {
   const [amendments, setAmendments] = useState(null);
+  const [amendmentsUnknown, setAmendmentsUnknown] = useState(false);
   const [amendmentsTruncated, setAmendmentsTruncated] = useState(false);
   const [versions, setVersions] = useState(null);
   const [consolidatedStatusUnknown, setConsolidatedStatusUnknown] = useState(false);
 
   useEffect(() => {
     setAmendments(null);
+    setAmendmentsUnknown(false);
     setAmendmentsTruncated(false);
     setVersions(null);
     setConsolidatedStatusUnknown(false);
@@ -39,7 +56,15 @@ export function useConsolidationStatus(celex) {
         setAmendments(result.amendments || []);
         setAmendmentsTruncated(Boolean(result.truncated));
       })
-      .catch(() => { if (!cancelled) setAmendments([]); });
+      .catch(() => {
+        if (cancelled) return;
+        // `[]` keeps `isOutdated` false so a Cellar outage cannot put a "this
+        // may be outdated" warning on a law we know nothing about — but the
+        // flag is what stops the *opposite* claim, that the law has never
+        // been amended, from being made on the same non-evidence.
+        setAmendments([]);
+        setAmendmentsUnknown(true);
+      });
 
     fetchConsolidatedVersions(celex)
       .then((result) => { if (!cancelled) setVersions(result.versions || []); })
@@ -73,6 +98,12 @@ export function useConsolidationStatus(celex) {
       // exists" and flashes "EUR-Lex has not published a consolidated
       // version" on first paint for acts that plainly have one.
       consolidatedStatusPending: versions === null,
+      // The same two distinctions for the amendment history. Only when it
+      // has actually answered can a caller say "this law has not been
+      // amended" rather than merely declining to warn.
+      amendmentStatusUnknown: amendmentsUnknown,
+      amendmentStatusPending: amendments === null,
+      corrigendumCount: countCorrigenda(amendments),
     };
-  }, [amendments, amendmentsTruncated, versions, consolidatedStatusUnknown]);
+  }, [amendments, amendmentsUnknown, amendmentsTruncated, versions, consolidatedStatusUnknown]);
 }

--- a/src/hooks/useConsolidationStatus.js
+++ b/src/hooks/useConsolidationStatus.js
@@ -67,6 +67,12 @@ export function useConsolidationStatus(celex) {
       consolidated: current,
       hasUpcomingConsolidation: upcoming.length > 0,
       consolidatedStatusUnknown,
+      // Still in flight. Distinct from `consolidatedStatusUnknown` (the fetch
+      // failed) and from a genuine empty result: `versions` starts null, and
+      // without this the caller cannot tell "not loaded yet" from "none
+      // exists" and flashes "EUR-Lex has not published a consolidated
+      // version" on first paint for acts that plainly have one.
+      consolidatedStatusPending: versions === null,
     };
   }, [amendments, amendmentsTruncated, versions, consolidatedStatusUnknown]);
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -287,7 +287,8 @@
     "judgmentInterprets": "judgment interprets",
     "judgmentsInterpret": "judgments interpret",
     "sidebarLabel": "Case law",
-    "noMatchSuffix": "in the sidebar for the full list and an AI digest."
+    "noMatchSuffix": "in the sidebar for the full list and an AI digest.",
+    "insertedInVersion": "This article was inserted by a later amendment, so no case law is mapped to it — CJEU rulings are indexed against the text as adopted."
   },
   "caseLawDigest": {
     "generate": "Generate case-law digest",
@@ -331,7 +332,8 @@
       "article": "Article {n}",
       "recital": "Recital {n}",
       "annex": "Annex {n}"
-    }
+    },
+    "insertedInVersion": "This article was inserted by a later amendment, so nothing is known to cite it — the citation graph is built from the text as adopted."
   },
   "lawViewer": {
     "notAvailableTitle": "This law is not available here yet",
@@ -466,6 +468,11 @@
     "amendedAtLeast": "It has been amended at least {count} times since.",
     "readConsolidated": "Read the consolidated text as of {date} on EUR-Lex",
     "noConsolidatedVersion": "EUR-Lex has not published a consolidated version.",
-    "consolidatedVersionPending": "A consolidated version has been prepared but is not yet in force."
+    "consolidatedVersionPending": "A consolidated version has been prepared but is not yet in force.",
+    "toggleReadAmended": "Read this law as amended",
+    "readingAsAmendedWithDate": "You are reading this law as amended, as of {date}.",
+    "readingAsAmended": "You are reading this law as amended.",
+    "backToAsAdopted": "Back to the text as adopted",
+    "versionUnavailable": "The current consolidated text could not be loaded right now — showing the text as adopted instead."
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -473,6 +473,11 @@
     "readingAsAmendedWithDate": "You are reading this law as amended, as of {date}.",
     "readingAsAmended": "You are reading this law as amended.",
     "backToAsAdopted": "Back to the text as adopted",
-    "versionUnavailable": "The current consolidated text could not be loaded right now — showing the text as adopted instead."
+    "versionUnavailable": "The current consolidated text could not be loaded right now — showing the text as adopted instead.",
+    "upToDate": "You are reading the current text.",
+    "neverAmended": "This law has not been amended since it was adopted.",
+    "correctedOnce": "One corrigendum has been published since. Corrigenda are applied to the consolidated text, not to the act as published here.",
+    "corrected": "{count} corrigenda have been published since. Corrigenda are applied to the consolidated text, not to the act as published here.",
+    "toggleReadCorrected": "Read this law with the corrections applied"
   }
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -456,7 +456,9 @@
     "scope": "Scope",
     "keyPoints": "Key points",
     "structure": "Structure",
-    "generatedOn": "Static summary generated {date}"
+    "generatedOn": "Static summary generated {date}",
+    "asAdoptedBadge": "As adopted",
+    "asAdoptedNote": "This overview describes the law as adopted. It is not regenerated for the amended text, so it does not reflect later amendments."
   },
   "consolidation": {
     "asAdopted": "You are reading this law as adopted.",

--- a/src/utils/formexApi.cacheEnvelopes.test.js
+++ b/src/utils/formexApi.cacheEnvelopes.test.js
@@ -14,7 +14,7 @@ import { PARSER_VERSION } from "./fmxParser.js";
 // takes effect once made.
 
 const DB_NAME = "formex-cache";
-const DB_VERSION = 2;
+const DB_VERSION = 3;
 const STORE_NAME = "laws";
 const META_STORE_NAME = "lawMeta";
 
@@ -291,6 +291,68 @@ describe("parsed-law fetch persistence", () => {
     const cached = await getCachedLawPayload(CELEX, "EN");
     expect(cached.payload.source).toBe("fmx-consolidated");
     expect(cached.payload.consolidatedVersion).toEqual({ celex: "02006R1907-20260511", date: "2026-05-11" });
+  });
+});
+
+describe("versioned cache key (#149 ?version=current)", () => {
+  const VERSIONED_CACHE_KEY = `${CELEX}_ENG_current`;
+
+  it("caches the as-adopted and requested-version reads under distinct keys, neither evicting the other", async () => {
+    const asAdopted = { title: "As adopted", articles: [{ number: "1" }], recitals: [{}], annexes: [] };
+    const asAmended = {
+      title: "As amended",
+      articles: [{ number: "1" }, { number: "2", insertedInVersion: true }],
+      recitals: [{}],
+      annexes: [],
+      source: "fmx-consolidated",
+      version: "current",
+      versionDate: "2026-01-01",
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(asAdopted))
+      .mockResolvedValueOnce(jsonResponse(asAmended));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { fetchParsedLaw, getCachedLawPayload } = await importFormexApi();
+
+    const fetchedAsAdopted = await fetchParsedLaw(CELEX, "EN");
+    const fetchedAsAmended = await fetchParsedLaw(CELEX, "EN", { version: "current" });
+
+    expect(fetchedAsAdopted.title).toBe("As adopted");
+    expect(fetchedAsAmended.title).toBe("As amended");
+
+    // Both entries survive in IndexedDB under their own keys...
+    expect((await readCache(CACHE_KEY)).payload.title).toBe("As adopted");
+    expect((await readCache(VERSIONED_CACHE_KEY)).payload.title).toBe("As amended");
+
+    // ...and re-reading either one afterwards is a cache hit, not a refetch
+    // that would prove the other had overwritten it.
+    expect(await getCachedLawPayload(CELEX, "EN")).toMatchObject({ payload: { title: "As adopted" } });
+    const versionedCached = await readCache(VERSIONED_CACHE_KEY);
+    expect(versionedCached.payload.title).toBe("As amended");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("still groups under one CELEX for pruning and the offline library despite the extra key segment", async () => {
+    const asAdopted = { title: "As adopted", articles: [{ number: "1" }], recitals: [], annexes: [] };
+    const asAmended = { title: "As amended", articles: [{ number: "1" }], recitals: [], annexes: [] };
+    vi.stubGlobal("fetch", vi.fn()
+      .mockResolvedValueOnce(jsonResponse(asAdopted))
+      .mockResolvedValueOnce(jsonResponse(asAmended)));
+
+    const { fetchParsedLaw, getLawMeta, listCachedCelexes } = await importFormexApi();
+    await fetchParsedLaw(CELEX, "EN");
+    await fetchParsedLaw(CELEX, "EN", { version: "current" });
+
+    // pruneCacheIfNeeded and listCachedCelexes both derive the CELEX from
+    // `key.split("_")[0]` — the versioned key must still resolve to the same
+    // CELEX, not register as a second law in the offline library.
+    const celexes = await listCachedCelexes();
+    expect(celexes.filter((c) => c === CELEX)).toHaveLength(1);
+
+    // Law meta is keyed by bare CELEX, so both fetches wrote to (and share)
+    // one meta row rather than the version producing its own.
+    expect(await getLawMeta(CELEX)).toMatchObject({ celex: CELEX });
   });
 });
 

--- a/src/utils/formexApi.cacheHygiene.test.js
+++ b/src/utils/formexApi.cacheHygiene.test.js
@@ -78,6 +78,7 @@ describe("formexApi cache hygiene", () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -198,6 +199,61 @@ describe("formexApi cache hygiene", () => {
       const envelope = await api.getCachedLawPayload("32016R0679", "EN");
       expect(envelope).toMatchObject({ format: "combined-v1", parserVersion: PARSER_VERSION });
       expect(envelope.payload).toEqual(currentPayload);
+    });
+
+    it("revalidates a stale current-version payload", async () => {
+      const firstPayload = {
+        title: "GDPR",
+        articles: [{}],
+        recitals: [],
+        annexes: [],
+        version: "current",
+        versionDate: "2026-01-01",
+      };
+      const secondPayload = { ...firstPayload, versionDate: "2026-02-01" };
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(jsonResponse(firstPayload))
+        .mockResolvedValueOnce(jsonResponse(secondPayload));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const api = await importFormexApi();
+      await api.fetchParsedLaw("32016R0679", "EN", { version: "current" });
+      await api.fetchParsedLaw("32016R0679", "EN", { version: "current" });
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      vi.setSystemTime(new Date(Date.now() + 25 * 60 * 60 * 1000));
+      await expect(api.fetchParsedLaw("32016R0679", "EN", { version: "current" }))
+        .resolves.toMatchObject({ versionDate: "2026-02-01" });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("does not persist an as-adopted fallback for a failed current-version request", async () => {
+      const fallbackPayload = {
+        title: "GDPR",
+        articles: [{}],
+        recitals: [],
+        annexes: [],
+        versionUnavailable: true,
+      };
+      const currentPayload = {
+        ...fallbackPayload,
+        versionUnavailable: undefined,
+        version: "current",
+        versionDate: "2026-02-01",
+      };
+      const fetchMock = vi.fn()
+        .mockResolvedValueOnce(jsonResponse(fallbackPayload))
+        .mockResolvedValueOnce(jsonResponse(currentPayload));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const api = await importFormexApi();
+      await expect(api.fetchParsedLaw("32016R0679", "EN", { version: "current" }))
+        .resolves.toMatchObject({ versionUnavailable: true });
+      expect(await getLawEntry(indexedDb, "32016R0679_ENG_current")).toBeUndefined();
+
+      await expect(api.fetchParsedLaw("32016R0679", "EN", { version: "current" }))
+        .resolves.toMatchObject({ version: "current" });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
     it("discards a pre-versioning envelope without raw XML instead of stamping it as current", async () => {

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -36,7 +36,7 @@ export function apiFetch(url, options = {}) {
 }
 
 // Cache version — bump to invalidate all cached entries
-const CACHE_VERSION = 2;
+const CACHE_VERSION = 3;
 const RECITAL_TITLE_CACHE_VERSION = 2;
 const DB_NAME = "formex-cache";
 const STORE_NAME = "laws";
@@ -194,8 +194,17 @@ export async function closeFormexDb() {
   }
 }
 
-function makeCacheKey(celex, lang = "EN") {
-  return `${celex}_${toApiLang(lang)}`;
+// `version` is an optional dimension on top of celex+lang (e.g. "current" for
+// the consolidated/as-amended reading, added for #149). Omitted, the key is
+// unchanged from before this dimension existed, so the as-adopted cache entry
+// keeps its historical key. A versioned key still starts with the bare CELEX
+// (`32013R0575_ENG_current`), which is all `pruneCacheIfNeeded` and
+// `listCachedCelexes` key off (`key.split("_")[0]`) — so the two versions of
+// an act group under one library entry and evict together, they just don't
+// share a cache slot and can't overwrite one another.
+function makeCacheKey(celex, lang = "EN", version = null) {
+  const base = `${celex}_${toApiLang(lang)}`;
+  return version ? `${base}_${version}` : base;
 }
 
 function makeRecitalTitleCacheKey(celex, lang = "EN") {
@@ -274,7 +283,7 @@ function createCombinedLawEnvelope(payload, rawXml = null) {
 // Bump whenever the shape of a cached API payload changes (e.g. renaming a
 // summary field) so stale cache-first entries are invalidated rather than
 // served for up to API_JSON_CACHE_MAX_AGE_MS under the old shape.
-const API_JSON_CACHE_VERSION = 4;
+const API_JSON_CACHE_VERSION = 5;
 // After this age, cache-first entries are revalidated against the network
 // (still served from cache if the network is unavailable).
 const API_JSON_CACHE_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
@@ -1183,9 +1192,16 @@ export async function fetchFormexByReference(reference, lang = "EN") {
   return res.text();
 }
 
-export async function fetchParsedLaw(celex, lang = "EN") {
+// `version` — only the literal "current" is meaningful today (#149's first
+// slice; the backend 400s on anything else) — asks the backend for the
+// consolidated ("as amended") reading instead of the act as adopted. It is
+// forwarded both as a query param and as a cache-key dimension (via
+// `makeCacheKey`): the two readings are different documents that happen to
+// share a CELEX, and without the key dimension whichever one loaded last
+// would silently overwrite the other in IndexedDB.
+export async function fetchParsedLaw(celex, lang = "EN", { version = null } = {}) {
   const apiLang = toApiLang(lang);
-  const cacheKey = makeCacheKey(celex, lang);
+  const cacheKey = makeCacheKey(celex, lang, version);
   return getInFlightRequest(`parsed:${cacheKey}`, async () => {
     const cached = await cacheGet(cacheKey);
     if (isCombinedLawEnvelope(cached) && cached.parserVersion === PARSER_VERSION) {
@@ -1196,6 +1212,9 @@ export async function fetchParsedLaw(celex, lang = "EN") {
     const params = new URLSearchParams({ lang: apiLang });
     if (hasKnownMissingFmx(celex, lang)) {
       params.set("skipFmxProbe", "1");
+    }
+    if (version) {
+      params.set("version", version);
     }
     const url = `${API_BASE}/api/laws/${encodeURIComponent(celex)}/parsed?${params.toString()}`;
     const res = await apiFetch(url);

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -274,11 +274,18 @@ function createCombinedLawEnvelope(payload, rawXml = null) {
   const envelope = {
     format: "combined-v1",
     parserVersion: Number.isFinite(reported) ? reported : PARSER_VERSION,
+    cachedAt: Date.now(),
     payload,
   };
   if (rawXml) envelope.rawXml = rawXml;
   return envelope;
 }
+
+// A consolidated version is addressed as "current", so unlike an as-adopted
+// CELEX it can change when EUR-Lex publishes a newer manifestation. Keep the
+// offline convenience bounded; otherwise the first successful (or fallback)
+// response would be served forever.
+const CURRENT_VERSION_CACHE_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 // Bump whenever the shape of a cached API payload changes (e.g. renaming a
 // summary field) so stale cache-first entries are invalidated rather than
@@ -1204,7 +1211,14 @@ export async function fetchParsedLaw(celex, lang = "EN", { version = null } = {}
   const cacheKey = makeCacheKey(celex, lang, version);
   return getInFlightRequest(`parsed:${cacheKey}`, async () => {
     const cached = await cacheGet(cacheKey);
-    if (isCombinedLawEnvelope(cached) && cached.parserVersion === PARSER_VERSION) {
+    const isFreshCurrentVersion = version !== "current"
+      || (
+        Number.isFinite(cached?.cachedAt)
+        && Date.now() - cached.cachedAt < CURRENT_VERSION_CACHE_MAX_AGE_MS
+        && cached.payload?.version === "current"
+        && !cached.payload?.versionUnavailable
+      );
+    if (isCombinedLawEnvelope(cached) && cached.parserVersion === PARSER_VERSION && isFreshCurrentVersion) {
       console.log(`[FormexAPI] Cache hit: ${cacheKey}`);
       return cached.payload;
     }
@@ -1224,7 +1238,12 @@ export async function fetchParsedLaw(celex, lang = "EN", { version = null } = {}
     }
 
     const payload = await res.json();
-    if (payloadHasContent(payload)) {
+    // A requested current version that fell back to the as-adopted text is
+    // deliberately not persisted: a transient outage must not poison this
+    // mutable selector until the user clears site data.
+    const cacheablePayload = version !== "current"
+      || (payload.version === "current" && !payload.versionUnavailable);
+    if (payloadHasContent(payload) && cacheablePayload) {
       await cacheSet(cacheKey, createCombinedLawEnvelope(payload));
       await upsertLawMeta(celex, { cachedAt: Date.now() });
       await pruneCacheIfNeeded(celex, PROTECTED_BUNDLED_CELEXES);


### PR DESCRIPTION
First slice of #149. A single toggle that swaps in the current consolidated articles while keeping the as-adopted recitals — the "one identity, version as a dimension" design decision applied at exactly one point on that axis.

Builds on #144 (the honest notice) and #170 (the empty-parse consolidated fallback).

## Version is a query parameter, never a CELEX

`validateCelex` already rejects point-in-time ids, so `/api/laws/02006R1907-20260511/parsed` is a 400. That is the property #149 asks for, already holding — this PR deliberately does not loosen it.

`?version=` accepts only `current` and 400s on anything else naming it, so adding `?version=YYYY-MM-DD` later is additive rather than a silent change of meaning for URLs already in the wild.

The consolidated fetch is not new code: it is #170's fallback, lifted out of `resolveParsedLaw` into `loadConsolidatedLaw` and now callable on request as well as on an empty parse, memoised so both paths fetch at most once.

## Why compose rather than link out

EUR-Lex publishes consolidated texts with **zero recitals**, so following the existing link costs the reader the recital grid, the TF-IDF recital→article map, the AI recital titles and the related-recitals rail. Consolidation does not amend recitals, so pairing consolidated articles with as-adopted recitals is both legally correct and the pairing that keeps those features working.

Composing also makes the join answerable exactly once, while both parses are in scope: an article with no as-adopted counterpart is stamped `insertedInVersion`, and the case-law and cited-by rails render honest copy instead of an empty panel — CJEU rulings and the citation graph are both indexed against the text as adopted, so an article that did not exist then genuinely has nothing to show.

Every failure falls back rather than erroring (no consolidated version, only future-dated ones, an unresolvable version, a Cellar or SPARQL outage), serving the as-adopted law with `versionUnavailable` so the notice can say so instead of a toggle that silently did nothing.

MCP gets the same dimension: `get_law_part` takes `version: "current"`. Without it, an assistant asked what CRR Article 72b says got a not-found and a list of 521 valid numbers, for an article that exists. Version fields are attached only when requested, so as-adopted responses keep their exact previous shape.

## Two parser fixes ride along

Both are prerequisites — they are what the consolidated path actually returns.

**`<CONS.ANNEX>`** — consolidated documents root at `<CONS.ACT>` and name their annexes `<CONS.ANNEX>`, a distinct element the plain `"ANNEX"` selector never matched, so every consolidated text parsed with `annexes: []`. REACH 0 → **35** annexes (I–XVII plus 16 appendices), consolidated CRR 0 → 4. Not new breakage: #170 already renders REACH from its consolidated version in production, so those 35 annexes have been missing from a shipped law.

Three sibling `.closest("ANNEX")` guards get the same treatment for consistency, not because they were firing — in both real consolidated documents the act precedes its annexes and every article carries an `IDENTIFIER`, so first-wins document order already resolves it. The guard is defensive, and its test has to place the annex first to make it bite.

**Unquoted definitions** — REACH drafts all 44 of its Article 3 definitions as `substance: means a chemical element …`, with no quote character anywhere in the article, so both existing patterns (which require quotes) missed every one and REACH rendered `definitions: 0`. The new pattern is anchored on the meansVerb: no verb after the colon, no match. Matches are deliberately flagged **not** `quoted`, so they cannot clear the corroboration bar in an article that does not title itself "Definitions" — acts drafted this way title the article, so nothing measurable is lost.

`PARSER_VERSION` 22 → 23 covers both.

## Three things found while testing the UI

**The GDPR was showing materially uncorrected text.** Corrigenda are excluded from the amendment count on purpose (they correct the published text rather than amend the law), so the GDPR rendered with no notice at all. But EUR-Lex applies corrigenda to the *consolidated* text and not to the act as published. Diffed live: **nine GDPR articles read differently**, including Article 37(1)(c), where the corrigendum turned "and" into "or" — and with it the test for when a controller must appoint a DPO. Article 41(3): "criteria" → "requirements".

The overview now counts the corrigenda, says the text on screen is uncorrected, and offers the same toggle labelled for what it does there. Laws with no corrigenda get a positive "you are reading the current text" line too — silence was ambiguous, since a reader could not tell "we checked" from "we did not".

**"EUR-Lex has not published a consolidated version" flashed on acts that plainly have one.** `useConsolidationStatus` started `versions` at `null` and only distinguished the *failure* case from an empty result, so still-loading fell through to "none exists". Wrong since #144, harmless while the notice only linked out — but that branch now decides whether the toggle appears, so it was a claim contradicted a moment later by a button. Same fix applied to the amendment history, which the new positive line depends on.

**The AI overview is not regenerated per version.** `/summary` has no version dimension — it summarises the act as adopted and serves that unchanged, which put an overview of 521 articles above a text of 786. Regenerating it means a second cache entry and a second model call per law, so that stays with #149; the panel now carries an "As adopted" chip and says so plainly instead of passing as current.

## Cache invalidation

The frontend cache key gains the version as a dimension — without it the consolidated payload overwrites the as-adopted one in IndexedDB and the toggle appears to poison the base law. A versioned key still starts with the bare CELEX, which is all `pruneCacheIfNeeded` and `listCachedCelexes` read, so the two readings group under one library entry and evict together. `CACHE_VERSION` 2 → 3, `API_JSON_CACHE_VERSION` 4 → 5.

## Verification

End to end on the CRR (`32013R0575`): 521 → 786 articles, all 136 recitals preserved, 265 articles stamped `insertedInVersion` (matching the count #149 measured independently), `versionCelex: 02013R0575-20260626`. Toggle, reverse banner, URL persistence and the inserted-article rails all checked in a browser against a local API.

Against the live documents:

| | before | after |
|---|---|---|
| REACH annexes | 0 | 35 |
| REACH definitions | 0 | 44 |
| GDPR consolidated definitions | 26 | 26 |
| CRR consolidated definitions | 793 | 793 |

GDPR and CRR are the controls: the quoted path is undisturbed, and CRR is byte-identical with the new pattern force-disabled, so it contributes no false positives across 786 articles.

497 frontend tests, 485 backend (+2 pre-existing skips), lint clean.

## Not in this slice

The version picker, arbitrary `?version=YYYY-MM-DD`, article-level diffs, per-version AI overviews, and any prerender or canonical change — prerendering never requests a version, so those pages stay as adopted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
