### PR TITLE
Resolve act references typed without the act-type word

### DIFF
--- a/backend/search/legal-cache-store.js
+++ b/backend/search/legal-cache-store.js
@@ -1333,6 +1333,13 @@ class JsonLegalCacheStore {
     if (parsed.type && parsed.year && parsed.number) {
       const referenceKey = `${parsed.type}|${parsed.year}|${parsed.number}`;
       addMatch(getDeterministicMatch(this.byOfficialReference, referenceKey));
+    } else if (parsed.year && parsed.number) {
+      // A bare year/number is still an official reference; pre-2015 sequences
+      // can overlap across act types, so probe each type in deterministic order.
+      for (const type of ["regulation", "directive", "decision"]) {
+        const referenceKey = `${type}|${parsed.year}|${parsed.number}`;
+        addMatch(getDeterministicMatch(this.byOfficialReference, referenceKey));
+      }
     }
 
     for (const key of [parsed.normalized, parsed.compact]) {

--- a/backend/search/legal-cache-store.test.js
+++ b/backend/search/legal-cache-store.test.js
@@ -183,6 +183,68 @@ test("legal cache store resolves exact official reference", () => {
   assert.equal(match?.celex, "32015L2366");
 });
 
+test("legal cache store resolves untyped official references before title matches", () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "legal-cache-store-untyped-reference-"));
+  const tempPath = path.join(tempDir, "search.json");
+  fs.writeFileSync(tempPath, JSON.stringify({ records: [
+    {
+      celex: "32021R2115",
+      title: "Common agricultural policy rules",
+      type: "regulation",
+      eli: "http://data.europa.eu/eli/reg/2021/2115/oj",
+    },
+    {
+      celex: "32024R0123",
+      title: "Regulation amending Regulation (EU) 2021/2115",
+      type: "regulation",
+      eli: "http://data.europa.eu/eli/reg/2024/123/oj",
+    },
+    {
+      celex: "32014R2115",
+      title: "Regulation 2014 reference",
+      type: "regulation",
+      eli: "http://data.europa.eu/eli/reg/2014/2115/oj",
+    },
+    {
+      celex: "32014L2115",
+      title: "Directive 2014 reference",
+      type: "directive",
+      eli: "http://data.europa.eu/eli/dir/2014/2115/oj",
+    },
+    {
+      celex: "32014D2115",
+      title: "Decision 2014 reference",
+      type: "decision",
+      eli: "http://data.europa.eu/eli/dec/2014/2115/oj",
+    },
+  ] }), "utf8");
+
+  const store = new JsonLegalCacheStore(tempPath, { preferJson: true });
+  try {
+    assert.equal(store.load(), true);
+
+    for (const query of ["2021/2115", "2021 2115"]) {
+      const results = store.searchLaws(query, { limit: 2 });
+      assert.deepEqual(results.map((result) => result.celex), ["32021R2115", "32024R0123"]);
+      assert.equal(results[0].matchReason, "reference_exact");
+      assert.equal(results[1].matchReason, "title_phrase");
+    }
+
+    const overlappingReferences = store.searchLaws("2014/2115", { limit: 3 });
+    assert.deepEqual(
+      overlappingReferences.map((result) => result.celex),
+      ["32014R2115", "32014L2115", "32014D2115"]
+    );
+    assert.deepEqual(
+      overlappingReferences.map((result) => result.matchReason),
+      ["reference_exact", "reference_exact", "reference_exact"]
+    );
+  } finally {
+    store.close();
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test("legal cache store supplements the ePrivacy Directive when missing from cache", () => {
   const store = new JsonLegalCacheStore(fixturePath);
   store.load();

--- a/backend/search/search-ranking.js
+++ b/backend/search/search-ranking.js
@@ -151,6 +151,7 @@ function parseStructuredQuery(query, options = {}) {
   const celexMatch = celexCompact.match(/^3\d{4}[RLD]\d{1,4}(?:\(\d+\))?$/);
 
   const slashMatch = raw.match(/\b(\d{4})\s*\/\s*(\d{1,4})\b/);
+  const spacedReferenceMatch = normalized.match(/^(\d{4})\s+(\d{1,4})$/);
   const typePrefixMatch = raw.match(/\b(regulation|directive|decision)\b/);
   const leadingTypeYearNumberMatch = raw.match(
     /\b(regulation|directive|decision)\b[^0-9]*(\d{4})\s*\/\s*(\d{1,4})\b/
@@ -167,10 +168,12 @@ function parseStructuredQuery(query, options = {}) {
       .filter((term) => term.length >= 2)
       .filter((term) => !LOW_SIGNAL_TERMS.has(term)),
     celex: celexMatch ? celexMatch[0] : null,
-    year: leadingTypeYearNumberMatch?.[2] || slashMatch?.[1] || null,
+    year: leadingTypeYearNumberMatch?.[2] || slashMatch?.[1] || spacedReferenceMatch?.[1] || null,
     number: leadingTypeYearNumberMatch?.[3]
       ? String(Number.parseInt(leadingTypeYearNumberMatch[3], 10))
-      : (slashMatch?.[2] ? String(Number.parseInt(slashMatch[2], 10)) : null),
+      : (slashMatch?.[2]
+        ? String(Number.parseInt(slashMatch[2], 10))
+        : (spacedReferenceMatch?.[2] ? String(Number.parseInt(spacedReferenceMatch[2], 10)) : null)),
     type: normalizeTypeToken(leadingTypeYearNumberMatch?.[1] || typePrefixMatch?.[1] || "")
   };
 }
@@ -281,10 +284,10 @@ function determineMatchReason(law, parsed) {
   if (normalizedTitle === parsed.normalized || compactText(law.title) === parsed.compact) {
     return "alias_exact";
   }
-  if (parsed.type && parsed.year && parsed.number &&
-      parsed.type === law.type &&
+  if (parsed.year && parsed.number &&
       parsed.year === law.celexYear &&
-      parsed.number === law.celexNumber) {
+      parsed.number === law.celexNumber &&
+      (!parsed.type || parsed.type === law.type)) {
     return "reference_exact";
   }
   if (normalizedTitle.includes(parsed.normalized) || compactText(law.title).includes(parsed.compact)) {

--- a/backend/search/search-ranking.test.js
+++ b/backend/search/search-ranking.test.js
@@ -19,3 +19,33 @@ test("determineMatchReason treats Law Enforcement Directive aliases as exact mat
     assert.equal(determineMatchReason(law, parsed), "alias_exact", `Expected alias_exact for ${query}`);
   }
 });
+
+test("parseStructuredQuery extracts slash and whitespace year/number references", () => {
+  for (const query of ["2021/2115", "2021 2115"]) {
+    const parsed = parseStructuredQuery(query);
+    assert.equal(parsed.year, "2021", `Expected year for ${query}`);
+    assert.equal(parsed.number, "2115", `Expected number for ${query}`);
+    assert.equal(parsed.type, null, `Expected no act type for ${query}`);
+  }
+});
+
+test("parseStructuredQuery does not infer references from numbers in prose", () => {
+  for (const query of ["emissions 2020 2030 targets", "chapter 3 2016 679"]) {
+    const parsed = parseStructuredQuery(query);
+    assert.equal(parsed.year, null, `Expected no year for ${query}`);
+    assert.equal(parsed.number, null, `Expected no number for ${query}`);
+  }
+});
+
+test("determineMatchReason reports untyped year/number references as exact", () => {
+  const law = enrichSearchRecord({
+    celex: "32021R2115",
+    title: "Common agricultural policy rules",
+    type: "regulation",
+    eli: "http://data.europa.eu/eli/reg/2021/2115/oj",
+  });
+
+  for (const query of ["2021/2115", "2021 2115"]) {
+    assert.equal(determineMatchReason(law, parseStructuredQuery(query)), "reference_exact");
+  }
+});


### PR DESCRIPTION
## Problem

Searching `2021/2115` returns the acts that *amend* Regulation (EU) 2021/2115, but never the act itself. Against production today:

```bash
curl -s -G https://api.legalviz.eu/api/search --data-urlencode 'q=2021/2115' --data-urlencode limit=3
```

→ `32026R1768`, `32024R1468`, … all `matchReason: "title_phrase"`. `32021R2115` is absent. Adding the word "regulation" fixes it (`reference_exact`), as does the raw CELEX.

## Cause

Two things combine:

1. The deterministic `byOfficialReference` lookup in `searchLaws` was gated on `parsed.type` as well as year/number. `parseStructuredQuery` extracts year and number from a bare `2021/2115` fine, but `type` stays null without a "regulation"/"directive"/"decision" token — so the exact-reference lookup was skipped entirely and the query degraded to ordinary text retrieval.
2. EUR-Lex titles do not repeat an act's own number, so the target act has no textual match for the token `2115`, while every amending act literally says "amending Regulation (EU) 2021/2115". The amenders were the only textual matches and took every slot.

## Change

- When year and number parse but the type does not, probe all three type keys in deterministic order. Post-2015 EU numbering is a single shared sequence, so this is normally one hit; pre-2015 sequences can overlap and all matching acts are returned.
- `determineMatchReason` reports `reference_exact` for these untyped matches, and only when the record's own `celexYear`/`celexNumber` match.
- Parse the whitespace form (`2021 2115`) too, **anchored to the whole query**: two adjacent numbers in prose ("emissions 2020 2030 targets", "chapter 3 2016 679") carry no reference signal and must not pin an unrelated act at rank 1. The slash form stays loose, as it is today — the punctuation makes it unambiguous.

## Notes

Query-time only — no persisted artifact shape changes, so no cache/version constant bump.

## Tests

New coverage in `search-ranking.test.js` (both query forms parse; prose numbers do not; `reference_exact` for untyped references) and `legal-cache-store.test.js` (untyped reference outranks the amending act; overlapping pre-2015 types all returned).

`npm test` from `backend/`: 494 tests, 492 pass, 0 fail, 2 skipped. `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)