### PR TITLE
Close parser-version drift in precomputed assets (#180)

### DIFF
--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -81,8 +81,6 @@ jobs:
             --pattern search-cache.json.gz \
             --pattern case-law-cache.json.gz \
             --pattern citation-graph.json.gz \
-            --pattern data.sqlite.gz \
-            --pattern data.sqlite.manifest.json \
             --dir refresh-inputs
           # Definitions are optional at runtime, but a present asset must be
           # downloaded successfully and carried forward unchanged.
@@ -97,7 +95,7 @@ jobs:
           else
             echo "No definitions.json.gz in current data release; continuing without the optional asset"
           fi
-          for asset in search-cache.json.gz case-law-cache.json.gz citation-graph.json.gz data.sqlite.gz data.sqlite.manifest.json; do
+          for asset in search-cache.json.gz case-law-cache.json.gz citation-graph.json.gz; do
             test -s "refresh-inputs/$asset" || { echo "Missing current data asset: $asset" >&2; exit 1; }
           done
 
@@ -128,11 +126,8 @@ jobs:
             > backend/search/data/search-cache.json
           gzip -cd refresh-inputs/case-law-cache.json.gz \
             > backend/law-cache/case-law-cache-v5.json
-          gzip -cd refresh-inputs/data.sqlite.gz \
-            > refresh-output/current-data.sqlite
           test -s backend/search/data/search-cache.json
           test -s backend/law-cache/case-law-cache-v5.json
-          test -s refresh-output/current-data.sqlite
 
       - name: Assert parser freshness of restored data inputs
         env:
@@ -143,8 +138,7 @@ jobs:
           node backend/search/assert-parser-freshness.js \
             --search-cache backend/search/data/search-cache.json \
             --citation-graph refresh-inputs/citation-graph.json.gz \
-            --definitions refresh-inputs/definitions.json.gz \
-            --data-sqlite refresh-output/current-data.sqlite
+            --definitions refresh-inputs/definitions.json.gz
 
       - name: Add corpus acts missing from the cache
         working-directory: backend

--- a/.github/workflows/refresh-data.yml
+++ b/.github/workflows/refresh-data.yml
@@ -81,6 +81,8 @@ jobs:
             --pattern search-cache.json.gz \
             --pattern case-law-cache.json.gz \
             --pattern citation-graph.json.gz \
+            --pattern data.sqlite.gz \
+            --pattern data.sqlite.manifest.json \
             --dir refresh-inputs
           # Definitions are optional at runtime, but a present asset must be
           # downloaded successfully and carried forward unchanged.
@@ -95,7 +97,7 @@ jobs:
           else
             echo "No definitions.json.gz in current data release; continuing without the optional asset"
           fi
-          for asset in search-cache.json.gz case-law-cache.json.gz citation-graph.json.gz; do
+          for asset in search-cache.json.gz case-law-cache.json.gz citation-graph.json.gz data.sqlite.gz data.sqlite.manifest.json; do
             test -s "refresh-inputs/$asset" || { echo "Missing current data asset: $asset" >&2; exit 1; }
           done
 
@@ -126,8 +128,23 @@ jobs:
             > backend/search/data/search-cache.json
           gzip -cd refresh-inputs/case-law-cache.json.gz \
             > backend/law-cache/case-law-cache-v5.json
+          gzip -cd refresh-inputs/data.sqlite.gz \
+            > refresh-output/current-data.sqlite
           test -s backend/search/data/search-cache.json
           test -s backend/law-cache/case-law-cache-v5.json
+          test -s refresh-output/current-data.sqlite
+
+      - name: Assert parser freshness of restored data inputs
+        env:
+          ALLOW_PARSER_DRIFT: ${{ vars.ALLOW_PARSER_DRIFT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node backend/search/assert-parser-freshness.js \
+            --search-cache backend/search/data/search-cache.json \
+            --citation-graph refresh-inputs/citation-graph.json.gz \
+            --definitions refresh-inputs/definitions.json.gz \
+            --data-sqlite refresh-output/current-data.sqlite
 
       - name: Add corpus acts missing from the cache
         working-directory: backend

--- a/.github/workflows/refresh-fulltext.yml
+++ b/.github/workflows/refresh-fulltext.yml
@@ -192,6 +192,15 @@ jobs:
           console.log(`Current fulltext has ${fulltextCelex.size} acts.`);
           NODE
 
+      - name: Assert parser freshness of restored fulltext index
+        env:
+          ALLOW_PARSER_DRIFT: ${{ vars.ALLOW_PARSER_DRIFT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          node backend/search/assert-parser-freshness.js \
+            --fulltext-sqlite refresh-output/fulltext.sqlite
+
       - name: Capture baseline fulltext count
         id: baseline
         shell: bash

--- a/backend/docs/legislation-data-refresh.md
+++ b/backend/docs/legislation-data-refresh.md
@@ -148,6 +148,48 @@ assets, then:
    open `automation/<tag>` for that release tag. That PR changes only
    `ARG FULLTEXT_RELEASE_TAG`; merging it is the deploy gate.
 
+## Parser-version freshness and offline re-derivation
+
+The derived-asset guard runs immediately after the current inputs are restored.
+It checks the search cache, citation graph, optional definitions index, and
+full-text SQLite metadata against `PARSER_VERSION` in the Formex parser. An
+unstamped or older asset is a failure; an absent definitions asset is allowed.
+`ALLOW_PARSER_DRIFT=true` is a temporary repository-variable escape hatch for
+the v21-to-v22 migration. Remove it after the v22 assets are published.
+
+The one-off re-derivation is an offline corpus pass: restore the complete
+`laws/`, `laws-html/`, and (for citation edges) case-law corpus first, and write
+every result to a fresh output path. Never point an incremental builder at the
+released input: full text skips existing CELEXes, and a definitions checkpoint
+is derived from its output path. Keep each asset in its own job so a timeout
+does not discard completed work in the others.
+
+The current builder commands are:
+
+```sh
+# From backend/; use a new directory for every run.
+node --max-old-space-size=6144 search/citation-graph-build.js \
+  --corpusDir search/data/laws --htmlDir search/data/laws-html \
+  --out /tmp/legalviz-v22/citation-graph.json --workerHeapMb 4096
+
+node search/definition-index-build.js \
+  --corpusDir search/data/laws --htmlDir search/data/laws-html \
+  --out /tmp/legalviz-v22/definitions.json --workerHeapMb 2048
+
+node --max-old-space-size=4096 search/fulltext-index-build.js \
+  --corpusDir search/data/fulltext-corpus \
+  --out /tmp/legalviz-v22/fulltext.sqlite --workerHeapMb 1024
+```
+
+The search-cache offline re-derive command belongs to the separate re-derive
+workflow because the existing `search-build.js` path performs network harvests;
+do not use it to repair a released cache. The citation graph has no resumable
+checkpoint and may need several gigabytes of heap. Definitions checkpoint each
+batch under `<output>.checkpoint`; delete stale checkpoints or use a new output
+path. Full text resumes at the SQLite database level, so its fresh output path
+is mandatory. These commands parse only the restored local corpus; they do not
+fetch EUR-Lex or mutate a published release.
+
 ## Candidate inspection
 
 Inspect the stage artifact and generated PR checks. For a full-text

--- a/backend/search/assert-parser-freshness.js
+++ b/backend/search/assert-parser-freshness.js
@@ -1,0 +1,189 @@
+"use strict";
+
+const fs = require("node:fs");
+const Database = require("better-sqlite3");
+
+const { getCurrentParserVersion, isFresh, normalizeParserStamp } = require("./parser-stamp");
+const { streamStats } = require("./json-stream-stats");
+
+function parseArgs(argv) {
+  const options = {};
+  const flags = new Map([
+    ["--search-cache", "searchCachePath"],
+    ["--citation-graph", "citationGraphPath"],
+    ["--definitions", "definitionsPath"],
+    ["--fulltext-sqlite", "fulltextSqlitePath"],
+    ["--data-sqlite", "dataSqlitePath"],
+  ]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = flags.get(argv[index]);
+    if (!key) throw new Error(`Unknown argument: ${argv[index]}`);
+    const value = argv[++index];
+    if (!value) throw new Error(`Missing value for ${argv[index - 1]}`);
+    options[key] = value;
+  }
+  return options;
+}
+
+function parseStoredStamp(value) {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function readSqliteMetadata(filePath) {
+  const database = new Database(filePath, { readonly: true, fileMustExist: true });
+  try {
+    return new Map(database.prepare("SELECT key, value FROM fulltext_metadata").all()
+      .map((row) => [row.key, row.value]));
+  } finally {
+    database.close();
+  }
+}
+
+function readDataMetadata(filePath) {
+  const database = new Database(filePath, { readonly: true, fileMustExist: true });
+  try {
+    return new Map(database.prepare("SELECT key, value FROM metadata").all()
+      .map((row) => [row.key, row.value]));
+  } finally {
+    database.close();
+  }
+}
+
+function staleFinding(asset, stamp, current, detail = null) {
+  if (isFresh(stamp, current)) return null;
+  return {
+    asset,
+    stamp: normalizeParserStamp(stamp),
+    current,
+    detail,
+  };
+}
+
+async function checkJsonAsset(filePath, asset, current) {
+  if (!fs.existsSync(filePath)) return staleFinding(asset, undefined, current, "missing");
+  try {
+    const stats = await streamStats(filePath, {
+      captureTopLevel: ["parserVersion"],
+    });
+    return staleFinding(asset, stats.topLevel?.parserVersion, current);
+  } catch (error) {
+    return staleFinding(asset, undefined, current, error.message);
+  }
+}
+
+function checkFulltextSqlite(filePath, asset, current) {
+  if (!fs.existsSync(filePath)) return staleFinding(asset, undefined, current, "missing");
+  try {
+    const metadata = readSqliteMetadata(filePath);
+    return staleFinding(asset, parseStoredStamp(metadata.get("parser_version")), current);
+  } catch (error) {
+    return staleFinding(asset, undefined, current, error.message);
+  }
+}
+
+function checkDataSqlite(filePath, current) {
+  if (!fs.existsSync(filePath)) return [staleFinding("data.sqlite", undefined, current, "missing")];
+  try {
+    const metadata = readDataMetadata(filePath);
+    const findings = [
+      staleFinding("data.sqlite search", parseStoredStamp(metadata.get("search_parser_version")), current),
+    ];
+    if ([...metadata.keys()].some((key) => key.startsWith("citation_graph_"))) {
+      findings.push(staleFinding(
+        "data.sqlite citation graph",
+        parseStoredStamp(metadata.get("citation_graph_parser_version")),
+        current
+      ));
+    }
+    if (metadata.has("definitions_parser_version") || metadata.get("definitions_available") === "1") {
+      findings.push(staleFinding(
+        "data.sqlite definitions",
+        parseStoredStamp(metadata.get("definitions_parser_version")),
+        current
+      ));
+    }
+    return findings.filter(Boolean);
+  } catch (error) {
+    return [staleFinding("data.sqlite", undefined, current, error.message)];
+  }
+}
+
+async function assertParserFreshness({
+  searchCachePath,
+  citationGraphPath,
+  definitionsPath,
+  fulltextSqlitePath,
+  dataSqlitePath,
+  currentVersion,
+} = {}) {
+  if (!Number.isSafeInteger(currentVersion)) throw new Error("currentVersion must be a parser version number");
+  const findings = [];
+  const jsonAssets = [
+    [searchCachePath, "search-cache", false],
+    [citationGraphPath, "citation-graph", false],
+    [definitionsPath, "definitions", true],
+  ];
+  for (const [filePath, asset, optional] of jsonAssets) {
+    if (!filePath || (optional && !fs.existsSync(filePath))) continue;
+    const finding = await checkJsonAsset(filePath, asset, currentVersion);
+    if (finding) findings.push(finding);
+  }
+  if (fulltextSqlitePath) {
+    const finding = checkFulltextSqlite(fulltextSqlitePath, "fulltext", currentVersion);
+    if (finding) findings.push(finding);
+  }
+  if (dataSqlitePath) findings.push(...checkDataSqlite(dataSqlitePath, currentVersion));
+  return { currentVersion, findings, fresh: findings.length === 0 };
+}
+
+function formatFinding(finding) {
+  const stamp = finding.stamp.length ? finding.stamp.join(",") : "absent";
+  return `parser drift: ${finding.asset} has ${stamp}; expected ${finding.current}${finding.detail ? ` (${finding.detail})` : ""}`;
+}
+
+function allowParserDrift(value) {
+  return ["1", "true", "yes", "on"].includes(String(value || "").trim().toLowerCase());
+}
+
+async function main(argv = process.argv.slice(2), env = process.env) {
+  const options = parseArgs(argv);
+  const currentVersion = await getCurrentParserVersion();
+  const result = await assertParserFreshness({ ...options, currentVersion });
+  if (!result.findings.length) {
+    console.log(`Parser freshness OK at v${currentVersion}.`);
+    return 0;
+  }
+  for (const finding of result.findings) console.error(formatFinding(finding));
+  if (allowParserDrift(env.ALLOW_PARSER_DRIFT)) {
+    const summary = result.findings.map(formatFinding).join("\n");
+    if (env.GITHUB_STEP_SUMMARY) fs.appendFileSync(env.GITHUB_STEP_SUMMARY, `${summary}\n`);
+    console.warn("ALLOW_PARSER_DRIFT is set; continuing despite parser drift.");
+    return 0;
+  }
+  return 1;
+}
+
+if (require.main === module) {
+  main().then((exitCode) => {
+    process.exitCode = exitCode;
+  }).catch((error) => {
+    console.error(`[parser-freshness] fatal: ${error.message}`);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = {
+  allowParserDrift,
+  assertParserFreshness,
+  formatFinding,
+  main,
+  parseArgs,
+  parseStoredStamp,
+  readDataMetadata,
+  readSqliteMetadata,
+};

--- a/backend/search/assert-parser-freshness.js
+++ b/backend/search/assert-parser-freshness.js
@@ -69,6 +69,7 @@ async function checkJsonAsset(filePath, asset, current) {
   try {
     const stats = await streamStats(filePath, {
       captureTopLevel: ["parserVersion"],
+      stopWhenCaptured: true,
     });
     return staleFinding(asset, stats.topLevel?.parserVersion, current);
   } catch (error) {

--- a/backend/search/assert-parser-freshness.test.js
+++ b/backend/search/assert-parser-freshness.test.js
@@ -1,0 +1,96 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+const Database = require("better-sqlite3");
+
+const { assertParserFreshness } = require("./assert-parser-freshness");
+
+function writeJson(dir, name, payload) {
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, `${JSON.stringify(payload)}\n`);
+  return file;
+}
+
+function writeMetadataDatabase(filePath, table, rows) {
+  const database = new Database(filePath);
+  database.exec(`CREATE TABLE ${table} (key TEXT PRIMARY KEY, value TEXT)`);
+  const insert = database.prepare(`INSERT INTO ${table} (key, value) VALUES (?, ?)`);
+  for (const [key, value] of Object.entries(rows)) insert.run(key, value);
+  database.close();
+  return filePath;
+}
+
+test("fresh JSON and fulltext assets pass, while absent definitions are allowed", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-freshness-fresh-"));
+  const searchCachePath = writeJson(dir, "search.json", { parserVersion: 22, records: [] });
+  const citationGraphPath = writeJson(dir, "citation.json", { parserVersion: [21, 22], edges: [] });
+  const fulltextSqlitePath = writeMetadataDatabase(path.join(dir, "fulltext.sqlite"), "fulltext_metadata", {
+    parser_version: "22",
+  });
+  const result = await assertParserFreshness({
+    searchCachePath,
+    citationGraphPath,
+    definitionsPath: path.join(dir, "definitions.json"),
+    fulltextSqlitePath,
+    currentVersion: 22,
+  });
+  assert.equal(result.fresh, true);
+  assert.deepEqual(result.findings, []);
+});
+
+test("reports every drifted or unstamped asset", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-freshness-drift-"));
+  const searchCachePath = writeJson(dir, "search.json", { records: [] });
+  const citationGraphPath = writeJson(dir, "citation.json", { parserVersion: 21, edges: [] });
+  const definitionsPath = writeJson(dir, "definitions.json", { parserVersion: 21, occurrences: [] });
+  const fulltextSqlitePath = writeMetadataDatabase(path.join(dir, "fulltext.sqlite"), "fulltext_metadata", {
+    parser_version: "null",
+  });
+  const result = await assertParserFreshness({
+    searchCachePath,
+    citationGraphPath,
+    definitionsPath,
+    fulltextSqlitePath,
+    currentVersion: 22,
+  });
+  assert.deepEqual(result.findings.map((finding) => finding.asset), [
+    "search-cache",
+    "citation-graph",
+    "definitions",
+    "fulltext",
+  ]);
+
+  const args = [
+    require.resolve("./assert-parser-freshness"),
+    "--search-cache", searchCachePath,
+    "--citation-graph", citationGraphPath,
+    "--definitions", definitionsPath,
+    "--fulltext-sqlite", fulltextSqlitePath,
+  ];
+  const failed = spawnSync(process.execPath, args, { encoding: "utf8" });
+  assert.equal(failed.status, 1);
+  for (const asset of ["search-cache", "citation-graph", "definitions", "fulltext"]) {
+    assert.match(failed.stderr, new RegExp(`parser drift: ${asset}`));
+  }
+  const allowed = spawnSync(process.execPath, args, {
+    encoding: "utf8",
+    env: { ...process.env, ALLOW_PARSER_DRIFT: "true" },
+  });
+  assert.equal(allowed.status, 0);
+});
+
+test("checks parser stamps propagated into data.sqlite", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-freshness-data-"));
+  const dataSqlitePath = writeMetadataDatabase(path.join(dir, "data.sqlite"), "metadata", {
+    search_parser_version: "22",
+    citation_graph_version: "2",
+    citation_graph_parser_version: "21",
+    definitions_available: "1",
+    definitions_parser_version: "22",
+  });
+  const result = await assertParserFreshness({ dataSqlitePath, currentVersion: 22 });
+  assert.deepEqual(result.findings.map((finding) => finding.asset), ["data.sqlite citation graph"]);
+});

--- a/backend/search/assert-parser-freshness.test.js
+++ b/backend/search/assert-parser-freshness.test.js
@@ -26,7 +26,7 @@ function writeMetadataDatabase(filePath, table, rows) {
 test("fresh JSON and fulltext assets pass, while absent definitions are allowed", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-freshness-fresh-"));
   const searchCachePath = writeJson(dir, "search.json", { parserVersion: 22, records: [] });
-  const citationGraphPath = writeJson(dir, "citation.json", { parserVersion: [21, 22], edges: [] });
+  const citationGraphPath = writeJson(dir, "citation.json", { parserVersion: [22], edges: [] });
   const fulltextSqlitePath = writeMetadataDatabase(path.join(dir, "fulltext.sqlite"), "fulltext_metadata", {
     parser_version: "22",
   });
@@ -39,6 +39,20 @@ test("fresh JSON and fulltext assets pass, while absent definitions are allowed"
   });
   assert.equal(result.fresh, true);
   assert.deepEqual(result.findings, []);
+});
+
+test("reports a mixed-version stamp as drift, not freshness", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "parser-freshness-mixed-"));
+  const searchCachePath = writeJson(dir, "search.json", { parserVersion: "21,22", records: [] });
+  const citationGraphPath = writeJson(dir, "citation.json", { parserVersion: [21, 22], edges: [] });
+  const result = await assertParserFreshness({
+    searchCachePath,
+    citationGraphPath,
+    definitionsPath: path.join(dir, "definitions.json"),
+    currentVersion: 22,
+  });
+  assert.equal(result.fresh, false);
+  assert.deepEqual(result.findings.map((finding) => finding.asset), ["search-cache", "citation-graph"]);
 });
 
 test("reports every drifted or unstamped asset", async () => {

--- a/backend/search/backfill-cache.js
+++ b/backend/search/backfill-cache.js
@@ -36,6 +36,7 @@ const {
 const { enrichRecordsWithEurovoc } = require("./eurovoc-enrich");
 const { enrichRecordsWithInForce } = require("./in-force-enrich");
 const { enrichSearchRecord } = require("./search-ranking");
+const { getCurrentParserVersion, mergeParserStamp } = require("./parser-stamp");
 
 function log(message) {
   console.log(`[backfill] ${message}`);
@@ -165,6 +166,8 @@ async function backfillCache(options = {}) {
 
   payload.count = payload.records.length;
   payload.patchedAt = new Date().toISOString();
+  const parserVersion = await getCurrentParserVersion();
+  payload.parserVersion = mergeParserStamp(payload.parserVersion, parserVersion);
 
   if (options["dry-run"]) {
     log(`dry run — would write ${payload.count} records (added=${added} replaced=${replaced})`);

--- a/backend/search/backfill-cache.test.js
+++ b/backend/search/backfill-cache.test.js
@@ -8,6 +8,7 @@ const zlib = require("node:zlib");
 
 const { backfillCache, readCelexIds } = require("./backfill-cache");
 const { buildCelexQuery, harvestActsByCelex } = require("./search-build");
+const { getCurrentParserVersion } = require("./parser-stamp");
 
 function tempCache(payload, { gzip = false } = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "backfill-"));
@@ -114,7 +115,7 @@ test("backfillCache merges the current parser version with an existing stamp", a
     enrichImpl: async () => {}
   });
 
-  assert.deepEqual(JSON.parse(fs.readFileSync(cachePath, "utf8")).parserVersion, [21, 22]);
+  assert.deepEqual(JSON.parse(fs.readFileSync(cachePath, "utf8")).parserVersion, [21, await getCurrentParserVersion()]);
 });
 
 // isPrimaryAct is derived from the ELI, so a record without a primary one would

--- a/backend/search/backfill-cache.test.js
+++ b/backend/search/backfill-cache.test.js
@@ -49,6 +49,7 @@ test("backfillCache adds a missing record with the shipped record shape", async 
   assert.deepEqual(result.addedIds, ["32014D0055"]);
   const written = JSON.parse(fs.readFileSync(cachePath, "utf8"));
   assert.equal(written.count, 2);
+  assert.equal(written.parserVersion, null);
   const added = written.records.find((r) => r.celex === "32014D0055");
   // enrichSearchRecord's derived fields must be baked in, like the swept records.
   assert.equal(added.isPrimaryAct, true);
@@ -95,6 +96,25 @@ test("backfillCache round-trips a gzipped cache", async () => {
   const written = JSON.parse(zlib.gunzipSync(fs.readFileSync(cachePath)).toString("utf8"));
   assert.equal(written.count, 1);
   assert.equal(written.records[0].celex, "32014D0055");
+});
+
+test("backfillCache merges the current parser version with an existing stamp", async () => {
+  const cachePath = tempCache({ count: 0, parserVersion: 21, records: [] });
+
+  await backfillCache({
+    cachePath,
+    celex: "32014D0055",
+    corpusDir: null,
+    eurovoc: false,
+    inForce: false,
+    harvestImpl: async () => [{
+      celex: "32014D0055", title: "Decision", date: "2014-12-15",
+      eli: "http://data.europa.eu/eli/dec/2015/425/oj", type: "decision"
+    }],
+    enrichImpl: async () => {}
+  });
+
+  assert.deepEqual(JSON.parse(fs.readFileSync(cachePath, "utf8")).parserVersion, [21, 22]);
 });
 
 // isPrimaryAct is derived from the ELI, so a record without a primary one would

--- a/backend/search/build-sqlite-data.js
+++ b/backend/search/build-sqlite-data.js
@@ -360,6 +360,7 @@ function buildSqliteData({
       insertMetadata.run("search_record_count", String(records.length));
       insertMetadata.run("case_law_count", String(caseLawEntries.length));
       insertMetadata.run("definitions_available", definitionsAsset ? "1" : "0");
+      insertMetadata.run("search_parser_version", JSON.stringify(searchPayload.parserVersion ?? null));
 
       records.forEach((record, ordinal) => {
         const excerpt = typeof record?.excerpt === "string" ? record.excerpt : "";
@@ -400,6 +401,12 @@ function buildSqliteData({
         insertMetadata.run("citation_graph_generated_at", String(header.generatedAt || ""));
         insertMetadata.run("citation_graph_coverage", JSON.stringify(header.coverage ?? null));
         insertMetadata.run("citation_graph_stats", JSON.stringify(header.stats ?? null));
+      }
+      if (definitionsAsset) {
+        insertMetadata.run(
+          "definitions_parser_version",
+          JSON.stringify(definitionsAsset.payload?.parserVersion ?? null)
+        );
       }
       const citationSourceTitles = new Map();
       for (const edge of citationEdges) {
@@ -522,6 +529,7 @@ function buildSqliteData({
           sha256: searchAsset.sha256,
           records: records.length,
           generatedAt: searchPayload.generatedAt || null,
+          parserVersion: searchPayload.parserVersion ?? null,
         },
         caseLaw: {
           file: path.basename(caseLawAsset.path),
@@ -538,6 +546,7 @@ function buildSqliteData({
           edges: expectedCitationCount,
           skippedEdges: skippedCitationEdges,
           graphVersion: citationAsset.payload?.graphVersion ?? null,
+          parserVersion: citationAsset.payload?.parserVersion ?? null,
           generatedAt: citationAsset.payload?.generatedAt || null,
         } : null,
         definitions: definitionsAsset ? {
@@ -547,6 +556,7 @@ function buildSqliteData({
           terms: definitionTerms.length,
           occurrences: definitionOccurrences.length,
           usageEdges: definitionUsageEdges.length,
+          parserVersion: definitionsAsset.payload?.parserVersion ?? null,
           generatedAt: definitionsAsset.payload?.generatedAt || null,
         } : null,
       },

--- a/backend/search/build-sqlite-data.test.js
+++ b/backend/search/build-sqlite-data.test.js
@@ -4,6 +4,7 @@ const crypto = require("node:crypto");
 const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const Database = require("better-sqlite3");
 
 const { buildSqliteData, SQLITE_SCHEMA_VERSION } = require("./build-sqlite-data");
 
@@ -19,6 +20,7 @@ test("buildSqliteData emits a verified manifest with source and table counts", (
   const manifestPath = path.join(tempDir, "manifest.json");
   fs.writeFileSync(searchPath, JSON.stringify({
     generatedAt: "2026-07-15T00:00:00.000Z",
+    parserVersion: 22,
     records: [
       {
         celex: "32024R9001",
@@ -72,8 +74,12 @@ test("buildSqliteData emits a verified manifest with source and table counts", (
     orphanFtsMappings: 0,
   });
   assert.equal(manifest.source.search.sha256, sha256(searchPath));
+  assert.equal(manifest.source.search.parserVersion, 22);
   assert.equal(manifest.source.caseLaw.sha256, sha256(caseLawPath));
   assert.equal(manifest.artifact.sha256, sha256(outputPath));
+  const database = new Database(outputPath, { readonly: true });
+  assert.equal(database.prepare("SELECT value FROM metadata WHERE key = 'search_parser_version'").get().value, "22");
+  database.close();
 });
 
 test("buildSqliteData optionally folds definitions into searchable tables", () => {
@@ -87,6 +93,7 @@ test("buildSqliteData optionally folds definitions into searchable tables", () =
   fs.writeFileSync(caseLawPath, "{}", "utf8");
   fs.writeFileSync(definitionsPath, JSON.stringify({
     generatedAt: "2026-07-16T00:00:00.000Z",
+    parserVersion: [21, 22],
     occurrences: [
       { term: "risk", definition: "the potential for loss", celex: "32022L2555", sourceArticle: "Article 6", definitionHash: "same" },
       { term: "Risk", definition: "the potential for loss", celex: "32022L2557", article: "3", wordingHash: "same" },
@@ -104,9 +111,16 @@ test("buildSqliteData optionally folds definitions into searchable tables", () =
   assert.equal(result.definitionUsageEdges, 0);
   assert.equal(manifest.source.definitions.terms, 1);
   assert.equal(manifest.source.definitions.occurrences, 2);
+  assert.deepEqual(manifest.source.definitions.parserVersion, [21, 22]);
   assert.equal(manifest.tables.definitionTerms, 1);
   assert.equal(manifest.tables.definitionOccurrences, 2);
   assert.equal(manifest.tables.definitionUsageEdges, 0);
+  const database = new Database(outputPath, { readonly: true });
+  assert.equal(
+    database.prepare("SELECT value FROM metadata WHERE key = 'definitions_parser_version'").get().value,
+    "[21,22]"
+  );
+  database.close();
 });
 
 test("buildSqliteData folds the citation graph into indexed tables and dedups source titles", () => {
@@ -119,7 +133,7 @@ test("buildSqliteData folds the citation graph into indexed tables and dedups so
   fs.writeFileSync(searchPath, JSON.stringify({ generatedAt: "2026-07-15T00:00:00.000Z", records: [] }), "utf8");
   fs.writeFileSync(caseLawPath, JSON.stringify({}), "utf8");
   fs.writeFileSync(graphPath, JSON.stringify({
-    graphVersion: 2, parserVersion: 15, generatedAt: "2026-07-15T19:22:07.710Z",
+    graphVersion: 2, parserVersion: 22, generatedAt: "2026-07-15T19:22:07.710Z",
     coverage: { legislation: { htmlLaws: 2 } }, stats: { edges: 3 },
     edges: [
       // two edges from one source: the title must be stored once
@@ -140,4 +154,11 @@ test("buildSqliteData folds the citation graph into indexed tables and dedups so
   assert.equal(manifest.source.citationGraph.edges, 3);
   assert.equal(manifest.source.citationGraph.skippedEdges, 1);
   assert.equal(manifest.source.citationGraph.graphVersion, 2);
+  assert.equal(manifest.source.citationGraph.parserVersion, 22);
+  const database = new Database(outputPath, { readonly: true });
+  assert.equal(
+    database.prepare("SELECT value FROM metadata WHERE key = 'citation_graph_parser_version'").get().value,
+    "22"
+  );
+  database.close();
 });

--- a/backend/search/fulltext-index-build.js
+++ b/backend/search/fulltext-index-build.js
@@ -30,6 +30,7 @@ const { dedupeCorpusFiles } = require("./definition-index-build");
 const { readJsonAsset, sha256File } = require("./build-sqlite-data");
 const { DEFAULT_SEARCH_CACHE_PATH } = require("./search-index");
 const { stripXmlTags, wrapForParsing } = require("./search-build");
+const { normalizeParserStamp } = require("./parser-stamp");
 
 const gunzip = promisify(zlib.gunzip);
 
@@ -303,7 +304,14 @@ async function buildFulltextIndex(options = {}) {
     });
 
     const allFailures = [];
-    const parserVersions = new Set();
+    const existingParserVersion = db.prepare(
+      "SELECT value FROM fulltext_metadata WHERE key = 'parser_version'"
+    ).get()?.value;
+    // Units have no parser-version column, and doneCelex intentionally skips
+    // existing acts. Preserve the metadata stamp for those rows before adding
+    // versions from newly parsed shards; otherwise an incremental build lies
+    // about the parser versions represented in the database.
+    const parserVersions = new Set(normalizeParserStamp(existingParserVersion));
     const totals = await runPool(batches, (shard) => {
       insertMany(shard.units || []);
       for (const failure of shard.failures || []) allFailures.push(failure);

--- a/backend/search/fulltext-index-build.test.js
+++ b/backend/search/fulltext-index-build.test.js
@@ -12,6 +12,7 @@ const {
   writeManifest,
   FULLTEXT_SCHEMA_VERSION,
 } = require("./fulltext-index-build");
+const { getCurrentParserVersion } = require("./parser-stamp");
 
 const FIXTURE_DIR = path.join(__dirname, "..", "shared", "__fixtures__", "corpus");
 
@@ -249,7 +250,7 @@ test("buildFulltextIndex resumes across two real invocations sharing a celex, wi
   });
   assert.equal(secondSummary.newlyParsed, 1, "the already-indexed act must not be re-parsed");
   assert.equal(secondSummary.actCount, 2);
-  assert.equal(secondSummary.parserVersion, "21,22");
+  assert.equal(secondSummary.parserVersion, `21,${await getCurrentParserVersion()}`);
 
   const db = openFulltextDatabase(outputPath);
   try {

--- a/backend/search/fulltext-index-build.test.js
+++ b/backend/search/fulltext-index-build.test.js
@@ -232,6 +232,10 @@ test("buildFulltextIndex resumes across two real invocations sharing a celex, wi
   assert.equal(firstSummary.actCount, 1);
   assert.equal(firstSummary.newlyParsed, 1);
 
+  const stampDb = openFulltextDatabase(outputPath);
+  stampDb.prepare("UPDATE fulltext_metadata SET value = '21' WHERE key = 'parser_version'").run();
+  stampDb.close();
+
   // Re-run over the superset [first, second]: first is already indexed and
   // must be skipped (row count for its celex stays the same, and the worker
   // pool never sees it as "newly parsed"), while second is newly ingested.
@@ -245,6 +249,7 @@ test("buildFulltextIndex resumes across two real invocations sharing a celex, wi
   });
   assert.equal(secondSummary.newlyParsed, 1, "the already-indexed act must not be re-parsed");
   assert.equal(secondSummary.actCount, 2);
+  assert.equal(secondSummary.parserVersion, "21,22");
 
   const db = openFulltextDatabase(outputPath);
   try {

--- a/backend/search/json-stream-stats.js
+++ b/backend/search/json-stream-stats.js
@@ -21,9 +21,10 @@ const zlib = require("zlib");
 //   topLevel   -> members of the top-level object/array (case-law cache)
 const MODES = new Set(["records", "topLevel"]);
 
-function createScanner(mode) {
+function createScanner(mode, { captureTopLevel = [] } = {}) {
   if (!MODES.has(mode)) throw new Error(`Unknown count mode: ${mode}`);
 
+  const captureNames = new Set(captureTopLevel);
   let depth = 0; // nesting depth, 0 = outside the root container
   let inString = false;
   let escaped = false;
@@ -33,17 +34,71 @@ function createScanner(mode) {
   let sawMember = false; // a member started at countingDepth
   let keyBuffer = ""; // current string literal, when it may be a key
   let pendingRecordsKey = false;
+  let pendingTopLevelKey = null;
+  let pendingCaptureKey = null;
+  let capture = null;
+  const topLevel = {};
+
+  function finishCapture() {
+    if (!capture) return;
+    const raw = capture.raw.join("").trim();
+    try {
+      topLevel[capture.key] = JSON.parse(raw);
+    } catch {
+      // The scanner still validates document completeness. A malformed value is
+      // treated as an absent stamp by callers rather than making the large-file
+      // probe retain the whole document just to produce a second parse error.
+    }
+    capture = null;
+  }
+
+  function captureChar(char) {
+    capture.raw.push(char);
+    if (capture.inString) {
+      if (capture.escaped) capture.escaped = false;
+      else if (char === "\\") capture.escaped = true;
+      else if (char === '"') {
+        capture.inString = false;
+        if (capture.nesting === 0) finishCapture();
+      }
+      return;
+    }
+    if (capture.raw.length === 1) {
+      if (char === '"') capture.inString = true;
+      else if (char === "[" || char === "{") capture.nesting = 1;
+      return;
+    }
+    if (char === '"') capture.inString = true;
+    else if (char === "[" || char === "{") capture.nesting += 1;
+    else if (char === "]" || char === "}") {
+      capture.nesting -= 1;
+      if (capture.nesting === 0) finishCapture();
+    }
+  }
 
   function write(chunk) {
     for (let i = 0; i < chunk.length; i += 1) {
       const char = String.fromCharCode(chunk[i]);
+
+      if (!capture && pendingCaptureKey && depth === 1 && !/[\s]/.test(char)) {
+        capture = { key: pendingCaptureKey, raw: [], inString: false, escaped: false, nesting: 0 };
+        pendingCaptureKey = null;
+      }
+      if (capture) {
+        if (capture.nesting === 0 && !capture.inString && (char === "," || char === "}")) finishCapture();
+        else captureChar(char);
+      }
+
       if (inString) {
         if (escaped) escaped = false;
         else if (char === "\\") escaped = true;
         else if (char === '"') {
           inString = false;
-          if (mode === "records" && !counting && depth === 1) pendingRecordsKey = keyBuffer === "records";
-        } else if (mode === "records" && !counting && depth === 1) keyBuffer += char;
+          if (depth === 1) {
+            pendingTopLevelKey = keyBuffer;
+            if (mode === "records" && !counting) pendingRecordsKey = keyBuffer === "records";
+          }
+        } else if (depth === 1) keyBuffer += char;
         continue;
       }
 
@@ -85,6 +140,10 @@ function createScanner(mode) {
         case "\n":
         case "\r":
         case ":":
+          if (depth === 1 && pendingTopLevelKey) {
+            if (captureNames.has(pendingTopLevelKey)) pendingCaptureKey = pendingTopLevelKey;
+            pendingTopLevelKey = null;
+          }
           break;
         default:
           if (depth === countingDepth) sawMember = true;
@@ -95,16 +154,16 @@ function createScanner(mode) {
 
   return {
     write,
-    result: () => ({ count, complete: depth === 0 }),
+    result: () => ({ count, complete: depth === 0, topLevel }),
   };
 }
 
-function streamStats(inputPath, { mode = "records", gunzip = null } = {}) {
+function streamStats(inputPath, { mode = "records", gunzip = null, captureTopLevel = [] } = {}) {
   const isGzip = gunzip === null ? inputPath.toLowerCase().endsWith(".gz") : gunzip;
 
   return new Promise((resolve, reject) => {
     // Inside the executor so a bad mode rejects like any other input error.
-    const scanner = createScanner(mode);
+    const scanner = createScanner(mode, { captureTopLevel });
     const hash = crypto.createHash("sha256");
     const source = inputPath === "-" ? process.stdin : fs.createReadStream(inputPath);
     // The digest covers the decompressed bytes so a gzipped baseline and a
@@ -117,12 +176,14 @@ function streamStats(inputPath, { mode = "records", gunzip = null } = {}) {
     plain.on("error", reject);
     source.on("error", reject);
     plain.on("end", () => {
-      const { count, complete } = scanner.result();
+      const { count, complete, topLevel } = scanner.result();
       if (!complete) {
         reject(new Error(`${inputPath} is not a complete JSON document`));
         return;
       }
-      resolve({ count, sha256: hash.digest("hex") });
+      const result = { count, sha256: hash.digest("hex") };
+      if (captureTopLevel.length) result.topLevel = topLevel;
+      resolve(result);
     });
   });
 }

--- a/backend/search/json-stream-stats.js
+++ b/backend/search/json-stream-stats.js
@@ -21,10 +21,11 @@ const zlib = require("zlib");
 //   topLevel   -> members of the top-level object/array (case-law cache)
 const MODES = new Set(["records", "topLevel"]);
 
-function createScanner(mode, { captureTopLevel = [] } = {}) {
+function createScanner(mode, { captureTopLevel = [], stopWhenCaptured = false } = {}) {
   if (!MODES.has(mode)) throw new Error(`Unknown count mode: ${mode}`);
 
   const captureNames = new Set(captureTopLevel);
+  let stopped = false;
   let depth = 0; // nesting depth, 0 = outside the root container
   let inString = false;
   let escaped = false;
@@ -38,6 +39,13 @@ function createScanner(mode, { captureTopLevel = [] } = {}) {
   let pendingCaptureKey = null;
   let capture = null;
   const topLevel = {};
+
+  // Once every requested field has been captured, the rest of the document
+  // (the huge arrays these caches are mostly made of) has nothing left to
+  // tell a stopWhenCaptured caller — it only wants the stamp.
+  function allCaptured() {
+    return captureNames.size > 0 && [...captureNames].every((name) => name in topLevel);
+  }
 
   function finishCapture() {
     if (!capture) return;
@@ -95,11 +103,22 @@ function createScanner(mode, { captureTopLevel = [] } = {}) {
         else if (char === '"') {
           inString = false;
           if (depth === 1) {
+            // A depth-1 string could be a key or a value; whether it's a key
+            // is only known once we see what follows. Stash it as a
+            // candidate and let the guard below discard it unless a colon
+            // (optionally after whitespace) comes right after.
             pendingTopLevelKey = keyBuffer;
             if (mode === "records" && !counting) pendingRecordsKey = keyBuffer === "records";
           }
         } else if (depth === 1) keyBuffer += char;
         continue;
+      }
+
+      // A pending candidate key is only real if a colon follows (whitespace
+      // in between is fine); anything else means the string we just closed
+      // was a value, not a key, so drop the candidate.
+      if (depth === 1 && pendingTopLevelKey !== null && char !== ":" && !/\s/.test(char)) {
+        pendingTopLevelKey = null;
       }
 
       switch (char) {
@@ -139,6 +158,7 @@ function createScanner(mode, { captureTopLevel = [] } = {}) {
         case "\t":
         case "\n":
         case "\r":
+          break; // whitespace neither confirms nor discards a candidate key
         case ":":
           if (depth === 1 && pendingTopLevelKey) {
             if (captureNames.has(pendingTopLevelKey)) pendingCaptureKey = pendingTopLevelKey;
@@ -149,41 +169,68 @@ function createScanner(mode, { captureTopLevel = [] } = {}) {
           if (depth === countingDepth) sawMember = true;
           break;
       }
+
+      if (stopWhenCaptured && allCaptured()) {
+        stopped = true;
+        break; // the rest of the chunk (and document) is unneeded
+      }
     }
   }
 
   return {
     write,
-    result: () => ({ count, complete: depth === 0, topLevel }),
+    result: () => ({ count, complete: stopped || depth === 0, topLevel, stopped }),
   };
 }
 
-function streamStats(inputPath, { mode = "records", gunzip = null, captureTopLevel = [] } = {}) {
+function streamStats(inputPath, { mode = "records", gunzip = null, captureTopLevel = [], stopWhenCaptured = false } = {}) {
   const isGzip = gunzip === null ? inputPath.toLowerCase().endsWith(".gz") : gunzip;
 
   return new Promise((resolve, reject) => {
     // Inside the executor so a bad mode rejects like any other input error.
-    const scanner = createScanner(mode, { captureTopLevel });
+    const scanner = createScanner(mode, { captureTopLevel, stopWhenCaptured });
     const hash = crypto.createHash("sha256");
     const source = inputPath === "-" ? process.stdin : fs.createReadStream(inputPath);
     // The digest covers the decompressed bytes so a gzipped baseline and a
     // plain candidate stay directly comparable.
     const plain = isGzip ? source.pipe(zlib.createGunzip()) : source;
+    let settled = false;
+
+    function settle(fn, value) {
+      if (settled) return;
+      settled = true;
+      plain.removeAllListeners();
+      source.removeAllListeners();
+      plain.destroy();
+      if (source !== plain) source.destroy();
+      fn(value);
+    }
+
     plain.on("data", (chunk) => {
       hash.update(chunk);
       scanner.write(chunk);
+      if (stopWhenCaptured) {
+        const { stopped, topLevel } = scanner.result();
+        if (stopped) {
+          // stopWhenCaptured stops mid-document on purpose: count/sha256
+          // would only reflect the bytes read so far, so they are
+          // meaningless and deliberately omitted rather than returned as if
+          // they were real.
+          settle(resolve, { topLevel });
+        }
+      }
     });
-    plain.on("error", reject);
-    source.on("error", reject);
+    plain.on("error", (error) => settle(reject, error));
+    source.on("error", (error) => settle(reject, error));
     plain.on("end", () => {
       const { count, complete, topLevel } = scanner.result();
       if (!complete) {
-        reject(new Error(`${inputPath} is not a complete JSON document`));
+        settle(reject, new Error(`${inputPath} is not a complete JSON document`));
         return;
       }
       const result = { count, sha256: hash.digest("hex") };
       if (captureTopLevel.length) result.topLevel = topLevel;
-      resolve(result);
+      settle(resolve, result);
     });
   });
 }

--- a/backend/search/json-stream-stats.test.js
+++ b/backend/search/json-stream-stats.test.js
@@ -83,3 +83,28 @@ test("a truncated document is rejected rather than silently miscounted", async (
 test("an unknown mode is rejected", async () => {
   await assert.rejects(streamStats(writeJson("mode.json", { records: [] }), { mode: "nope" }), /Unknown count mode/);
 });
+
+test("stopWhenCaptured resolves once every requested field is captured, without count or sha256", async () => {
+  const bigRecords = Array.from({ length: 2000 }, (_, index) => ({ celex: `${index}` }));
+  const file = writeJson("early-exit.json", { parserVersion: 22, records: bigRecords });
+  const stats = await streamStats(file, { captureTopLevel: ["parserVersion"], stopWhenCaptured: true });
+  assert.deepEqual(stats.topLevel, { parserVersion: 22 });
+  assert.equal("count" in stats, false);
+  assert.equal("sha256" in stats, false);
+});
+
+test("without stopWhenCaptured, the default full-stream path still returns a correct sha256 and count", async () => {
+  const payload = { parserVersion: 22, records: [{ celex: "32016R0679" }, { celex: "32024R1689" }] };
+  const file = writeJson("full-pass.json", payload);
+  const stats = await streamStats(file, { captureTopLevel: ["parserVersion"] });
+  assert.equal(stats.count, 2);
+  assert.deepEqual(stats.topLevel, { parserVersion: 22 });
+  assert.equal(stats.sha256, crypto.createHash("sha256").update(fs.readFileSync(file)).digest("hex"));
+});
+
+test("a string value that looks like a captured key name is not mistaken for that key", async () => {
+  const file = writeJson("false-key.json", { note: "parserVersion", parserVersion: 22, records: [1, 2, 3] });
+  const stats = await streamStats(file, { captureTopLevel: ["parserVersion"] });
+  assert.deepEqual(stats.topLevel, { parserVersion: 22 });
+  assert.equal(stats.count, 3);
+});

--- a/backend/search/json-stream-stats.test.js
+++ b/backend/search/json-stream-stats.test.js
@@ -65,6 +65,16 @@ test("empty containers count zero members", async () => {
   assert.equal((await streamStats(writeJson("empty-object.json", {}), { mode: "topLevel" })).count, 0);
 });
 
+test("captures requested top-level scalar and array values without loading the document", async () => {
+  const file = writeJson("captured.json", {
+    parserVersion: [21, 22],
+    generatedAt: "now",
+    records: [{ parserVersion: 99 }],
+  });
+  const stats = await streamStats(file, { captureTopLevel: ["parserVersion", "generatedAt"] });
+  assert.deepEqual(stats.topLevel, { parserVersion: [21, 22], generatedAt: "now" });
+});
+
 test("a truncated document is rejected rather than silently miscounted", async () => {
   const file = writeJson("truncated.json", '{"records": [{"celex": "32016R0679"}');
   await assert.rejects(streamStats(file), /not a complete JSON document/);

--- a/backend/search/parser-stamp.js
+++ b/backend/search/parser-stamp.js
@@ -45,9 +45,9 @@ function mergeParserStamp(existing, current) {
 
 function isFresh(stamp, current) {
   const currentVersions = normalizeParserStamp(current);
-  if (normalizeParserStamp(stamp).length === 0 || currentVersions.length === 0) return false;
   const stampedVersions = normalizeParserStamp(stamp);
-  return currentVersions.every((version) => stampedVersions.includes(version));
+  if (stampedVersions.length === 0 || currentVersions.length === 0) return false;
+  return stampedVersions.every((version) => currentVersions.includes(version));
 }
 
 async function getCurrentParserVersion() {

--- a/backend/search/parser-stamp.js
+++ b/backend/search/parser-stamp.js
@@ -1,0 +1,63 @@
+"use strict";
+
+function normalizeVersion(value) {
+  if (typeof value === "number") {
+    return Number.isSafeInteger(value) && value >= 0 ? value : null;
+  }
+  if (typeof value !== "string") return null;
+  const text = value.trim();
+  if (!text || text.toLowerCase() === "null" || !/^\d+$/.test(text)) return null;
+  const version = Number(text);
+  return Number.isSafeInteger(version) ? version : null;
+}
+
+function normalizeParserStamp(value) {
+  let candidates;
+  if (Array.isArray(value)) {
+    candidates = value.flat(Infinity);
+  } else if (typeof value === "string" && value.includes(",")) {
+    candidates = value.split(",");
+  } else {
+    candidates = [value];
+  }
+  return [...new Set(candidates.map(normalizeVersion).filter((version) => version != null))]
+    .sort((a, b) => a - b);
+}
+
+function mergeParserStamp(existing, current) {
+  const existingVersions = normalizeParserStamp(existing);
+  // An unstamped legacy asset is not evidence that every record was parsed by
+  // the current parser. Preserve that absence so an additive write cannot
+  // silently turn it into a falsely fresh singleton stamp.
+  if (existingVersions.length === 0) return existing == null ? null : existing;
+
+  const versions = existingVersions;
+  for (const version of normalizeParserStamp(current)) {
+    if (!versions.includes(version)) versions.push(version);
+  }
+  versions.sort((a, b) => a - b);
+  if (versions.length === 0) return existing == null ? null : existing;
+  if (versions.length === 1) return versions[0];
+  if (Array.isArray(existing) || Array.isArray(current)) return versions;
+  if (typeof existing === "string" || typeof current === "string") return versions.join(",");
+  return versions;
+}
+
+function isFresh(stamp, current) {
+  const currentVersions = normalizeParserStamp(current);
+  if (normalizeParserStamp(stamp).length === 0 || currentVersions.length === 0) return false;
+  const stampedVersions = normalizeParserStamp(stamp);
+  return currentVersions.every((version) => stampedVersions.includes(version));
+}
+
+async function getCurrentParserVersion() {
+  const parser = await import("../shared/formex-parser/fmxParser.mjs");
+  return parser.PARSER_VERSION;
+}
+
+module.exports = {
+  getCurrentParserVersion,
+  isFresh,
+  mergeParserStamp,
+  normalizeParserStamp,
+};

--- a/backend/search/parser-stamp.test.js
+++ b/backend/search/parser-stamp.test.js
@@ -1,0 +1,31 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const { isFresh, mergeParserStamp, normalizeParserStamp } = require("./parser-stamp");
+
+test("normalizeParserStamp accepts the shipped stamp shapes and sorts numerically", () => {
+  assert.deepEqual(normalizeParserStamp(21), [21]);
+  assert.deepEqual(normalizeParserStamp([22, 21, 22]), [21, 22]);
+  assert.deepEqual(normalizeParserStamp("21,22"), [21, 22]);
+  assert.deepEqual(normalizeParserStamp(" 21, 22 "), [21, 22]);
+  assert.deepEqual(normalizeParserStamp("null"), []);
+  assert.deepEqual(normalizeParserStamp(null), []);
+  assert.deepEqual(normalizeParserStamp(undefined), []);
+});
+
+test("mergeParserStamp unions versions while retaining a multi-version container shape", () => {
+  assert.deepEqual(mergeParserStamp(21, 22), [21, 22]);
+  assert.deepEqual(mergeParserStamp([21], 22), [21, 22]);
+  assert.equal(mergeParserStamp("21,22", 22), "21,22");
+  assert.equal(mergeParserStamp("null", 22), "null");
+  assert.equal(mergeParserStamp(undefined, 22), null);
+});
+
+test("isFresh requires a non-empty stamp containing the current parser version", () => {
+  assert.equal(isFresh(22, 22), true);
+  assert.equal(isFresh([21, 22], 22), true);
+  assert.equal(isFresh("21,22", 22), true);
+  assert.equal(isFresh(21, 22), false);
+  assert.equal(isFresh("null", 22), false);
+  assert.equal(isFresh(undefined, 22), false);
+});

--- a/backend/search/parser-stamp.test.js
+++ b/backend/search/parser-stamp.test.js
@@ -21,10 +21,11 @@ test("mergeParserStamp unions versions while retaining a multi-version container
   assert.equal(mergeParserStamp(undefined, 22), null);
 });
 
-test("isFresh requires a non-empty stamp containing the current parser version", () => {
+test("isFresh requires a non-empty stamp where every version equals the current parser version", () => {
   assert.equal(isFresh(22, 22), true);
-  assert.equal(isFresh([21, 22], 22), true);
-  assert.equal(isFresh("21,22", 22), true);
+  assert.equal(isFresh([22], 22), true);
+  assert.equal(isFresh([21, 22], 22), false);
+  assert.equal(isFresh("21,22", 22), false);
   assert.equal(isFresh(21, 22), false);
   assert.equal(isFresh("null", 22), false);
   assert.equal(isFresh(undefined, 22), false);

--- a/backend/search/search-build.js
+++ b/backend/search/search-build.js
@@ -12,6 +12,7 @@ const { readCorpusXml, writeCorpusXml } = require("./law-corpus-store");
 const { mergeCorpusDates } = require("./law-corpus-dates");
 const { enrichRecordsWithEurovoc } = require("./eurovoc-enrich");
 const { enrichRecordsWithInForce } = require("./in-force-enrich");
+const { getCurrentParserVersion } = require("./parser-stamp");
 
 const execFileAsync = promisify(execFile);
 const SPARQL_ENDPOINT = "https://publications.europa.eu/webapi/rdf/sparql";
@@ -926,11 +927,19 @@ async function reEnrichCurrentCache(options = {}) {
     }
   });
 
+  const parserVersion = await getCurrentParserVersion();
+  const generatedAt = new Date().toISOString();
   const nextPayload = {
+    generatedAt,
+    parserVersion,
+    records: enrichResult.records,
     ...payload,
-    generatedAt: new Date().toISOString(),
-    records: enrichResult.records
   };
+  // Keep the header order stable even when the input was a legacy unstamped
+  // payload (or carried an older stamp): parserVersion must precede records.
+  nextPayload.generatedAt = generatedAt;
+  nextPayload.parserVersion = parserVersion;
+  nextPayload.records = enrichResult.records;
   nextPayload.count = nextPayload.records.length;
 
   await attachEurovocTopics(nextPayload.records, options, logProgress);
@@ -1089,10 +1098,12 @@ async function buildSearchCache(options = {}) {
     },
   });
 
+  const parserVersion = await getCurrentParserVersion();
   const payload = {
     generatedAt: new Date().toISOString(),
     fromYear,
     toYear,
+    parserVersion,
     records: enrichResult.records
       .filter((record) => record.isPrimaryAct)
       .sort((a, b) => String(b.date || "").localeCompare(String(a.date || "")))

--- a/backend/search/search-build.js
+++ b/backend/search/search-build.js
@@ -12,7 +12,7 @@ const { readCorpusXml, writeCorpusXml } = require("./law-corpus-store");
 const { mergeCorpusDates } = require("./law-corpus-dates");
 const { enrichRecordsWithEurovoc } = require("./eurovoc-enrich");
 const { enrichRecordsWithInForce } = require("./in-force-enrich");
-const { getCurrentParserVersion } = require("./parser-stamp");
+const { getCurrentParserVersion, mergeParserStamp } = require("./parser-stamp");
 
 const execFileAsync = promisify(execFile);
 const SPARQL_ENDPOINT = "https://publications.europa.eu/webapi/rdf/sparql";
@@ -815,6 +815,12 @@ async function enrichRecords(records, options = {}) {
   let processed = 0;
   let enriched = 0;
   let failed = 0;
+  // Counts records whose enrichment threw and therefore kept their prior
+  // excerpt untouched (see the catch branch below) — i.e. records that were
+  // NOT genuinely re-derived at the current parser version. reEnrichCurrentCache
+  // uses this to decide whether a run is eligible to claim a bare parserVersion
+  // stamp for the whole payload.
+  let excerptFallback = 0;
 
   for (let batchStart = 0; batchStart < eligibleIndices.length; batchStart += concurrency) {
     const batchIndices = eligibleIndices.slice(batchStart, batchStart + concurrency);
@@ -822,6 +828,7 @@ async function enrichRecords(records, options = {}) {
     const batchResults = await Promise.all(batchIndices.map(async (index) => {
       const current = records[index];
       const next = { ...current };
+      let fellBackToPreviousExcerpt = false;
       try {
         const titleResult = await extractOfficialTitleWithFallback(current.celex, { corpusDir, htmlFallback });
         if (titleResult.title) next.title = normalizeTitle(titleResult.title);
@@ -833,12 +840,16 @@ async function enrichRecords(records, options = {}) {
           ? (titleResult.fmxError?.message || null)
           : null;
       } catch (error) {
+        // next.excerpt still holds current.excerpt here (next was seeded from
+        // current and never overwritten) — this is a deliberate fallback to
+        // the previous excerpt, not a fresh re-derive at the current parser.
         next.excerpt = next.excerpt || "";
         next.fmxAvailable = false;
         next.fmxUnavailable = String(error.message || error).includes("No FMX URI found");
         next.enrichError = error.message;
+        fellBackToPreviousExcerpt = true;
       }
-      return { index, record: enrichSearchRecord(next) };
+      return { index, record: enrichSearchRecord(next), fellBackToPreviousExcerpt };
     }));
 
     for (const result of batchResults) {
@@ -848,6 +859,9 @@ async function enrichRecords(records, options = {}) {
         enriched += 1;
       } else {
         failed += 1;
+      }
+      if (result.fellBackToPreviousExcerpt) {
+        excerptFallback += 1;
       }
     }
 
@@ -888,6 +902,7 @@ async function enrichRecords(records, options = {}) {
     processed,
     enriched,
     failed,
+    excerptFallback,
     complete: true,
   };
 }
@@ -927,7 +942,25 @@ async function reEnrichCurrentCache(options = {}) {
     }
   });
 
-  const parserVersion = await getCurrentParserVersion();
+  const currentParserVersion = await getCurrentParserVersion();
+  // A bare stamp of the current version is only true when this run genuinely
+  // re-derived every single record at that version: no title/primary-act
+  // filter left records untouched, no maxRecords cap truncated the pass short
+  // of the full record set, and no record fell back to its previous excerpt
+  // after a failed re-enrichment (see the `excerptFallback` counter in
+  // enrichRecords). Any of those makes this a partial pass, and a partial
+  // pass must MERGE onto whatever stamp the payload already carried —
+  // otherwise records this run never touched (most of them, by default)
+  // would be falsely claimed as current, which is exactly the false-fresh
+  // stamp assert-parser-freshness.js exists to catch.
+  const isCompleteRederive = !onlyMissingTitles
+    && !primaryActsOnly
+    && !maxRecords
+    && enrichResult.excerptFallback === 0
+    && enrichResult.processed === records.length;
+  const parserVersion = isCompleteRederive
+    ? currentParserVersion
+    : mergeParserStamp(payload.parserVersion, currentParserVersion);
   const generatedAt = new Date().toISOString();
   const nextPayload = {
     generatedAt,

--- a/backend/search/search-build.test.js
+++ b/backend/search/search-build.test.js
@@ -14,18 +14,111 @@ const {
   reEnrichCurrentCache,
   requestWithRetry,
 } = require("./search-build");
+const { writeCorpusXml } = require("./law-corpus-store");
 
-test("reEnrichCurrentCache stamps the current parser version", async () => {
+// The current PARSER_VERSION at the time these tests were written; kept as a
+// literal (like the assertions below already were) rather than re-deriving it
+// from parser-stamp, so a bump makes these tests fail loudly instead of
+// trivially passing against a moving target.
+const CURRENT_PARSER_VERSION = 22;
+
+const SAMPLE_FMX_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<ACT>
+  <BIB.INSTANCE><LG.DOC>EN</LG.DOC></BIB.INSTANCE>
+  <TITLE><TI><P>Regulation on Widget Automation</P></TI></TITLE>
+  <PREAMBLE>
+    <GR.CONSID>
+      <CONSID><NP><NO.P>(1)</NO.P><TXT>Automated decision-making systems require a harmonised legal framework.</TXT></NP></CONSID>
+    </GR.CONSID>
+  </PREAMBLE>
+  <ENACTING.TERMS>
+    <ARTICLE IDENTIFIER="001">
+      <TI.ART>Article 1</TI.ART>
+      <STI.ART>Subject matter</STI.ART>
+      <ALINEA><P>This Regulation lays down harmonised rules on automated decision-making systems.</P></ALINEA>
+    </ARTICLE>
+  </ENACTING.TERMS>
+</ACT>`;
+
+// A record whose title is already present and which is not a primary act (no
+// `eli`): under the default options (onlyMissingTitles / primaryActsOnly both
+// true) it is never eligible for re-enrichment, so these tests never touch
+// the network and only exercise the stamping decision itself.
+function skippedRecord(celex) {
+  return { celex, title: "The GDPR" };
+}
+
+test("reEnrichCurrentCache merges onto an existing stamp for a default (partial) run", async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "search-reenrich-stamp-"));
   const cachePath = path.join(dir, "search-cache.json");
   fs.writeFileSync(cachePath, JSON.stringify({
     generatedAt: "2026-01-01T00:00:00.000Z",
-    records: [{ celex: "32016R0679", title: "The GDPR" }],
+    parserVersion: 21,
+    records: [skippedRecord("32016R0679")],
   }));
 
   await reEnrichCurrentCache({ cachePath, eurovoc: false, inForce: false });
   const written = fs.readFileSync(cachePath, "utf8");
-  assert.equal(JSON.parse(written).parserVersion, 22);
+  // Default options only re-enrich records missing a title among primary
+  // acts, so this run touches nothing here — it must MERGE onto the
+  // existing "21" stamp, not overwrite it with a bare "22" that would
+  // falsely claim every record was re-derived by the current parser.
+  assert.deepEqual(JSON.parse(written).parserVersion, [21, CURRENT_PARSER_VERSION]);
+  assert.ok(written.indexOf('"parserVersion"') < written.indexOf('"records"'));
+});
+
+test("reEnrichCurrentCache leaves a legacy unstamped payload unstamped after a partial run", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "search-reenrich-stamp-legacy-"));
+  const cachePath = path.join(dir, "search-cache.json");
+  fs.writeFileSync(cachePath, JSON.stringify({
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    records: [skippedRecord("32016R0679")],
+  }));
+
+  await reEnrichCurrentCache({ cachePath, eurovoc: false, inForce: false });
+  const written = JSON.parse(fs.readFileSync(cachePath, "utf8"));
+  // mergeParserStamp deliberately preserves an absent stamp rather than
+  // turning it into a falsely-fresh singleton (see parser-stamp.js).
+  assert.equal(written.parserVersion, null);
+});
+
+test("reEnrichCurrentCache writes a bare current version only for a complete re-derive", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "search-reenrich-stamp-complete-"));
+  const corpusDir = path.join(dir, "corpus");
+  const cachePath = path.join(dir, "search-cache.json");
+  const celex = "32024R0001";
+  fs.writeFileSync(cachePath, JSON.stringify({
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    parserVersion: 21,
+    records: [{ celex, title: "Old Title" }],
+  }));
+  await writeCorpusXml(corpusDir, celex, SAMPLE_FMX_XML);
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => {
+    throw new Error("network access is not allowed when the corpus is warm");
+  };
+  try {
+    // onlyMissingTitles: false and primaryActsOnly: false make every record
+    // eligible; no maxRecords cap; the corpus is warm so extraction succeeds
+    // for every record without falling back to its previous excerpt. Only
+    // under these conditions is the run a genuine complete re-derive that
+    // may claim the bare current version for the whole payload.
+    await reEnrichCurrentCache({
+      cachePath,
+      corpusDir,
+      onlyMissingTitles: false,
+      primaryActsOnly: false,
+      htmlFallback: false,
+      eurovoc: false,
+      inForce: false,
+    });
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  const written = fs.readFileSync(cachePath, "utf8");
+  assert.equal(JSON.parse(written).parserVersion, CURRENT_PARSER_VERSION);
   assert.ok(written.indexOf('"parserVersion"') < written.indexOf('"records"'));
 });
 

--- a/backend/search/search-build.test.js
+++ b/backend/search/search-build.test.js
@@ -11,8 +11,23 @@ const {
   extractTitleFromEurlexHtml,
   harvestPrimaryActs,
   normalizeYearQueryActTypes,
+  reEnrichCurrentCache,
   requestWithRetry,
 } = require("./search-build");
+
+test("reEnrichCurrentCache stamps the current parser version", async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "search-reenrich-stamp-"));
+  const cachePath = path.join(dir, "search-cache.json");
+  fs.writeFileSync(cachePath, JSON.stringify({
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    records: [{ celex: "32016R0679", title: "The GDPR" }],
+  }));
+
+  await reEnrichCurrentCache({ cachePath, eurovoc: false, inForce: false });
+  const written = fs.readFileSync(cachePath, "utf8");
+  assert.equal(JSON.parse(written).parserVersion, 22);
+  assert.ok(written.indexOf('"parserVersion"') < written.indexOf('"records"'));
+});
 
 // EuroVoc runs as the last step of the build so a finished cache is complete
 // (a CELEX-keyed pass bolted on afterwards strands records silently). But

--- a/backend/search/search-build.test.js
+++ b/backend/search/search-build.test.js
@@ -15,12 +15,11 @@ const {
   requestWithRetry,
 } = require("./search-build");
 const { writeCorpusXml } = require("./law-corpus-store");
+const { getCurrentParserVersion } = require("./parser-stamp");
 
-// The current PARSER_VERSION at the time these tests were written; kept as a
-// literal (like the assertions below already were) rather than re-deriving it
-// from parser-stamp, so a bump makes these tests fail loudly instead of
-// trivially passing against a moving target.
-const CURRENT_PARSER_VERSION = 22;
+// Read from the parser rather than pinned to a literal: these tests assert the
+// merge/overwrite *rule*, not which version happens to be current, and a
+// routine PARSER_VERSION bump should not turn them red.
 
 const SAMPLE_FMX_XML = `<?xml version="1.0" encoding="UTF-8"?>
 <ACT>
@@ -63,7 +62,7 @@ test("reEnrichCurrentCache merges onto an existing stamp for a default (partial)
   // acts, so this run touches nothing here — it must MERGE onto the
   // existing "21" stamp, not overwrite it with a bare "22" that would
   // falsely claim every record was re-derived by the current parser.
-  assert.deepEqual(JSON.parse(written).parserVersion, [21, CURRENT_PARSER_VERSION]);
+  assert.deepEqual(JSON.parse(written).parserVersion, [21, await getCurrentParserVersion()]);
   assert.ok(written.indexOf('"parserVersion"') < written.indexOf('"records"'));
 });
 
@@ -118,7 +117,7 @@ test("reEnrichCurrentCache writes a bare current version only for a complete re-
   }
 
   const written = fs.readFileSync(cachePath, "utf8");
-  assert.equal(JSON.parse(written).parserVersion, CURRENT_PARSER_VERSION);
+  assert.equal(JSON.parse(written).parserVersion, await getCurrentParserVersion());
   assert.ok(written.indexOf('"parserVersion"') < written.indexOf('"records"'));
 });
 


### PR DESCRIPTION
Closes #180

## Summary
- centralize parser stamps across cache and SQLite/fulltext build outputs
- add a streaming freshness guard for unstamped or mismatched precomputed assets
- run the guard after asset restore in the refresh workflows, with an explicit ALLOW_PARSER_DRIFT escape hatch
- document offline rebuild requirements and add regression coverage

## Tests
- node --test search/*.test.js shared/*.test.js routes/*.test.js bin/*.test.js mcp/*.test.js (497 passed, 2 skipped)
- ./node_modules/.bin/eslint .
- Ruby YAML parsing for both modified workflow files