### PR TITLE
Re-derive the precomputed assets against the current parser

### DIFF
--- a/.github/workflows/rederive-parser-assets.yml
+++ b/.github/workflows/rederive-parser-assets.yml
@@ -1,0 +1,1069 @@
+name: Rederive parser assets
+
+# One-off, offline, corpus-wide re-derive of the precomputed release assets
+# after a parser fix, so they all carry the current parser stamp (issue #180).
+#
+# The normal refresh workflows cannot do this:
+#   - refresh-data.yml only packages assets when the search/case-law hash
+#     changed, so a citation-graph/definitions-only rebuild publishes nothing.
+#   - refresh-fulltext.yml sets `changed` purely from actCount > baseline, so a
+#     fresh index over the same acts is built and then discarded, and its
+#     checkpoint step only adopts a checkpoint with MORE acts than the
+#     published index -- a partial fresh rebuild is always thrown away there.
+#   - Both open separate one-argument Docker tag-bump PRs; this opens one PR
+#     bumping both DATA_RELEASE_TAG and FULLTEXT_RELEASE_TAG together.
+#
+# Every builder below writes to a brand-new output path -- never over a
+# restored/published input -- and the whole candidate set is gated on
+# backend/search/assert-parser-freshness.js passing with no
+# ALLOW_PARSER_DRIFT escape before anything is published.
+
+on:
+  workflow_dispatch:
+    inputs:
+      rebuild_search_cache:
+        description: Rederive search-cache.json (MiniSearch metadata cache)
+        type: boolean
+        default: true
+      rebuild_citation_graph:
+        description: Rederive citation-graph.json (reverse-citation graph)
+        type: boolean
+        default: true
+      rebuild_definitions:
+        description: Rederive definitions.json (definition index)
+        type: boolean
+        default: true
+      rebuild_fulltext:
+        description: Rederive fulltext.sqlite (full-text index, cold build)
+        type: boolean
+        default: true
+      dry_run:
+        description: Validate everything but publish no release and open no PR
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: rederive-parser-assets
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------
+  # Resolve current release tags and which assets this run will rebuild.
+  # ---------------------------------------------------------------------
+  resolve:
+    runs-on: ubuntu-latest
+    outputs:
+      data_tag: ${{ steps.tags.outputs.data_tag }}
+      fulltext_tag: ${{ steps.tags.outputs.fulltext_tag }}
+      corpus_tag: ${{ steps.tags.outputs.corpus_tag }}
+      want_search_cache: ${{ steps.wants.outputs.search_cache }}
+      want_citation_graph: ${{ steps.wants.outputs.citation_graph }}
+      want_definitions: ${{ steps.wants.outputs.definitions }}
+      want_fulltext: ${{ steps.wants.outputs.fulltext }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+
+      - name: Resolve current release tags and latest corpus
+        id: tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          data_tags=$(sed -n 's/^ARG DATA_RELEASE_TAG=//p' backend/Dockerfile)
+          test "$(printf '%s\n' "$data_tags" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          data_tag=$(printf '%s\n' "$data_tags" | sed -n '1p')
+          .github/scripts/release-tags.sh validate data "$data_tag"
+
+          fulltext_tags=$(sed -n 's/^ARG FULLTEXT_RELEASE_TAG=//p' backend/Dockerfile)
+          test "$(printf '%s\n' "$fulltext_tags" | sed '/^$/d' | wc -l | tr -d ' ')" = 1
+          fulltext_tag=$(printf '%s\n' "$fulltext_tags" | sed -n '1p')
+          .github/scripts/release-tags.sh validate fulltext "$fulltext_tag"
+
+          corpus_tag=$(.github/scripts/release-tags.sh latest corpus)
+
+          {
+            echo "data_tag=$data_tag"
+            echo "fulltext_tag=$fulltext_tag"
+            echo "corpus_tag=$corpus_tag"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "Current data release: $data_tag"
+            echo "Current fulltext release: $fulltext_tag"
+            echo "Latest immutable corpus: $corpus_tag"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Determine which assets to rederive
+        id: wants
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "search_cache=${{ github.event.inputs.rebuild_search_cache }}"
+            echo "citation_graph=${{ github.event.inputs.rebuild_citation_graph }}"
+            echo "definitions=${{ github.event.inputs.rebuild_definitions }}"
+            echo "fulltext=${{ github.event.inputs.rebuild_fulltext }}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Rebuilding: search-cache=${{ github.event.inputs.rebuild_search_cache }} citation-graph=${{ github.event.inputs.rebuild_citation_graph }} definitions=${{ github.event.inputs.rebuild_definitions }} fulltext=${{ github.event.inputs.rebuild_fulltext }} (dry_run=${{ github.event.inputs.dry_run }})" \
+            >> "$GITHUB_STEP_SUMMARY"
+
+  # ---------------------------------------------------------------------
+  # search-cache.json -- offline, corpus-wide MiniSearch metadata rebuild.
+  #
+  # build-cache-from-corpus.js --rederive requires an existing cache at
+  # search/data/search-cache.json (it refreshes title/excerpt for every
+  # already-present CELEX by reparsing its corpus file, for every year, with
+  # no year floor -- it never adds new CELEX ids, and leaves date/eurovoc/
+  # in-force fields untouched). The currently published cache is restored
+  # into that path below so it has something to refresh; the write-back is
+  # in place by design (backed up to search-cache.json.bak first), which is
+  # fine here since it is this job's only output, not shared with anything
+  # else in this workflow.
+  # ---------------------------------------------------------------------
+  rebuild-search-cache:
+    needs: resolve
+    if: ${{ needs.resolve.outputs.want_search_cache == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+      - name: Install backend dependencies
+        run: |
+          set -euo pipefail
+          pnpm install --dir backend --no-frozen-lockfile
+          cd backend
+          pnpm rebuild better-sqlite3
+          node -e "const D = require('better-sqlite3'); new D(':memory:').close()"
+
+      - name: Download corpus
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p rederive-inputs rederive-output backend/search/data
+          gh release download "${{ needs.resolve.outputs.corpus_tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern laws.tar \
+            --pattern laws-html.tar \
+            --dir rederive-inputs
+          for archive in laws.tar laws-html.tar; do
+            test -s "rederive-inputs/$archive" || { echo "Missing corpus asset: $archive" >&2; exit 1; }
+            tar -xf "rederive-inputs/$archive" -C backend/search/data
+          done
+          test -d backend/search/data/laws
+          test -d backend/search/data/laws-html
+
+      - name: Download and restore the currently published search cache
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release download "${{ needs.resolve.outputs.data_tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern search-cache.json.gz \
+            --dir rederive-inputs
+          test -s rederive-inputs/search-cache.json.gz
+          gzip -cd rederive-inputs/search-cache.json.gz > backend/search/data/search-cache.json
+          test -s backend/search/data/search-cache.json
+
+      - name: Rederive search-cache.json from the corpus
+        working-directory: backend
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --max-old-space-size=8192 search/build-cache-from-corpus.js --rederive \
+            | tee ../rederive-output/search-cache-build.log
+          test -s search/data/search-cache.json
+
+      - name: Validate and package the candidate search cache
+        working-directory: backend
+        shell: bash
+        run: |
+          set -euo pipefail
+          stats=$(node search/json-stream-stats.js search/data/search-cache.json --mode records)
+          count=$(jq -er '.count | numbers' <<< "$stats")
+          test "$count" -gt 0 || { echo "Rederived search cache has no records" >&2; exit 1; }
+          echo "Rederived search cache: $count records." >> "$GITHUB_STEP_SUMMARY"
+          gzip --best --stdout search/data/search-cache.json > ../rederive-output/search-cache.json.gz
+          gzip --test ../rederive-output/search-cache.json.gz
+          test -s ../rederive-output/search-cache.json.gz
+
+      - name: Upload candidate search cache
+        uses: actions/upload-artifact@v4
+        with:
+          name: rederive-search-cache-${{ github.run_id }}
+          path: rederive-output/
+          if-no-files-found: error
+          retention-days: 14
+
+  # ---------------------------------------------------------------------
+  # citation-graph.json -- largest RAM risk (shards retained, then copied
+  # into a second parent array; some acts need ~4 GB against the 768 MB
+  # worker default), no incremental path, so a timeout costs a full restart
+  # of this asset alone -- hence its own job.
+  #
+  # Consumes the just-rebuilt search cache when one was produced this run
+  # (ordering via `needs`), otherwise the currently published one.
+  # ---------------------------------------------------------------------
+  rebuild-citation-graph:
+    needs: [resolve, rebuild-search-cache]
+    if: ${{ !cancelled() && needs.resolve.outputs.want_citation_graph == 'true' && (needs.rebuild-search-cache.result == 'success' || needs.rebuild-search-cache.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+      - name: Install backend dependencies
+        run: |
+          set -euo pipefail
+          pnpm install --dir backend --no-frozen-lockfile
+          cd backend
+          pnpm rebuild better-sqlite3
+          node -e "const D = require('better-sqlite3'); new D(':memory:').close()"
+
+      - name: Download corpus
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p rederive-inputs rederive-output backend/search/data backend/law-cache
+          gh release download "${{ needs.resolve.outputs.corpus_tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern laws.tar \
+            --pattern laws-html.tar \
+            --dir rederive-inputs
+          for archive in laws.tar laws-html.tar; do
+            test -s "rederive-inputs/$archive" || { echo "Missing corpus asset: $archive" >&2; exit 1; }
+            tar -xf "rederive-inputs/$archive" -C backend/search/data
+          done
+          test -d backend/search/data/laws
+          test -d backend/search/data/laws-html
+
+      - name: Download search-cache resolver input
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.resolve.outputs.want_search_cache }}" = true ] && [ "${{ needs.rebuild-search-cache.result }}" = success ]; then
+            echo "Using this run's rederived search cache." >> "$GITHUB_STEP_SUMMARY"
+            mkdir -p from-search-cache-job
+            gh run download "${{ github.run_id }}" \
+              --repo "${{ github.repository }}" \
+              --name "rederive-search-cache-${{ github.run_id }}" \
+              --dir from-search-cache-job
+            cp from-search-cache-job/search-cache.json.gz rederive-inputs/search-cache.json.gz
+          else
+            echo "Using the currently published search cache ($( echo '${{ needs.resolve.outputs.data_tag }}' ))." >> "$GITHUB_STEP_SUMMARY"
+            gh release download "${{ needs.resolve.outputs.data_tag }}" \
+              --repo "${{ github.repository }}" \
+              --pattern search-cache.json.gz \
+              --dir rederive-inputs
+          fi
+          test -s rederive-inputs/search-cache.json.gz
+
+          gh release download "${{ needs.resolve.outputs.data_tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern case-law-cache.json.gz \
+            --dir rederive-inputs
+          test -s rederive-inputs/case-law-cache.json.gz
+          gzip -cd rederive-inputs/case-law-cache.json.gz > backend/law-cache/case-law-cache-v5.json
+          test -s backend/law-cache/case-law-cache-v5.json
+
+      # Fresh output path: never the restored/published citation-graph.json,
+      # so a partial or re-run build can never be mistaken for the old asset.
+      - name: Rederive citation-graph.json from the corpus
+        working-directory: backend
+        env:
+          SEARCH_CACHE_PATH: ${{ github.workspace }}/rederive-inputs/search-cache.json.gz
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --max-old-space-size=8192 search/citation-graph-build.js \
+            --corpusDir search/data/laws \
+            --workerHeapMb 4096 \
+            --out ../rederive-output/citation-graph.json \
+            | tee ../rederive-output/citation-graph-build.log
+          test -s ../rederive-output/citation-graph.json
+
+      - name: Package the candidate citation graph
+        shell: bash
+        run: |
+          set -euo pipefail
+          gzip --best --stdout rederive-output/citation-graph.json > rederive-output/citation-graph.json.gz
+          gzip --test rederive-output/citation-graph.json.gz
+          test -s rederive-output/citation-graph.json.gz
+          rm rederive-output/citation-graph.json
+
+      - name: Upload candidate citation graph
+        uses: actions/upload-artifact@v4
+        with:
+          name: rederive-citation-graph-${{ github.run_id }}
+          path: rederive-output/
+          if-no-files-found: error
+          retention-days: 14
+
+  # ---------------------------------------------------------------------
+  # definitions.json -- resumes per batch via its own checkpoint. Fresh --out
+  # path gives a fresh checkpoint path for free; any checkpoint adopted from a
+  # previous dispatch of this same job is still validated against the current
+  # parser version before use and discarded otherwise, so a leftover
+  # stale-parser checkpoint can never contaminate this rebuild.
+  # ---------------------------------------------------------------------
+  rebuild-definitions:
+    needs: resolve
+    if: ${{ needs.resolve.outputs.want_definitions == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 300
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+      - name: Install backend dependencies
+        run: |
+          set -euo pipefail
+          pnpm install --dir backend --no-frozen-lockfile
+          cd backend
+          pnpm rebuild better-sqlite3
+          node -e "const D = require('better-sqlite3'); new D(':memory:').close()"
+
+      - name: Download corpus
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p rederive-inputs rederive-output backend/search/data
+          gh release download "${{ needs.resolve.outputs.corpus_tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern laws.tar \
+            --pattern laws-html.tar \
+            --dir rederive-inputs
+          for archive in laws.tar laws-html.tar; do
+            test -s "rederive-inputs/$archive" || { echo "Missing corpus asset: $archive" >&2; exit 1; }
+            tar -xf "rederive-inputs/$archive" -C backend/search/data
+          done
+          test -d backend/search/data/laws
+          test -d backend/search/data/laws-html
+
+      # Resume from a checkpoint left by an earlier (timed-out) dispatch of
+      # this same job -- but only if it was stamped by the current parser.
+      # An absent or mismatched checkpoint is discarded explicitly here, on
+      # top of definition-index-build.js's own version check, rather than
+      # trusted implicitly.
+      - name: Resume from an interrupted run's checkpoint, if still fresh
+        working-directory: backend
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ../rederive-output
+          artifact=$(gh api \
+            "repos/${{ github.repository }}/actions/artifacts?per_page=100&name=rederive-definitions-checkpoint" \
+            --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last // empty')
+          if [ -z "$artifact" ]; then
+            echo "No definitions checkpoint from a previous run." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          artifact_id=$(jq -er '.id' <<< "$artifact")
+          gh api "repos/${{ github.repository }}/actions/artifacts/$artifact_id/zip" > ../checkpoint.zip
+          rm -rf ../checkpoint && mkdir ../checkpoint
+          unzip -q ../checkpoint.zip -d ../checkpoint
+          test -s ../checkpoint/definitions.json.checkpoint || { echo "Checkpoint artifact is empty; ignoring it." >> "$GITHUB_STEP_SUMMARY"; exit 0; }
+          current_version=$(node -e 'require("./search/parser-stamp").getCurrentParserVersion().then((v) => process.stdout.write(String(v)))')
+          checkpoint_version=$(jq -r '.parserVersion // empty' ../checkpoint/definitions.json.checkpoint 2>/dev/null || true)
+          if [ "$checkpoint_version" = "$current_version" ]; then
+            mkdir -p ../rederive-output
+            mv ../checkpoint/definitions.json.checkpoint ../rederive-output/definitions.json.checkpoint
+            echo "Resumed definitions checkpoint stamped with the current parser version ($current_version)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Discarding definitions checkpoint (stamped '$checkpoint_version', current is '$current_version')." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      # Fresh output path: never the restored/published definitions.json.
+      - name: Rederive definitions.json from the corpus
+        working-directory: backend
+        shell: bash
+        run: |
+          set -euo pipefail
+          set +e
+          node --max-old-space-size=4096 search/definition-index-build.js \
+            --corpusDir search/data/laws \
+            --out ../rederive-output/definitions.json \
+            | tee ../rederive-output/definitions-build.log
+          build_status=${PIPESTATUS[0]}
+          set -e
+          if [ "$build_status" -ne 0 ]; then
+            echo "::error::definitions build exited with status $build_status; its checkpoint is uploaded for the next dispatch to resume from"
+            exit "$build_status"
+          fi
+          test -s ../rederive-output/definitions.json
+          test ! -e ../rederive-output/definitions.json.checkpoint
+
+      - name: Package the candidate definitions index
+        shell: bash
+        run: |
+          set -euo pipefail
+          gzip --best --stdout rederive-output/definitions.json > rederive-output/definitions.json.gz
+          gzip --test rederive-output/definitions.json.gz
+          test -s rederive-output/definitions.json.gz
+          rm rederive-output/definitions.json
+
+      # Runs on timeout/cancellation too, so batches completed so far survive
+      # for the next dispatch of this job to resume from.
+      - name: Upload interrupted definitions checkpoint
+        if: ${{ failure() || cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: rederive-definitions-checkpoint
+          path: rederive-output/definitions.json.checkpoint
+          if-no-files-found: ignore
+          overwrite: true
+          retention-days: 14
+
+      - name: Upload candidate definitions index
+        uses: actions/upload-artifact@v4
+        with:
+          name: rederive-definitions-${{ github.run_id }}
+          path: rederive-output/
+          if-no-files-found: error
+          retention-days: 14
+
+  # ---------------------------------------------------------------------
+  # fulltext.sqlite -- the wall-clock risk. This is a COLD build (never the
+  # restored/published index, so its doneCelex resume never preserves stale
+  # rows), budgeted like refresh-fulltext's incremental pass but very unlikely
+  # to finish the whole corpus in one dispatch; it resumes from its own
+  # checkpoint artifact across re-dispatches of this workflow, accepted
+  # whenever it covers more than zero acts (a partial fresh build is
+  # legitimately below the published baseline, unlike refresh-fulltext.yml's
+  # incremental case).
+  # ---------------------------------------------------------------------
+  rebuild-fulltext:
+    needs: [resolve, rebuild-search-cache]
+    if: ${{ !cancelled() && needs.resolve.outputs.want_fulltext == 'true' && (needs.rebuild-search-cache.result == 'success' || needs.rebuild-search-cache.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 330
+    env:
+      GH_TOKEN: ${{ github.token }}
+      NODE_PATH: ${{ github.workspace }}/backend/node_modules
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+      - name: Install backend dependencies
+        run: |
+          set -euo pipefail
+          pnpm install --dir backend --no-frozen-lockfile
+          cd backend
+          pnpm rebuild better-sqlite3
+          node -e "const D = require('better-sqlite3'); new D(':memory:').close()"
+
+      - name: Download corpus and build the merged fulltext corpus tree
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p rederive-inputs rederive-output backend/search/data
+          gh release download "${{ needs.resolve.outputs.corpus_tag }}" \
+            --repo "${{ github.repository }}" \
+            --pattern laws.tar \
+            --pattern laws-html.tar \
+            --dir rederive-inputs
+          for archive in laws.tar laws-html.tar; do
+            test -s "rederive-inputs/$archive" || { echo "Missing corpus asset: $archive" >&2; exit 1; }
+            tar -xf "rederive-inputs/$archive" -C backend/search/data
+          done
+          test -d backend/search/data/laws
+          test -d backend/search/data/laws-html
+          mkdir -p backend/search/data/fulltext-corpus
+          cp -al backend/search/data/laws/. backend/search/data/fulltext-corpus/
+          cp -al backend/search/data/laws-html/. backend/search/data/fulltext-corpus/
+
+      - name: Download search-cache resolver input
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.resolve.outputs.want_search_cache }}" = true ] && [ "${{ needs.rebuild-search-cache.result }}" = success ]; then
+            echo "Using this run's rederived search cache." >> "$GITHUB_STEP_SUMMARY"
+            mkdir -p from-search-cache-job
+            gh run download "${{ github.run_id }}" \
+              --repo "${{ github.repository }}" \
+              --name "rederive-search-cache-${{ github.run_id }}" \
+              --dir from-search-cache-job
+            cp from-search-cache-job/search-cache.json.gz backend/search/data/search-cache.json.gz
+          else
+            echo "Using the currently published search cache ($( echo '${{ needs.resolve.outputs.data_tag }}' ))." >> "$GITHUB_STEP_SUMMARY"
+            gh release download "${{ needs.resolve.outputs.data_tag }}" \
+              --repo "${{ github.repository }}" \
+              --pattern search-cache.json.gz \
+              --dir backend/search/data
+          fi
+          test -s backend/search/data/search-cache.json.gz
+
+      # This run's own checkpoint artifact only -- never refresh-fulltext's
+      # `fulltext-checkpoint`, and never compared against the published
+      # index's act count (a fresh cold build starts at 0 by design).
+      - name: Resume from an interrupted dispatch of this job
+        shell: bash
+        run: |
+          set -euo pipefail
+          artifact=$(gh api \
+            "repos/${{ github.repository }}/actions/artifacts?per_page=100&name=rederive-fulltext-checkpoint" \
+            --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last // empty')
+          if [ -z "$artifact" ]; then
+            echo "No fulltext checkpoint from a previous dispatch; starting a cold build." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          artifact_id=$(jq -er '.id' <<< "$artifact")
+          gh api "repos/${{ github.repository }}/actions/artifacts/$artifact_id/zip" > checkpoint.zip
+          rm -rf checkpoint && mkdir checkpoint
+          unzip -q checkpoint.zip -d checkpoint
+          test -s checkpoint/fulltext.sqlite || { echo "Checkpoint artifact has no fulltext.sqlite; ignoring it." >> "$GITHUB_STEP_SUMMARY"; exit 0; }
+          checkpoint_act_count=$(node -e '
+            const Database = require("better-sqlite3");
+            const db = new Database("checkpoint/fulltext.sqlite", { readonly: true });
+            process.stdout.write(String(db.prepare("SELECT COUNT(DISTINCT celex) n FROM units").get().n));
+            db.close();
+          ') || { echo "Checkpoint is unreadable; starting a cold build." >> "$GITHUB_STEP_SUMMARY"; exit 0; }
+          if [ "$checkpoint_act_count" -le 0 ]; then
+            echo "Checkpoint has no acts; starting a cold build." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          mkdir -p rederive-output
+          mv checkpoint/fulltext.sqlite rederive-output/fulltext.sqlite
+          rm -f rederive-output/fulltext.sqlite-wal rederive-output/fulltext.sqlite-shm
+          echo "Resumed from this job's own checkpoint: $checkpoint_act_count acts already indexed." >> "$GITHUB_STEP_SUMMARY"
+
+      # Fresh output path: this is a cold build, never the restored/published
+      # fulltext.sqlite, so doneCelex-based resume can never preserve stale
+      # (previous-parser) rows under a fresh tag.
+      - name: Incrementally build the rederived fulltext index
+        working-directory: backend
+        shell: bash
+        run: |
+          set -uo pipefail
+          set +e
+          SEARCH_CACHE_PATH="$PWD/search/data/search-cache.json.gz" \
+            timeout --signal=INT 300m \
+            node --max-old-space-size=3072 search/fulltext-index-build.js \
+              --corpusDir search/data/fulltext-corpus \
+              --pool 2 \
+              --workerHeapMb 512 \
+              --out ../rederive-output/fulltext.sqlite \
+            | tee ../rederive-output/fulltext-build.log
+          build_status=${PIPESTATUS[0]}
+          set -e
+          if [ -s ../rederive-output/fulltext.sqlite ]; then
+            node -e 'const Database=require("better-sqlite3"); const db=new Database("../rederive-output/fulltext.sqlite"); db.pragma("wal_checkpoint(TRUNCATE)"); db.close();'
+            rm -f ../rederive-output/fulltext.sqlite-wal ../rederive-output/fulltext.sqlite-shm
+          fi
+          if [ "$build_status" -ne 0 ]; then
+            echo "::error::fulltext build exited with status $build_status; the partial index is uploaded as this job's checkpoint for the next dispatch to resume from"
+            exit "$build_status"
+          fi
+          test -s ../rederive-output/fulltext.sqlite
+          test ! -e ../rederive-output/fulltext.sqlite-wal
+          test ! -e ../rederive-output/fulltext.sqlite-shm
+
+      - name: Build the candidate fulltext manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          node <<'NODE'
+          const fs = require("node:fs");
+          const crypto = require("node:crypto");
+          const Database = require("better-sqlite3");
+
+          const normalize = (value) => String(value || "").trim().toUpperCase();
+          const db = new Database("rederive-output/fulltext.sqlite", { readonly: true });
+          const rows = db.prepare("SELECT DISTINCT celex FROM units").all();
+          const celex = new Set(rows.map((row) => normalize(row.celex)).filter(Boolean));
+          const counts = {
+            unitCount: db.prepare("SELECT COUNT(*) n FROM units").get().n,
+            articleCount: db.prepare("SELECT COUNT(*) n FROM units WHERE unit_type='article'").get().n,
+            recitalCount: db.prepare("SELECT COUNT(*) n FROM units WHERE unit_type='recital'").get().n,
+            actCount: celex.size,
+          };
+          const metadata = new Map(db.prepare("SELECT key, value FROM fulltext_metadata").all().map((r) => [r.key, r.value]));
+          db.close();
+          if (counts.actCount <= 0) throw new Error("rederived fulltext index has no acts");
+
+          const hashFile = (file) => {
+            const hash = crypto.createHash("sha256");
+            const fd = fs.openSync(file, "r");
+            try {
+              const buf = Buffer.allocUnsafe(1024 * 1024);
+              let read = 0;
+              while ((read = fs.readSync(fd, buf, 0, buf.length, null)) > 0) hash.update(buf.subarray(0, read));
+            } finally {
+              fs.closeSync(fd);
+            }
+            return hash.digest("hex");
+          };
+          const stat = fs.statSync("rederive-output/fulltext.sqlite");
+          const sha256 = hashFile("rederive-output/fulltext.sqlite");
+          const manifest = {
+            generatedAt: new Date().toISOString(),
+            ...counts,
+            bytes: stat.size,
+            sha256,
+            parserVersion: metadata.get("parser_version") || null,
+          };
+          fs.writeFileSync("rederive-output/fulltext.sqlite.manifest.json", `${JSON.stringify(manifest, null, 2)}\n`);
+          console.log(`Rederived fulltext index: ${counts.actCount} acts, ${counts.unitCount} units.`);
+          NODE
+          echo "Rederived fulltext index acts: $(jq -r '.actCount' rederive-output/fulltext.sqlite.manifest.json)" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Package the candidate fulltext index
+        shell: bash
+        run: |
+          set -euo pipefail
+          gzip --best --stdout rederive-output/fulltext.sqlite > rederive-output/fulltext.sqlite.gz
+          gzip --test rederive-output/fulltext.sqlite.gz
+          test -s rederive-output/fulltext.sqlite.gz
+          raw_bytes=$(stat -c %s rederive-output/fulltext.sqlite)
+          gz_bytes=$(stat -c %s rederive-output/fulltext.sqlite.gz)
+          echo "Fulltext asset: $((raw_bytes / 1048576)) MiB raw, $((gz_bytes / 1048576)) MiB gz." >> "$GITHUB_STEP_SUMMARY"
+          test "$gz_bytes" -le "$((1536 * 1048576))" || {
+            echo "fulltext.sqlite.gz is $((gz_bytes / 1048576)) MiB, over the 1536 MiB release-asset guard" >&2
+            exit 1
+          }
+          rm rederive-output/fulltext.sqlite
+
+      # Runs on timeout/cancellation too, so acts indexed so far survive for
+      # the next dispatch of this job to resume from.
+      - name: Upload interrupted fulltext checkpoint
+        if: ${{ failure() || cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: rederive-fulltext-checkpoint
+          path: rederive-output/fulltext.sqlite
+          if-no-files-found: ignore
+          overwrite: true
+          retention-days: 14
+
+      - name: Upload candidate fulltext index
+        uses: actions/upload-artifact@v4
+        with:
+          name: rederive-fulltext-${{ github.run_id }}
+          path: rederive-output/
+          if-no-files-found: error
+          retention-days: 14
+
+  # ---------------------------------------------------------------------
+  # Assemble the COMPLETE candidate asset set (rederived assets plus the
+  # unchanged carry-forwards for anything not selected this run), assert
+  # parser freshness with no drift escape, rebuild data.sqlite, and run the
+  # existing integrity/non-regression checks. This is the single gate that
+  # decides whether anything gets published.
+  # ---------------------------------------------------------------------
+  validate:
+    needs: [resolve, rebuild-search-cache, rebuild-citation-graph, rebuild-definitions, rebuild-fulltext]
+    if: ${{ !cancelled() && needs.resolve.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    outputs:
+      artifact_name: rederive-release-assets-${{ github.run_id }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Verify every requested rebuild job actually succeeded
+        shell: bash
+        run: |
+          set -euo pipefail
+          check() {
+            local wanted="$1" result="$2" label="$3"
+            if [ "$wanted" = true ] && [ "$result" != success ]; then
+              echo "Requested rebuild of $label did not succeed (job result: $result)" >&2
+              exit 1
+            fi
+          }
+          check "${{ needs.resolve.outputs.want_search_cache }}" "${{ needs.rebuild-search-cache.result }}" "search-cache"
+          check "${{ needs.resolve.outputs.want_citation_graph }}" "${{ needs.rebuild-citation-graph.result }}" "citation-graph"
+          check "${{ needs.resolve.outputs.want_definitions }}" "${{ needs.rebuild-definitions.result }}" "definitions"
+          check "${{ needs.resolve.outputs.want_fulltext }}" "${{ needs.rebuild-fulltext.result }}" "fulltext"
+
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.15.0
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "24"
+      - name: Install backend dependencies
+        run: |
+          set -euo pipefail
+          pnpm install --dir backend --no-frozen-lockfile
+          cd backend
+          pnpm rebuild better-sqlite3
+          node -e "const D = require('better-sqlite3'); new D(':memory:').close()"
+
+      - name: Assemble the complete candidate asset set
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p candidate
+
+          fetch_rederived() {
+            local job="$1" artifact_name="$2"
+            mkdir -p "from-$job"
+            gh run download "${{ github.run_id }}" \
+              --repo "${{ github.repository }}" \
+              --name "$artifact_name" \
+              --dir "from-$job"
+          }
+
+          if [ "${{ needs.resolve.outputs.want_search_cache }}" = true ]; then
+            fetch_rederived search-cache "rederive-search-cache-${{ github.run_id }}"
+            cp from-search-cache/search-cache.json.gz candidate/search-cache.json.gz
+          else
+            gh release download "${{ needs.resolve.outputs.data_tag }}" --repo "${{ github.repository }}" \
+              --pattern search-cache.json.gz --dir candidate
+          fi
+
+          if [ "${{ needs.resolve.outputs.want_citation_graph }}" = true ]; then
+            fetch_rederived citation-graph "rederive-citation-graph-${{ github.run_id }}"
+            cp from-citation-graph/citation-graph.json.gz candidate/citation-graph.json.gz
+          else
+            gh release download "${{ needs.resolve.outputs.data_tag }}" --repo "${{ github.repository }}" \
+              --pattern citation-graph.json.gz --dir candidate
+          fi
+
+          if [ "${{ needs.resolve.outputs.want_definitions }}" = true ]; then
+            fetch_rederived definitions "rederive-definitions-${{ github.run_id }}"
+            cp from-definitions/definitions.json.gz candidate/definitions.json.gz
+          else
+            release_assets=$(gh release view "${{ needs.resolve.outputs.data_tag }}" --repo "${{ github.repository }}" \
+              --json assets --jq '.assets[].name')
+            if grep -Fxq definitions.json.gz <<< "$release_assets"; then
+              gh release download "${{ needs.resolve.outputs.data_tag }}" --repo "${{ github.repository }}" \
+                --pattern definitions.json.gz --dir candidate
+            else
+              echo "No definitions.json.gz in the current data release; carrying forward none." >> "$GITHUB_STEP_SUMMARY"
+            fi
+          fi
+
+          # case-law-cache.json.gz is never rebuilt by this workflow; always
+          # carried forward unchanged from the current data release.
+          gh release download "${{ needs.resolve.outputs.data_tag }}" --repo "${{ github.repository }}" \
+            --pattern case-law-cache.json.gz --dir candidate
+
+          if [ "${{ needs.resolve.outputs.want_fulltext }}" = true ]; then
+            fetch_rederived fulltext "rederive-fulltext-${{ github.run_id }}"
+            cp from-fulltext/fulltext.sqlite.gz candidate/fulltext.sqlite.gz
+            cp from-fulltext/fulltext.sqlite.manifest.json candidate/fulltext.sqlite.manifest.json
+          else
+            gh release download "${{ needs.resolve.outputs.fulltext_tag }}" --repo "${{ github.repository }}" \
+              --pattern fulltext.sqlite.gz \
+              --pattern fulltext.sqlite.manifest.json \
+              --dir candidate
+          fi
+
+          for asset in search-cache.json.gz citation-graph.json.gz case-law-cache.json.gz \
+            fulltext.sqlite.gz fulltext.sqlite.manifest.json; do
+            test -s "candidate/$asset" || { echo "Missing candidate asset: $asset" >&2; exit 1; }
+          done
+
+      - name: Assert parser freshness of the complete candidate set
+        # Deliberately blank, never inherited from the repository variable:
+        # the whole point of this workflow is a run that passes with no
+        # drift-allow escape hatch.
+        env:
+          ALLOW_PARSER_DRIFT: ""
+        shell: bash
+        run: |
+          set -euo pipefail
+          gzip -cd candidate/fulltext.sqlite.gz > candidate/fulltext.sqlite
+          definitions_arg=()
+          if [ -f candidate/definitions.json.gz ]; then
+            definitions_arg=(--definitions candidate/definitions.json.gz)
+          fi
+          node backend/search/assert-parser-freshness.js \
+            --search-cache candidate/search-cache.json.gz \
+            --citation-graph candidate/citation-graph.json.gz \
+            --fulltext-sqlite candidate/fulltext.sqlite \
+            "${definitions_arg[@]}"
+
+      - name: Rebuild and validate data.sqlite from the candidate set
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Definitions are genuinely optional: absent from the candidate set
+          # whenever this run neither rebuilt them nor found them on the base
+          # release. Passing a path that does not exist would fail the repack.
+          definitions_arg=()
+          if [ -f candidate/definitions.json.gz ]; then
+            definitions_arg=(--definitions candidate/definitions.json.gz)
+          fi
+          node backend/search/build-sqlite-data.js \
+            --search candidate/search-cache.json.gz \
+            --case-law candidate/case-law-cache.json.gz \
+            --citation-graph candidate/citation-graph.json.gz \
+            "${definitions_arg[@]}" \
+            --output candidate/data.sqlite \
+            --manifest candidate/data.sqlite.manifest.json \
+            | tee candidate/sqlite-build.log
+          test -s candidate/data.sqlite
+          test -s candidate/data.sqlite.manifest.json
+          jq -e '
+            .integrity.sqlite == "ok" and
+            .integrity.orphanLawMappings == 0 and
+            .integrity.orphanFtsMappings == 0 and
+            (.source.search.records | numbers) and
+            (.source.caseLaw.records | numbers)
+          ' candidate/data.sqlite.manifest.json >/dev/null
+
+      - name: Non-regression check against the currently published data.sqlite
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh release download "${{ needs.resolve.outputs.data_tag }}" --repo "${{ github.repository }}" \
+            --pattern data.sqlite.manifest.json --dir published
+          published_search=$(jq -er '.source.search.records | numbers' published/data.sqlite.manifest.json)
+          published_case_law=$(jq -er '.source.caseLaw.records | numbers' published/data.sqlite.manifest.json)
+          candidate_search=$(jq -er '.source.search.records | numbers' candidate/data.sqlite.manifest.json)
+          candidate_case_law=$(jq -er '.source.caseLaw.records | numbers' candidate/data.sqlite.manifest.json)
+          test "$candidate_search" -ge "$published_search" || {
+            echo "Candidate search record count regressed ($published_search -> $candidate_search)" >&2
+            exit 1
+          }
+          test "$candidate_case_law" -ge "$published_case_law" || {
+            echo "Candidate case-law record count regressed ($published_case_law -> $candidate_case_law)" >&2
+            exit 1
+          }
+          candidate_acts=$(jq -er '.actCount | numbers' candidate/fulltext.sqlite.manifest.json)
+          echo "Candidate counts: search $published_search -> $candidate_search; case law $published_case_law -> $candidate_case_law; fulltext acts $candidate_acts." \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Compress data.sqlite and finish the candidate set
+        shell: bash
+        run: |
+          set -euo pipefail
+          gzip --best --stdout candidate/data.sqlite > candidate/data.sqlite.gz
+          gzip --test candidate/data.sqlite.gz
+          test -s candidate/data.sqlite.gz
+          rm candidate/data.sqlite candidate/fulltext.sqlite
+          jq -n \
+            --arg generatedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --argjson rebuiltSearchCache "${{ needs.resolve.outputs.want_search_cache }}" \
+            --argjson rebuiltCitationGraph "${{ needs.resolve.outputs.want_citation_graph }}" \
+            --argjson rebuiltDefinitions "${{ needs.resolve.outputs.want_definitions }}" \
+            --argjson rebuiltFulltext "${{ needs.resolve.outputs.want_fulltext }}" \
+            --arg baseDataTag "${{ needs.resolve.outputs.data_tag }}" \
+            --arg baseFulltextTag "${{ needs.resolve.outputs.fulltext_tag }}" \
+            --arg corpusTag "${{ needs.resolve.outputs.corpus_tag }}" \
+            '{generatedAt: $generatedAt, rebuilt: {searchCache: $rebuiltSearchCache, citationGraph: $rebuiltCitationGraph, definitions: $rebuiltDefinitions, fulltext: $rebuiltFulltext}, baseDataTag: $baseDataTag, baseFulltextTag: $baseFulltextTag, corpusTag: $corpusTag}' \
+            > candidate/rederive-summary.json
+
+      - name: Upload the complete validated candidate set
+        uses: actions/upload-artifact@v4
+        with:
+          name: rederive-release-assets-${{ github.run_id }}
+          path: candidate/
+          if-no-files-found: error
+          retention-days: 14
+
+  # ---------------------------------------------------------------------
+  # Publish one complete data release, one fulltext release, and one PR
+  # bumping both Dockerfile pins together. Skipped entirely for a dry run.
+  # ---------------------------------------------------------------------
+  publish:
+    needs: [resolve, validate]
+    if: ${{ needs.validate.result == 'success' && github.event.inputs.dry_run != 'true' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: rederive-release-assets-${{ github.run_id }}
+          path: release-assets
+
+      - name: Resolve next data and fulltext release tags
+        id: tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          data_resolved=$(.github/scripts/release-tags.sh resolve data)
+          data_tag=$(sed -n 's/^tag=//p' <<< "$data_resolved")
+          data_state=$(sed -n 's/^state=//p' <<< "$data_resolved")
+          fulltext_resolved=$(.github/scripts/release-tags.sh resolve fulltext)
+          fulltext_tag=$(sed -n 's/^tag=//p' <<< "$fulltext_resolved")
+          fulltext_state=$(sed -n 's/^state=//p' <<< "$fulltext_resolved")
+          {
+            echo "data_tag=$data_tag"
+            echo "data_state=$data_state"
+            echo "fulltext_tag=$fulltext_tag"
+            echo "fulltext_state=$fulltext_state"
+          } >> "$GITHUB_OUTPUT"
+          echo "Publishing rederived assets as $data_tag and $fulltext_tag." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Verify the candidate carries every asset the Dockerfile fetches
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker_assets=$(sed -n 's/.*for asset in \(.*\); do.*/\1/p' backend/Dockerfile)
+          test -n "$docker_assets"
+          read -r -a docker_asset_list <<< "$docker_assets"
+          for asset in "${docker_asset_list[@]}"; do
+            test -s "release-assets/$asset" || { echo "Missing Docker build input: $asset" >&2; exit 1; }
+          done
+          for asset in data.sqlite.gz data.sqlite.manifest.json fulltext.sqlite.gz fulltext.sqlite.manifest.json; do
+            test -s "release-assets/$asset" || { echo "Missing candidate asset: $asset" >&2; exit 1; }
+          done
+
+      - name: Render release and pull-request notes
+        shell: bash
+        run: |
+          set -euo pipefail
+          current_version=$(node -e 'require("./backend/search/parser-stamp").getCurrentParserVersion().then((v) => process.stdout.write(String(v)))')
+          run_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          summary=release-assets/rederive-summary.json
+          rebuilt_search_cache=$(jq -r '.rebuilt.searchCache' "$summary")
+          rebuilt_citation_graph=$(jq -r '.rebuilt.citationGraph' "$summary")
+          rebuilt_definitions=$(jq -r '.rebuilt.definitions' "$summary")
+          rebuilt_fulltext=$(jq -r '.rebuilt.fulltext' "$summary")
+          {
+            echo "One-off, offline, corpus-wide re-derive so every precomputed asset carries the current parser version ($current_version). See $run_url."
+            echo
+            echo "Rebuilt this run: search-cache=$rebuilt_search_cache citation-graph=$rebuilt_citation_graph definitions=$rebuilt_definitions fulltext=$rebuilt_fulltext."
+            echo "Anything not rebuilt this run was carried forward unchanged from ${{ needs.resolve.outputs.data_tag }} / ${{ needs.resolve.outputs.fulltext_tag }}."
+          } > release-notes.md
+          cp release-notes.md pr-notes.md
+          cat release-notes.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish the complete data release from a draft
+        shell: bash
+        run: |
+          set -euo pipefail
+          data_tag="${{ steps.tags.outputs.data_tag }}"
+          data_assets=(
+            release-assets/search-cache.json.gz
+            release-assets/case-law-cache.json.gz
+            release-assets/citation-graph.json.gz
+            release-assets/data.sqlite.gz
+            release-assets/data.sqlite.manifest.json
+          )
+          if [ -f release-assets/definitions.json.gz ]; then
+            data_assets+=(release-assets/definitions.json.gz)
+          fi
+          if [ "${{ steps.tags.outputs.data_state }}" = absent ]; then
+            gh release create "$data_tag" --repo "${{ github.repository }}" \
+              --draft --title "$data_tag" --notes-file release-notes.md
+          fi
+          gh release upload "$data_tag" "${data_assets[@]}" --repo "${{ github.repository }}" --clobber
+          test "$(gh release view "$data_tag" --repo "${{ github.repository }}" --json isDraft --jq '.isDraft')" = true
+          gh release edit "$data_tag" --repo "${{ github.repository }}" --notes-file release-notes.md --draft=false
+          echo "Published complete data release $data_tag." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish the fulltext release from a draft
+        shell: bash
+        run: |
+          set -euo pipefail
+          fulltext_tag="${{ steps.tags.outputs.fulltext_tag }}"
+          if [ "${{ steps.tags.outputs.fulltext_state }}" = absent ]; then
+            gh release create "$fulltext_tag" --repo "${{ github.repository }}" \
+              --draft --title "$fulltext_tag" --notes-file release-notes.md
+          fi
+          gh release upload "$fulltext_tag" \
+            release-assets/fulltext.sqlite.gz \
+            release-assets/fulltext.sqlite.manifest.json \
+            --repo "${{ github.repository }}" --clobber
+          test "$(gh release view "$fulltext_tag" --repo "${{ github.repository }}" --json isDraft --jq '.isDraft')" = true
+          gh release edit "$fulltext_tag" --repo "${{ github.repository }}" --notes-file release-notes.md --draft=false
+          echo "Published fulltext release $fulltext_tag." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or update the Docker tag-bump pull request
+        shell: bash
+        run: |
+          set -euo pipefail
+          data_tag="${{ steps.tags.outputs.data_tag }}"
+          fulltext_tag="${{ steps.tags.outputs.fulltext_tag }}"
+          branch="automation/rederive-$data_tag"
+          if git ls-remote --exit-code origin "refs/heads/$branch" >/dev/null 2>&1; then
+            git fetch origin "$branch"
+            git switch --create "$branch" "origin/$branch"
+            test "$(git diff --name-only origin/${{ github.event.repository.default_branch }}...HEAD)" = "backend/Dockerfile"
+          else
+            git switch --create "$branch" "origin/${{ github.event.repository.default_branch }}"
+          fi
+          sed -i "s/^ARG DATA_RELEASE_TAG=.*/ARG DATA_RELEASE_TAG=$data_tag/" backend/Dockerfile
+          sed -i "s/^ARG FULLTEXT_RELEASE_TAG=.*/ARG FULLTEXT_RELEASE_TAG=$fulltext_tag/" backend/Dockerfile
+          test "$(sed -n 's/^ARG DATA_RELEASE_TAG=//p' backend/Dockerfile)" = "$data_tag"
+          test "$(sed -n 's/^ARG FULLTEXT_RELEASE_TAG=//p' backend/Dockerfile)" = "$fulltext_tag"
+          git add backend/Dockerfile
+          changed_files=$(git diff --cached --name-only)
+          test -z "$changed_files" || test "$changed_files" = "backend/Dockerfile" || {
+            echo "PR update would change files outside backend/Dockerfile" >&2
+            exit 1
+          }
+          if ! git diff --cached --quiet; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -m "Deploy rederived parser assets: $data_tag, $fulltext_tag"
+          fi
+          if git ls-remote --exit-code origin "refs/heads/$branch" >/dev/null 2>&1; then
+            git push origin "$branch"
+          else
+            git push --set-upstream origin "$branch"
+          fi
+          pr_number=$(gh pr list --repo "${{ github.repository }}" --head "$branch" --state open \
+            --json number --jq '.[0].number // empty')
+          title="Deploy rederived parser assets: $data_tag, $fulltext_tag"
+          if [ -n "$pr_number" ]; then
+            gh pr edit "$pr_number" --repo "${{ github.repository }}" --title "$title" --body-file pr-notes.md
+          else
+            gh pr create --repo "${{ github.repository }}" \
+              --base "${{ github.event.repository.default_branch }}" \
+              --head "$branch" \
+              --title "$title" \
+              --body-file pr-notes.md
+          fi
+
+      - name: Dispatch Docker validation for the tag-bump PR
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh workflow run backend-docker.yml \
+            --repo "${{ github.repository }}" \
+            --ref "automation/rederive-${{ steps.tags.outputs.data_tag }}"

--- a/.github/workflows/rederive-parser-assets.yml
+++ b/.github/workflows/rederive-parser-assets.yml
@@ -41,9 +41,14 @@ on:
         description: Validate everything but publish no release and open no PR
         type: boolean
         default: false
+      allow_non_default_ref:
+        description: Allow a deliberate test run from a non-default parser ref
+        type: boolean
+        default: false
 
 permissions:
   contents: read
+  actions: read
 
 concurrency:
   group: rederive-parser-assets
@@ -59,6 +64,7 @@ jobs:
       data_tag: ${{ steps.tags.outputs.data_tag }}
       fulltext_tag: ${{ steps.tags.outputs.fulltext_tag }}
       corpus_tag: ${{ steps.tags.outputs.corpus_tag }}
+      parser_version: ${{ steps.tags.outputs.parser_version }}
       want_search_cache: ${{ steps.wants.outputs.search_cache }}
       want_citation_graph: ${{ steps.wants.outputs.citation_graph }}
       want_definitions: ${{ steps.wants.outputs.definitions }}
@@ -66,6 +72,14 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
+      - name: Reject non-default dispatch refs unless explicitly overridden
+        if: ${{ github.ref_name != github.event.repository.default_branch && github.event.inputs.allow_non_default_ref != 'true' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::error::Ref '${{ github.ref_name }}' is not the repository default branch '${{ github.event.repository.default_branch }}'. Publishing parser-derived assets from this ref could stamp assets with a parser that is not running on the default branch; set allow_non_default_ref=true only for a deliberate test run after accepting that risk." >&2
+          exit 1
+
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref }}
@@ -86,16 +100,19 @@ jobs:
           .github/scripts/release-tags.sh validate fulltext "$fulltext_tag"
 
           corpus_tag=$(.github/scripts/release-tags.sh latest corpus)
+          parser_version=$(node -e 'require("./backend/search/parser-stamp").getCurrentParserVersion().then((v) => process.stdout.write(String(v)))')
 
           {
             echo "data_tag=$data_tag"
             echo "fulltext_tag=$fulltext_tag"
             echo "corpus_tag=$corpus_tag"
+            echo "parser_version=$parser_version"
           } >> "$GITHUB_OUTPUT"
           {
             echo "Current data release: $data_tag"
             echo "Current fulltext release: $fulltext_tag"
             echo "Latest immutable corpus: $corpus_tag"
+            echo "Current parser version: $parser_version"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Determine which assets to rederive
@@ -327,11 +344,12 @@ jobs:
   # path gives a fresh checkpoint path for free; any checkpoint adopted from a
   # previous dispatch of this same job is still validated against the current
   # parser version before use and discarded otherwise, so a leftover
-  # stale-parser checkpoint can never contaminate this rebuild.
+  # stale-parser checkpoint can never contaminate this rebuild. The artifact
+  # name also binds it to both the parser version and corpus release.
   # ---------------------------------------------------------------------
   rebuild-definitions:
-    needs: resolve
-    if: ${{ needs.resolve.outputs.want_definitions == 'true' }}
+    needs: [resolve, rebuild-search-cache]
+    if: ${{ !cancelled() && needs.resolve.outputs.want_definitions == 'true' && (needs.rebuild-search-cache.result == 'success' || needs.rebuild-search-cache.result == 'skipped') }}
     runs-on: ubuntu-latest
     timeout-minutes: 300
     env:
@@ -371,6 +389,27 @@ jobs:
           test -d backend/search/data/laws
           test -d backend/search/data/laws-html
 
+      - name: Download search-cache resolver input
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ needs.resolve.outputs.want_search_cache }}" = true ] && [ "${{ needs.rebuild-search-cache.result }}" = success ]; then
+            echo "Using this run's rederived search cache." >> "$GITHUB_STEP_SUMMARY"
+            mkdir -p from-search-cache-job
+            gh run download "${{ github.run_id }}" \
+              --repo "${{ github.repository }}" \
+              --name "rederive-search-cache-${{ github.run_id }}" \
+              --dir from-search-cache-job
+            cp from-search-cache-job/search-cache.json.gz rederive-inputs/search-cache.json.gz
+          else
+            echo "Using the currently published search cache (${{ needs.resolve.outputs.data_tag }})." >> "$GITHUB_STEP_SUMMARY"
+            gh release download "${{ needs.resolve.outputs.data_tag }}" \
+              --repo "${{ github.repository }}" \
+              --pattern search-cache.json.gz \
+              --dir rederive-inputs
+          fi
+          test -s rederive-inputs/search-cache.json.gz
+
       # Resume from a checkpoint left by an earlier (timed-out) dispatch of
       # this same job -- but only if it was stamped by the current parser.
       # An absent or mismatched checkpoint is discarded explicitly here, on
@@ -383,7 +422,7 @@ jobs:
           set -euo pipefail
           mkdir -p ../rederive-output
           artifact=$(gh api \
-            "repos/${{ github.repository }}/actions/artifacts?per_page=100&name=rederive-definitions-checkpoint" \
+            "repos/${{ github.repository }}/actions/artifacts?per_page=100&name=rederive-definitions-checkpoint-parser-v${{ needs.resolve.outputs.parser_version }}-corpus-${{ needs.resolve.outputs.corpus_tag }}" \
             --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last // empty')
           if [ -z "$artifact" ]; then
             echo "No definitions checkpoint from a previous run." >> "$GITHUB_STEP_SUMMARY"
@@ -407,6 +446,8 @@ jobs:
       # Fresh output path: never the restored/published definitions.json.
       - name: Rederive definitions.json from the corpus
         working-directory: backend
+        env:
+          SEARCH_CACHE_PATH: ${{ github.workspace }}/rederive-inputs/search-cache.json.gz
         shell: bash
         run: |
           set -euo pipefail
@@ -439,7 +480,7 @@ jobs:
         if: ${{ failure() || cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: rederive-definitions-checkpoint
+          name: rederive-definitions-checkpoint-parser-v${{ needs.resolve.outputs.parser_version }}-corpus-${{ needs.resolve.outputs.corpus_tag }}
           path: rederive-output/definitions.json.checkpoint
           if-no-files-found: ignore
           overwrite: true
@@ -461,7 +502,10 @@ jobs:
   # checkpoint artifact across re-dispatches of this workflow, accepted
   # whenever it covers more than zero acts (a partial fresh build is
   # legitimately below the published baseline, unlike refresh-fulltext.yml's
-  # incremental case).
+  # incremental case). The checkpoint artifact name is bound to this parser
+  # version and corpus release. The interrupted database has no parser_version
+  # metadata until the pool drains and final metadata is written, so the name
+  # is the only binding available for this checkpoint.
   # ---------------------------------------------------------------------
   rebuild-fulltext:
     needs: [resolve, rebuild-search-cache]
@@ -538,7 +582,7 @@ jobs:
         run: |
           set -euo pipefail
           artifact=$(gh api \
-            "repos/${{ github.repository }}/actions/artifacts?per_page=100&name=rederive-fulltext-checkpoint" \
+            "repos/${{ github.repository }}/actions/artifacts?per_page=100&name=rederive-fulltext-checkpoint-parser-v${{ needs.resolve.outputs.parser_version }}-corpus-${{ needs.resolve.outputs.corpus_tag }}" \
             --jq '[.artifacts[] | select(.expired == false)] | sort_by(.created_at) | last // empty')
           if [ -z "$artifact" ]; then
             echo "No fulltext checkpoint from a previous dispatch; starting a cold build." >> "$GITHUB_STEP_SUMMARY"
@@ -666,7 +710,7 @@ jobs:
         if: ${{ failure() || cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: rederive-fulltext-checkpoint
+          name: rederive-fulltext-checkpoint-parser-v${{ needs.resolve.outputs.parser_version }}-corpus-${{ needs.resolve.outputs.corpus_tag }}
           path: rederive-output/fulltext.sqlite
           if-no-files-found: ignore
           overwrite: true
@@ -795,6 +839,68 @@ jobs:
             fulltext.sqlite.gz fulltext.sqlite.manifest.json; do
             test -s "candidate/$asset" || { echo "Missing candidate asset: $asset" >&2; exit 1; }
           done
+
+      - name: Gate rederived artifact failure and coverage stats
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Permit a handful of isolated corpus anomalies, but catch a terminal
+          # worker failure that turns a meaningful part of an asset into empty
+          # shards. Ten is deliberately small relative to this corpus-wide run.
+          max_failures=10
+
+          if [ "${{ needs.resolve.outputs.want_citation_graph }}" = true ]; then
+            citation_failures=$(node -e '
+              const { streamStats } = require("./backend/search/json-stream-stats");
+              const [file, field] = process.argv.slice(1);
+              (async () => {
+                const { topLevel } = await streamStats(file, { captureTopLevel: ["stats"], stopWhenCaptured: true });
+                const value = topLevel.stats?.[field];
+                if (!Number.isFinite(value)) throw new Error(`Missing numeric stats.${field}`);
+                process.stdout.write(String(value));
+              })().catch((error) => { console.error(error); process.exit(1); });
+            ' candidate/citation-graph.json.gz parseFailures)
+            test "$citation_failures" -le "$max_failures" || {
+              echo "Citation graph reports $citation_failures parse failures (maximum allowed: $max_failures)" >&2
+              exit 1
+            }
+          fi
+
+          if [ "${{ needs.resolve.outputs.want_definitions }}" = true ]; then
+            definition_failures=$(node -e '
+              const { streamStats } = require("./backend/search/json-stream-stats");
+              const [file, field] = process.argv.slice(1);
+              (async () => {
+                const { topLevel } = await streamStats(file, { captureTopLevel: ["stats"], stopWhenCaptured: true });
+                const value = topLevel.stats?.[field];
+                if (!Number.isFinite(value)) throw new Error(`Missing numeric stats.${field}`);
+                process.stdout.write(String(value));
+              })().catch((error) => { console.error(error); process.exit(1); });
+            ' candidate/definitions.json.gz failures)
+            test "$definition_failures" -le "$max_failures" || {
+              echo "Definitions index reports $definition_failures failures (maximum allowed: $max_failures)" >&2
+              exit 1
+            }
+          fi
+
+          if [ "${{ needs.resolve.outputs.want_fulltext }}" = true ]; then
+            mkdir -p published-fulltext
+            gh release download "${{ needs.resolve.outputs.fulltext_tag }}" \
+              --repo "${{ github.repository }}" \
+              --pattern fulltext.sqlite.manifest.json \
+              --dir published-fulltext
+            fulltext_acts=$(jq -er '.actCount | numbers' candidate/fulltext.sqlite.manifest.json)
+            published_fulltext_acts=$(jq -er '.actCount | numbers' published-fulltext/fulltext.sqlite.manifest.json)
+            # The intuitive denominator (all search-cache records) is wrong:
+            # fulltext-index-build.js intersects that universe with corpus files
+            # actually present before indexing. The published fulltext manifest's
+            # actCount is the observed matched-corpus baseline; require strict
+            # non-regression so missing/empty rebuilt shards cannot pass.
+            test "$fulltext_acts" -ge "$published_fulltext_acts" || {
+              echo "Fulltext index has $fulltext_acts acts, below the published matched-corpus baseline of $published_fulltext_acts" >&2
+              exit 1
+            }
+          fi
 
       - name: Assert parser freshness of the complete candidate set
         # Deliberately blank, never inherited from the repository variable:

--- a/backend/README.md
+++ b/backend/README.md
@@ -671,6 +671,16 @@ than discarding a multi-hour harvest. Opt out with `--no-eurovoc` /
 network-free build (the enrichment runs in the driver; the parse workers keep
 their hard `fetch` block either way).
 
+`build-cache-from-corpus.js --rederive` inverts the normal merge for one
+purpose: refreshing `title` and `excerpt` on records the cache already holds,
+after a parser fix that the additive monthly refresh would never reach (issue
+#180). It applies no year floor, adds no acts, and skips EuroVoc/in-force
+entirely — those fields, plus `date` and the alias fields, are preserved from
+the existing record — so it is offline in the driver as well as in the workers.
+It stamps `parserVersion` bare only when nothing stale was left behind; see
+[docs/legislation-data-refresh.md](docs/legislation-data-refresh.md) for when to
+run it and what the other three assets need.
+
 If a cache is fine but its topics or status aren't — a build ran `--no-eurovoc`,
 EuroVoc changed upstream, or acts have since fallen out of force — backfill
 without a rebuild:

--- a/backend/docs/legislation-data-refresh.md
+++ b/backend/docs/legislation-data-refresh.md
@@ -150,45 +150,109 @@ assets, then:
 
 ## Parser-version freshness and offline re-derivation
 
-The derived-asset guard runs immediately after the current inputs are restored.
-It checks the search cache, citation graph, optional definitions index, and
-full-text SQLite metadata against `PARSER_VERSION` in the Formex parser. An
-unstamped or older asset is a failure; an absent definitions asset is allowed.
-`ALLOW_PARSER_DRIFT=true` is a temporary repository-variable escape hatch for
-the v21-to-v22 migration. Remove it after the v22 assets are published.
+The derived-asset guard (`search/assert-parser-freshness.js`) runs immediately
+after the current inputs are restored. It checks the search cache, citation
+graph, optional definitions index, and full-text SQLite metadata against
+`PARSER_VERSION` in the Formex parser. An unstamped or older asset is a
+failure; an absent definitions asset is allowed. `ALLOW_PARSER_DRIFT=true` is
+a temporary repository-variable escape hatch while the published assets are
+known to lag. Remove it once a re-derive has published assets at the current
+parser version.
 
-The one-off re-derivation is an offline corpus pass: restore the complete
-`laws/`, `laws-html/`, and (for citation edges) case-law corpus first, and write
-every result to a fresh output path. Never point an incremental builder at the
-released input: full text skips existing CELEXes, and a definitions checkpoint
-is derived from its output path. Keep each asset in its own job so a timeout
-does not discard completed work in the others.
+### Why a re-derive is sometimes needed
 
-The current builder commands are:
+The monthly chain above only ever *adds* acts — Stage 2 backfills what's
+missing from the cache and reparses stale case-law entries, but it never
+re-runs the parser over an act it has already indexed. A `fmxParser.mjs` fix
+therefore reaches new acts immediately and everything else never, until
+someone re-derives the whole corpus against the current parser. GitHub issue
+#180 measured exactly this against the live releases as of 2026-08-21, when
+`PARSER_VERSION` was 22 (it has since moved on again — the point is the gap,
+not the specific numbers):
+
+| Asset | Stamped parser version |
+| --- | --- |
+| `citation-graph.json.gz` | v16 |
+| `definitions.json.gz` | v18 |
+| `search-cache.json.gz` | unstamped |
+| `fulltext.sqlite` | metadata claims v22, but all but one of its 28,049 acts were actually parsed at v21 |
+
+That is the drift the guard above now fails loudly on instead of serving
+silently. A full offline re-derive per asset is the fix.
+
+### Running the re-derive
+
+Also available as the `rederive-parser-assets.yml` workflow (see its own
+`workflow_dispatch` inputs for the automated path); this is the manual/local
+equivalent, useful for a one-off or for testing a parser fix before wiring it
+into that workflow. It is an offline corpus pass — parsing only the restored
+local `laws/`/`laws-html/` trees, no EUR-Lex or Cellar traffic — with two
+exceptions: the citation graph also reads the search cache (`SEARCH_CACHE_PATH`,
+as a resolver for external legislative references) and the case-law cache
+(`CASE_LAW_CACHE_PATH`, folded in as judgment-to-article edges), so "corpus
+only" undersells it for that one asset. Keep each asset in its own job so a
+timeout in one does not discard completed work in the others.
+
+Check each builder's own `parseCliArgs` before trusting flag names below —
+the definitions builder's checkpoint safety (previous section notwithstanding)
+and the fulltext builder's resume-by-database logic both make flag mistakes
+expensive to redo.
 
 ```sh
-# From backend/; use a new directory for every run.
+# From backend/; use a new output directory for every run.
+SEARCH_CACHE_PATH=search/data/search-cache.json.gz \
 node --max-old-space-size=6144 search/citation-graph-build.js \
   --corpusDir search/data/laws --htmlDir search/data/laws-html \
-  --out /tmp/legalviz-v22/citation-graph.json --workerHeapMb 4096
+  --out /tmp/legalviz-rederive/citation-graph.json --workerHeapMb 4096
 
 node search/definition-index-build.js \
   --corpusDir search/data/laws --htmlDir search/data/laws-html \
-  --out /tmp/legalviz-v22/definitions.json --workerHeapMb 2048
+  --out /tmp/legalviz-rederive/definitions.json --workerHeapMb 2048
 
+# No --htmlDir flag here: it auto-derives the laws-html sibling of --corpusDir.
 node --max-old-space-size=4096 search/fulltext-index-build.js \
-  --corpusDir search/data/fulltext-corpus \
-  --out /tmp/legalviz-v22/fulltext.sqlite --workerHeapMb 1024
+  --corpusDir search/data/laws \
+  --out /tmp/legalviz-rederive/fulltext.sqlite --workerHeapMb 1024
+
+# Search cache: build-cache-from-corpus.js's --rederive mode (new — check the
+# script's own CLI parsing for its current flags before running).
+node search/build-cache-from-corpus.js --rederive
 ```
 
-The search-cache offline re-derive command belongs to the separate re-derive
-workflow because the existing `search-build.js` path performs network harvests;
-do not use it to repair a released cache. The citation graph has no resumable
-checkpoint and may need several gigabytes of heap. Definitions checkpoint each
-batch under `<output>.checkpoint`; delete stale checkpoints or use a new output
-path. Full text resumes at the SQLite database level, so its fresh output path
-is mandatory. These commands parse only the restored local corpus; they do not
-fetch EUR-Lex or mutate a published release.
+**Always write to a fresh output path — never point a builder at the released
+asset.** For fulltext this is mandatory, not just tidy: its `doneCelex` resume
+check skips any CELEX already present in the target database, so building into
+the previous `fulltext.sqlite` silently preserves every stale, older-parser row
+instead of reparsing it — the manifest would report growth while most of the
+database stayed on the old version. For definitions, a stale checkpoint left at
+`<output>.checkpoint` from an older-parser run is now (previous section)
+rejected and discarded automatically rather than silently resumed into a mixed
+artifact — but a fresh output path avoids the discard-and-restart entirely.
+
+### Resumability and cost per asset
+
+- **Citation graph** — not resumable; it merges all shards in a single pass at
+  the end. It is the biggest RAM risk of the four (`--workerHeapMb` per worker,
+  plus `--max-old-space-size` for the final merge).
+- **Full text** — resumes at the database level via `doneCelex`. It is the
+  wall-clock risk: reparsing the full corpus into SQLite is the slowest of the
+  four passes.
+- **Definitions** — resumes per batch via `<output>.checkpoint`, now keyed to
+  the parser version that produced it (see above).
+- **Search cache** — resumes by CELEX through its stable work directory
+  (`CORPUS_BUILD_WORKDIR`, default a fixed `os.tmpdir()` path), so an
+  interrupted `--rederive` run picks back up without redoing completed batches.
+
+### Which release each asset belongs to
+
+`citation-graph.json.gz`, `definitions.json.gz`, and `search-cache.json.gz`
+all ship in the **data** release (`DATA_RELEASE_TAG`); `fulltext.sqlite.gz`
+ships in its own **fulltext** release (`FULLTEXT_RELEASE_TAG`). Both
+Dockerfile fetch loops pull every asset from one tag, so publishing a
+rebuilt-only-one-asset release still means re-uploading the other, unchanged
+assets from that train alongside it — a partial asset set 404s the Docker
+build. Bump the matching `*_RELEASE_TAG` constant in `backend/Dockerfile` in
+the same commit as the release, per the root `CLAUDE.md` cache table.
 
 ## Candidate inspection
 

--- a/backend/search/build-cache-from-corpus.js
+++ b/backend/search/build-cache-from-corpus.js
@@ -226,13 +226,13 @@ function buildPrimaryEli(celex) {
 // never adds new acts, only refreshes ones already present.
 //
 // `corpusCoveredKeys` is the set of existing CELEX keys that have *any* corpus
-// file (FMX or HTML) — used only to report how many existing records had no
-// corpus file to rederive from at all (they're preserved untouched too, same
-// as a failed parse, just for a different reason).
+// file (FMX or HTML) — used to report both records with no corpus file and
+// corpus-covered records whose worker output never came back.
 function mergeRederivedRecords({ existingRecords, rawRecords, corpusCoveredKeys, enrichSearchRecord }) {
   const existingByCelex = new Map(existingRecords.map((rec) => [normCelex(rec.celex), rec]));
 
   const rederived = [];
+  const returnedKeys = new Set();
   let rederivedCount = 0;
   let failedCount = 0;
   let excerptChangedCount = 0;
@@ -241,6 +241,7 @@ function mergeRederivedRecords({ existingRecords, rawRecords, corpusCoveredKeys,
     const key = normCelex(raw.celex);
     const existing = existingByCelex.get(key);
     if (!existing) continue; // not part of the existing cache; out of scope
+    returnedKeys.add(key);
 
     if (raw.enrichError) {
       failedCount += 1;
@@ -296,8 +297,14 @@ function mergeRederivedRecords({ existingRecords, rawRecords, corpusCoveredKeys,
   // what keeps the payload from honestly claiming a single current version.
   let noCorpusFileCount = 0;
   let staleUncoveredCount = 0;
+  let missedCount = 0;
   for (const [key, rec] of existingByCelex) {
-    if (corpusCoveredKeys.has(key)) continue;
+    if (corpusCoveredKeys.has(key)) {
+      // A failed worker batch leaves no raw record at all. Count that gap here
+      // so it cannot disappear from the parser-stamp decision.
+      if (!returnedKeys.has(key)) missedCount += 1;
+      continue;
+    }
     noCorpusFileCount += 1;
     if (rec.excerpt) staleUncoveredCount += 1;
   }
@@ -309,6 +316,7 @@ function mergeRederivedRecords({ existingRecords, rawRecords, corpusCoveredKeys,
       failed: failedCount,
       noCorpusFile: noCorpusFileCount,
       staleUncovered: staleUncoveredCount,
+      missed: missedCount,
       excerptChanged: excerptChangedCount,
       unkeyable,
     },
@@ -317,17 +325,19 @@ function mergeRederivedRecords({ existingRecords, rawRecords, corpusCoveredKeys,
 
 // A bare current-version stamp claims every *parser-derived* field in the
 // payload came from that version, so it is only honest when this run left no
-// stale parse behind: no failed parse, and no record still carrying an excerpt
-// from an earlier version that no corpus file could refresh. Records with no
-// corpus file and no excerpt are not a gap — they never held parser output in
-// the first place, and the cache holds tens of thousands of them (SPARQL-only
-// acts outside the harvested corpus), so counting them would make a bare stamp
-// unreachable forever. Any real gap means some records still reflect whatever
-// parser produced the existing payload, so the stamp must MERGE with whatever
-// the payload already carried (mirrors the same bare-vs-merge decision in
-// search-build.js's reEnrichCurrentCache).
+// stale parse behind: no failed parse, no corpus-covered record missed by this
+// run, and no record still carrying an excerpt from an earlier version that no
+// corpus file could refresh. Records with no corpus file and no excerpt are not
+// a gap — they never held parser output in the first place, and the cache holds
+// tens of thousands of them (SPARQL-only acts outside the harvested corpus), so
+// counting them would make a bare stamp unreachable forever. Any real gap means
+// some records still reflect whatever parser produced the existing payload, so
+// the stamp must MERGE with whatever the payload already carried (mirrors the
+// same bare-vs-merge decision in search-build.js's reEnrichCurrentCache).
 function computeRederiveParserStamp({ existingParserVersion, currentParserVersion, stats }) {
-  const isCompleteRederive = stats.failed === 0 && (stats.staleUncovered || 0) === 0;
+  const isCompleteRederive = stats.failed === 0
+    && (stats.staleUncovered || 0) === 0
+    && (stats.missed || 0) === 0;
   return isCompleteRederive
     ? currentParserVersion
     : mergeParserStamp(existingParserVersion, currentParserVersion);
@@ -529,6 +539,7 @@ async function driver({ noEurovoc = false, noInForce = false, rederive = false }
     console.log(`  unchanged (no corpus file): ${result.stats.noCorpusFile}`);
     console.log(`    of those, with an excerpt: ${result.stats.staleUncovered}`);
     console.log(`  failed:                     ${result.stats.failed}`);
+    console.log(`  missed (corpus-covered):    ${result.stats.missed}`);
     console.log(`  excerpt changed:            ${result.stats.excerptChanged}`);
     console.log(`  parserVersion stamp:        ${JSON.stringify(parserVersion)}`);
   } else {

--- a/backend/search/build-cache-from-corpus.js
+++ b/backend/search/build-cache-from-corpus.js
@@ -23,6 +23,17 @@
 // --worker), pooled `CONCURRENCY` at a time; each writes a partial JSON that the
 // driver merges. `fetch` is hard-blocked in the worker so a corpus miss fails
 // loudly instead of silently hitting the network.
+//
+// --rederive mode (issue #180): the shipped cache can carry `title`/`excerpt`
+// derived by an older PARSER_VERSION with no version stamp at all. `--rederive`
+// re-parses every existing record that has a corpus file, regardless of year,
+// and lets the freshly derived title/excerpt win — every other field (eurovoc
+// topics, in-force status, date, and the alias/normalized fields
+// `enrichSearchRecord` derives from title) is preserved exactly. An act with no
+// corpus file, or whose parse fails, keeps its existing record untouched, and
+// the output record count can never regress. See `mergeRederivedRecords` /
+// `computeRederiveParserStamp` below, which are the pure, unit-testable core of
+// this mode — the driver just wires them to the worker-batch machinery above.
 
 const fs = require("fs");
 const fsp = require("fs/promises");
@@ -35,8 +46,15 @@ const { readCorpusDates, normalizeCelexKey } = require("./law-corpus-dates.js");
 const { listCorpusFiles: listCorpusEntries } = require("./corpus-files.js");
 const { enrichRecordsWithEurovoc } = require("./eurovoc-enrich.js");
 const { enrichRecordsWithInForce } = require("./in-force-enrich.js");
+const { getCurrentParserVersion, mergeParserStamp } = require("./parser-stamp.js");
 
-const CORPUS_DIR = path.join(__dirname, "data");
+// Overridable so tests can point the whole build at a throwaway fixture corpus
+// instead of the real (huge) checked-out corpus under search/data. Everything
+// below (FMX/HTML roots, cache path, backup path) is derived from this, so one
+// env var redirects the entire build.
+const CORPUS_DIR = process.env.CORPUS_BUILD_CORPUS_DIR
+  ? path.resolve(process.env.CORPUS_BUILD_CORPUS_DIR)
+  : path.join(__dirname, "data");
 const FMX_ROOT = path.join(CORPUS_DIR, "laws");
 const HTML_ROOT = path.join(CORPUS_DIR, "laws-html");
 const CACHE_PATH = path.join(CORPUS_DIR, "search-cache.json");
@@ -46,6 +64,13 @@ const BACKUP_PATH = path.join(CORPUS_DIR, "search-cache.json.bak");
 // survive and are reused on the next run. Resume is keyed by CELEX coverage, not
 // batch index, so it stays correct even if batch boundaries shift. Removed only
 // after a fully successful build; override for tests/isolation.
+//
+// --rederive uses a *separate*, parser-version-keyed work dir (see driver()
+// below): a work dir seeded by parser v21 must never be treated as coverage for
+// a v22 rederive run, since its parsed title/excerpt would be stale by
+// definition. Keying by version means an old rederive work dir is simply
+// ignored (and safe to leave on disk, or delete by hand) once the parser moves
+// on; the default (non-rederive) mode is unaffected and keeps this exact path.
 const WORK_DIR = process.env.CORPUS_BUILD_WORKDIR || path.join(os.tmpdir(), "corpus-build-work");
 
 // Everything strictly older than this comes from the corpus; this year and
@@ -181,6 +206,134 @@ function buildPrimaryEli(celex) {
 }
 
 // ---------------------------------------------------------------------------
+// --rederive: pure merge/stamp core (no fs, no workers — easy to unit test).
+// ---------------------------------------------------------------------------
+
+// Folds freshly re-parsed worker output (`rawRecords`, the same shape
+// `runWorker` writes for the normal mode) onto the existing cache. For each raw
+// record whose CELEX is in the existing cache:
+//   - a failed parse (rec.enrichError set) leaves the existing record untouched
+//     and counts as `failed`;
+//   - a successful parse overwrites ONLY `title` (when non-empty — an empty
+//     fresh title is not allowed to erase a good existing one) and `excerpt`
+//     (always, even to "", since a genuinely empty excerpt is itself a fresh
+//     result) on a shallow copy of the existing record, then re-runs
+//     `enrichSearchRecord` so the derived fields (normalizedTitle, aliases,
+//     eliKind, isPrimaryAct, ...) stay consistent with the new title. Every
+//     other field — eurovoc topics, in-force status, date, eli, etc. — comes
+//     through the `{ ...existing }` spread untouched.
+// A raw record whose CELEX isn't in the existing cache is ignored: rederive
+// never adds new acts, only refreshes ones already present.
+//
+// `corpusCoveredKeys` is the set of existing CELEX keys that have *any* corpus
+// file (FMX or HTML) — used only to report how many existing records had no
+// corpus file to rederive from at all (they're preserved untouched too, same
+// as a failed parse, just for a different reason).
+function mergeRederivedRecords({ existingRecords, rawRecords, corpusCoveredKeys, enrichSearchRecord }) {
+  const existingByCelex = new Map(existingRecords.map((rec) => [normCelex(rec.celex), rec]));
+
+  const rederived = [];
+  let rederivedCount = 0;
+  let failedCount = 0;
+  let excerptChangedCount = 0;
+
+  for (const raw of rawRecords) {
+    const key = normCelex(raw.celex);
+    const existing = existingByCelex.get(key);
+    if (!existing) continue; // not part of the existing cache; out of scope
+
+    if (raw.enrichError) {
+      failedCount += 1;
+      continue; // existing record is preserved untouched via the merge below
+    }
+
+    const next = { ...existing };
+    if (raw.title) next.title = raw.title;
+    next.excerpt = typeof raw.excerpt === "string" ? raw.excerpt : "";
+    if (next.excerpt !== (existing.excerpt || "")) excerptChangedCount += 1;
+    rederived.push(enrichSearchRecord(next));
+    rederivedCount += 1;
+  }
+
+  // Rederived records win for their CELEX; every other existing record (no
+  // corpus file, or a failed parse) is pushed through unchanged. Order matters
+  // for `push`'s existing-wins-by-key dedup: rederived first, then existing.
+  const merged = [];
+  const mergedSeen = new Set();
+  const push = (rec) => {
+    const key = normCelex(rec.celex);
+    if (!key || mergedSeen.has(key)) return;
+    mergedSeen.add(key);
+    merged.push(rec);
+  };
+  for (const rec of rederived) push(rec);
+  for (const rec of existingRecords) push(rec);
+
+  // Never drop records: rederive only refreshes fields on existing CELEX keys,
+  // it never removes one. Compare against the number of *distinct, keyable*
+  // existing records rather than the raw array length — a duplicate CELEX or a
+  // record with no CELEX at all is collapsed by `push` in the default mode too,
+  // and aborting a multi-hour pass at the write step over one malformed legacy
+  // row would be a worse outcome than reporting it.
+  const expected = new Set();
+  let unkeyable = 0;
+  for (const rec of existingRecords) {
+    const key = normCelex(rec.celex);
+    if (key) expected.add(key);
+    else unkeyable += 1;
+  }
+  if (merged.length < expected.size) {
+    throw new Error(
+      `[corpus-build] rederive record count regressed: ${expected.size} -> ${merged.length}`
+    );
+  }
+
+  // A record with no corpus file was not re-derived. Whether that matters for
+  // the stamp depends on whether it carries parser output at all: a record
+  // harvested from SPARQL alone has a title and no excerpt, so there is no
+  // stale parse in it to misrepresent. One that *does* carry an excerpt was
+  // parsed by some earlier version and is now unreachable offline — that is
+  // what keeps the payload from honestly claiming a single current version.
+  let noCorpusFileCount = 0;
+  let staleUncoveredCount = 0;
+  for (const [key, rec] of existingByCelex) {
+    if (corpusCoveredKeys.has(key)) continue;
+    noCorpusFileCount += 1;
+    if (rec.excerpt) staleUncoveredCount += 1;
+  }
+
+  return {
+    merged,
+    stats: {
+      rederived: rederivedCount,
+      failed: failedCount,
+      noCorpusFile: noCorpusFileCount,
+      staleUncovered: staleUncoveredCount,
+      excerptChanged: excerptChangedCount,
+      unkeyable,
+    },
+  };
+}
+
+// A bare current-version stamp claims every *parser-derived* field in the
+// payload came from that version, so it is only honest when this run left no
+// stale parse behind: no failed parse, and no record still carrying an excerpt
+// from an earlier version that no corpus file could refresh. Records with no
+// corpus file and no excerpt are not a gap — they never held parser output in
+// the first place, and the cache holds tens of thousands of them (SPARQL-only
+// acts outside the harvested corpus), so counting them would make a bare stamp
+// unreachable forever. Any real gap means some records still reflect whatever
+// parser produced the existing payload, so the stamp must MERGE with whatever
+// the payload already carried (mirrors the same bare-vs-merge decision in
+// search-build.js's reEnrichCurrentCache).
+function computeRederiveParserStamp({ existingParserVersion, currentParserVersion, stats }) {
+  const isCompleteRederive = stats.failed === 0 && (stats.staleUncovered || 0) === 0;
+  return isCompleteRederive
+    ? currentParserVersion
+    : mergeParserStamp(existingParserVersion, currentParserVersion);
+}
+
+// ---------------------------------------------------------------------------
 // Driver.
 // ---------------------------------------------------------------------------
 
@@ -239,7 +392,7 @@ async function runPool(jobs, concurrency) {
   return failed;
 }
 
-async function driver({ noEurovoc = false, noInForce = false } = {}) {
+async function driver({ noEurovoc = false, noInForce = false, rederive = false } = {}) {
   const t0 = Date.now();
   const { enrichSearchRecord } = require("./search-ranking.js");
 
@@ -249,54 +402,73 @@ async function driver({ noEurovoc = false, noInForce = false } = {}) {
   const seen = new Set(existingRecords.map((r) => normCelex(r.celex)).filter(Boolean));
   console.log(`[corpus-build] Existing cache: ${existingRecords.length} records`);
 
+  // --rederive gets its own, parser-version-keyed work dir (see the WORK_DIR
+  // comment above): a work dir seeded by a different parser version must never
+  // be read as coverage, since its parsed title/excerpt would be stale by
+  // definition. Default mode is unaffected and keeps the plain WORK_DIR path.
+  const currentParserVersion = rederive ? await getCurrentParserVersion() : null;
+  const workDir = rederive ? `${WORK_DIR}-rederive-v${currentParserVersion}` : WORK_DIR;
+
   // Resume: reuse partials from a previous (possibly interrupted) run. Keyed by
   // CELEX coverage so it's correct regardless of how batches are chunked.
-  fs.mkdirSync(WORK_DIR, { recursive: true });
-  const alreadyParsed = loadParsedCelexes(WORK_DIR);
+  fs.mkdirSync(workDir, { recursive: true });
+  const alreadyParsed = loadParsedCelexes(workDir);
   if (alreadyParsed.size) {
-    console.log(`[corpus-build] Resume: ${alreadyParsed.size} records already parsed in ${WORK_DIR}`);
+    console.log(`[corpus-build] Resume: ${alreadyParsed.size} records already parsed in ${workDir}`);
   }
 
   // FMX first (preferred), then HTML only for celexes not covered by FMX.
-  const fmxAll = listCorpusFiles(FMX_ROOT, ".xml.gz", REUSE_FROM_YEAR);
+  //   default mode: only pre-REUSE_FROM_YEAR acts NOT already in the cache.
+  //   --rederive:   every year, and ONLY celexes ALREADY in the cache — it
+  //                 refreshes existing records, it never adds new ones (see
+  //                 mergeRederivedRecords, which silently ignores any raw
+  //                 record whose CELEX isn't in the existing cache).
+  const yearFloor = rederive ? undefined : REUSE_FROM_YEAR;
+  const fmxAll = listCorpusFiles(FMX_ROOT, ".xml.gz", yearFloor);
   const fmxJobs = [];
   const fmxSeen = new Set();
   for (const item of fmxAll) {
     const key = normCelex(item.celex);
-    if (seen.has(key) || fmxSeen.has(key) || alreadyParsed.has(key)) continue;
+    if (rederive ? !seen.has(key) : seen.has(key)) continue;
+    if (fmxSeen.has(key) || alreadyParsed.has(key)) continue;
     fmxSeen.add(key);
     fmxJobs.push(item);
   }
 
-  const htmlAll = listCorpusFiles(HTML_ROOT, ".html.gz", REUSE_FROM_YEAR);
+  const htmlAll = listCorpusFiles(HTML_ROOT, ".html.gz", yearFloor);
   const htmlJobs = [];
   const htmlSeen = new Set();
   for (const item of htmlAll) {
     const key = normCelex(item.celex);
-    if (seen.has(key) || fmxSeen.has(key) || htmlSeen.has(key) || alreadyParsed.has(key)) continue;
+    if (rederive ? !seen.has(key) : seen.has(key)) continue;
+    if (fmxSeen.has(key) || htmlSeen.has(key) || alreadyParsed.has(key)) continue;
     htmlSeen.add(key);
     htmlJobs.push(item);
   }
 
-  console.log(`[corpus-build] Pre-${REUSE_FROM_YEAR} still to build: FMX=${fmxJobs.length} HTML=${htmlJobs.length}`);
+  console.log(
+    rederive
+      ? `[corpus-build] Rederive: FMX=${fmxJobs.length} HTML=${htmlJobs.length} corpus files to reparse (no year floor)`
+      : `[corpus-build] Pre-${REUSE_FROM_YEAR} still to build: FMX=${fmxJobs.length} HTML=${htmlJobs.length}`
+  );
 
-  // This run's partials go into the shared WORK_DIR under a unique run id so they
+  // This run's partials go into the shared work dir under a unique run id so they
   // never collide with partials carried over from an earlier interrupted run.
   const runId = Date.now().toString(36);
   const jobs = [];
 
   const fmxBatches = chunk(fmxJobs, FMX_BATCH);
   fmxBatches.forEach((batch, idx) => {
-    const batchPath = path.join(WORK_DIR, `fmx-batch-${runId}-${idx}.json`);
-    const outPath = path.join(WORK_DIR, `fmx-out-${runId}-${idx}.json`);
+    const batchPath = path.join(workDir, `fmx-batch-${runId}-${idx}.json`);
+    const outPath = path.join(workDir, `fmx-out-${runId}-${idx}.json`);
     fs.writeFileSync(batchPath, JSON.stringify(batch));
     jobs.push({ label: `fmx#${idx}`, run: () => spawnWorker("fmx", batchPath, outPath) });
   });
 
   const htmlBatches = chunk(htmlJobs, HTML_BATCH);
   htmlBatches.forEach((batch, idx) => {
-    const batchPath = path.join(WORK_DIR, `html-batch-${runId}-${idx}.json`);
-    const outPath = path.join(WORK_DIR, `html-out-${runId}-${idx}.json`);
+    const batchPath = path.join(workDir, `html-batch-${runId}-${idx}.json`);
+    const outPath = path.join(workDir, `html-out-${runId}-${idx}.json`);
     fs.writeFileSync(batchPath, JSON.stringify(batch));
     jobs.push({ label: `html#${idx}`, run: () => spawnWorker("html", batchPath, outPath) });
   });
@@ -304,23 +476,70 @@ async function driver({ noEurovoc = false, noInForce = false } = {}) {
   console.log(`[corpus-build] Spawning ${jobs.length} worker batches, concurrency=${CONCURRENCY}`);
   const failed = await runPool(jobs, CONCURRENCY);
 
-  // Precise dates harvested from SPARQL (work_date_document), persisted by
-  // search-build.js at harvest time. Overlay them onto the corpus records (the
-  // offline worker has no date). A CELEX missing from the manifest keeps its
-  // null date until the next harvest populates it.
-  const corpusDates = readCorpusDates(CORPUS_DIR);
-  let preciseDates = 0;
-
   // Collect ALL partials in the work dir (this run + any carried over from an
-  // interrupted run), enrich to the canonical record shape. Dedup by CELEX
-  // happens in the merge below, so overlap between partials is harmless.
-  const newRecords = [];
-  for (const f of fs.readdirSync(WORK_DIR)) {
+  // interrupted run). Dedup by CELEX happens in the merges below, so overlap
+  // between partials is harmless.
+  const rawRecords = [];
+  for (const f of fs.readdirSync(workDir)) {
     if (!/-out-.*\.json$/.test(f)) continue;
     let raw;
-    try { raw = JSON.parse(fs.readFileSync(path.join(WORK_DIR, f), "utf8")); }
+    try { raw = JSON.parse(fs.readFileSync(path.join(workDir, f), "utf8")); }
     catch { continue; } // skip a corrupt/half-written partial
-    for (const rec of raw) {
+    rawRecords.push(...raw);
+  }
+
+  let merged;
+  let payload;
+
+  if (rederive) {
+    // Any existing CELEX with a corpus file (FMX or HTML, any year) is
+    // "covered" — used only to report how many existing records had no corpus
+    // file to rederive from at all (see mergeRederivedRecords).
+    const corpusCoveredKeys = new Set();
+    for (const item of fmxAll) corpusCoveredKeys.add(normCelex(item.celex));
+    for (const item of htmlAll) corpusCoveredKeys.add(normCelex(item.celex));
+
+    const result = mergeRederivedRecords({ existingRecords, rawRecords, corpusCoveredKeys, enrichSearchRecord });
+    merged = result.merged;
+    // Same ordering as buildSearchCache: newest first, records without a date
+    // (corpus acts missing from the manifest) last.
+    merged.sort((a, b) => String(b.date || "").localeCompare(String(a.date || "")));
+
+    const parserVersion = computeRederiveParserStamp({
+      existingParserVersion: existing.parserVersion,
+      currentParserVersion,
+      stats: result.stats,
+    });
+
+    const years = merged.map((r) => Number(r.celexYear)).filter((y) => Number.isFinite(y));
+    // Field order matters: parserVersion must precede records so
+    // assert-parser-freshness.js's streaming header scan finds it without
+    // reading the (huge) records array first.
+    payload = {
+      generatedAt: new Date().toISOString(),
+      fromYear: years.length ? Math.max(...years) : existing.fromYear,
+      toYear: years.length ? Math.min(...years) : existing.toYear,
+      parserVersion,
+      count: merged.length,
+      records: merged,
+    };
+
+    console.log("[corpus-build] Rederive report:");
+    console.log(`  re-derived:                 ${result.stats.rederived}`);
+    console.log(`  unchanged (no corpus file): ${result.stats.noCorpusFile}`);
+    console.log(`    of those, with an excerpt: ${result.stats.staleUncovered}`);
+    console.log(`  failed:                     ${result.stats.failed}`);
+    console.log(`  excerpt changed:            ${result.stats.excerptChanged}`);
+    console.log(`  parserVersion stamp:        ${JSON.stringify(parserVersion)}`);
+  } else {
+    // Precise dates harvested from SPARQL (work_date_document), persisted by
+    // search-build.js at harvest time. Overlay them onto the corpus records (the
+    // offline worker has no date). A CELEX missing from the manifest keeps its
+    // null date until the next harvest populates it.
+    const corpusDates = readCorpusDates(CORPUS_DIR);
+    let preciseDates = 0;
+    const newRecords = [];
+    for (const rec of rawRecords) {
       const enriched = enrichSearchRecord(rec);
       const precise = corpusDates[normalizeCelexKey(enriched.celex)];
       if (precise) {
@@ -329,48 +548,53 @@ async function driver({ noEurovoc = false, noInForce = false } = {}) {
       }
       newRecords.push(enriched);
     }
+    console.log(`[corpus-build] Parsed ${newRecords.length} corpus records (${preciseDates} with precise SPARQL dates, ${failed.length} batches failed this run)`);
+
+    // Merge: existing (as-is) + new, dedup by CELEX (existing wins), primary only.
+    merged = [];
+    const mergedSeen = new Set();
+    const push = (rec) => {
+      const key = normCelex(rec.celex);
+      if (!key || mergedSeen.has(key)) return;
+      mergedSeen.add(key);
+      merged.push(rec);
+    };
+    for (const rec of existingRecords) push(rec);
+    for (const rec of newRecords) {
+      if (!rec.isPrimaryAct) continue;
+      push(rec);
+    }
+
+    // Same ordering as buildSearchCache: newest first, records without a date
+    // (corpus acts missing from the manifest) last.
+    merged.sort((a, b) => String(b.date || "").localeCompare(String(a.date || "")));
+
+    const years = merged.map((r) => Number(r.celexYear)).filter((y) => Number.isFinite(y));
+    payload = {
+      generatedAt: new Date().toISOString(),
+      fromYear: years.length ? Math.max(...years) : existing.fromYear,
+      toYear: years.length ? Math.min(...years) : existing.toYear,
+      count: merged.length,
+      records: merged,
+    };
   }
-  console.log(`[corpus-build] Parsed ${newRecords.length} corpus records (${preciseDates} with precise SPARQL dates, ${failed.length} batches failed this run)`);
 
-  // Merge: existing (as-is) + new, dedup by CELEX (existing wins), primary only.
-  const merged = [];
-  const mergedSeen = new Set();
-  const push = (rec) => {
-    const key = normCelex(rec.celex);
-    if (!key || mergedSeen.has(key)) return;
-    mergedSeen.add(key);
-    merged.push(rec);
-  };
-  for (const rec of existingRecords) push(rec);
-  for (const rec of newRecords) {
-    if (!rec.isPrimaryAct) continue;
-    push(rec);
-  }
-
-  // Same ordering as buildSearchCache: newest first, records without a date
-  // (corpus acts missing from the manifest) last.
-  merged.sort((a, b) => String(b.date || "").localeCompare(String(a.date || "")));
-
-  const years = merged.map((r) => Number(r.celexYear)).filter((y) => Number.isFinite(y));
-  const payload = {
-    generatedAt: new Date().toISOString(),
-    fromYear: years.length ? Math.max(...years) : existing.fromYear,
-    toYear: years.length ? Math.min(...years) : existing.toYear,
-    count: merged.length,
-    records: merged,
-  };
-
-  // EuroVoc topics and in-force status are SPARQL metadata, so — like the dates
-  // overlaid above — they can't be reconstructed from disk. These are the only
-  // network calls in an otherwise offline build, and they run *here in the
-  // driver*: the workers keep their hard `fetch` block, so a corpus miss still
-  // fails loudly instead of silently scraping. Skip them with --no-eurovoc /
-  // --no-in-force for a genuinely offline run.
+  // EuroVoc topics and in-force status are SPARQL metadata that can't be
+  // reconstructed from disk. --rederive is specifically a parser-fields-only
+  // pass (title/excerpt), and mergeRederivedRecords already preserves these
+  // fields exactly from the existing record, so refreshing them here would
+  // both add an unwanted network dependency to an otherwise-offline rederive
+  // and risk drifting them from whatever a separate harvest already set. In
+  // the default mode this is unchanged: the only network calls in an
+  // otherwise offline build, run *here in the driver* (the workers keep their
+  // hard `fetch` block), opt-out via --no-eurovoc / --no-in-force.
   //
   // It runs as part of the build rather than as a follow-up pass because a
   // CELEX-keyed sidecar bolted on afterwards strands every record it never saw,
   // silently (see eurovoc-enrich.js). Best-effort: topics never fail a build.
-  if (noEurovoc) {
+  if (rederive) {
+    console.log("[corpus-build] EuroVoc/in-force enrichment skipped (--rederive preserves them as-is)");
+  } else if (noEurovoc) {
     console.log("[corpus-build] EuroVoc enrichment skipped (--no-eurovoc)");
   } else {
     try {
@@ -383,16 +607,18 @@ async function driver({ noEurovoc = false, noInForce = false } = {}) {
     }
   }
 
-  if (noInForce) {
-    console.log("[corpus-build] In-force enrichment skipped (--no-in-force)");
-  } else {
-    try {
-      const stats = await enrichRecordsWithInForce(payload.records, {
-        log: (message) => console.log(`[corpus-build] [in-force] ${message}`),
-      });
-      console.log(`[corpus-build] In-force: ${stats.withStatus} records with status, ${stats.inForce} in force (${stats.fromJournal} from journal, ${stats.fetched} fetched)`);
-    } catch (error) {
-      console.log(`[corpus-build] In-force enrichment failed, cache ships without status: ${error.message}`);
+  if (!rederive) {
+    if (noInForce) {
+      console.log("[corpus-build] In-force enrichment skipped (--no-in-force)");
+    } else {
+      try {
+        const stats = await enrichRecordsWithInForce(payload.records, {
+          log: (message) => console.log(`[corpus-build] [in-force] ${message}`),
+        });
+        console.log(`[corpus-build] In-force: ${stats.withStatus} records with status, ${stats.inForce} in force (${stats.fromJournal} from journal, ${stats.fetched} fetched)`);
+      } catch (error) {
+        console.log(`[corpus-build] In-force enrichment failed, cache ships without status: ${error.message}`);
+      }
     }
   }
 
@@ -408,9 +634,9 @@ async function driver({ noEurovoc = false, noInForce = false } = {}) {
   // Keep the work dir if anything failed this run, so a re-run resumes and
   // retries only the still-missing celexes; clear it only on a clean build.
   if (failed.length === 0) {
-    await fsp.rm(WORK_DIR, { recursive: true, force: true });
+    await fsp.rm(workDir, { recursive: true, force: true });
   } else {
-    console.log(`[corpus-build] Kept ${WORK_DIR} for resume (${failed.length} batches failed)`);
+    console.log(`[corpus-build] Kept ${workDir} for resume (${failed.length} batches failed)`);
   }
 
   const withExcerpt = merged.filter((r) => r.excerpt && r.excerpt.length > 0).length;
@@ -433,6 +659,7 @@ async function main() {
   await driver({
     noEurovoc: args.includes("--no-eurovoc"),
     noInForce: args.includes("--no-in-force"),
+    rederive: args.includes("--rederive"),
   });
 }
 
@@ -443,4 +670,11 @@ if (require.main === module) {
   });
 }
 
-module.exports = { buildPrimaryEli, inferType, listCorpusFiles };
+module.exports = {
+  buildPrimaryEli,
+  inferType,
+  listCorpusFiles,
+  driver,
+  mergeRederivedRecords,
+  computeRederiveParserStamp,
+};

--- a/backend/search/build-cache-from-corpus.test.js
+++ b/backend/search/build-cache-from-corpus.test.js
@@ -83,6 +83,7 @@ test("mergeRederivedRecords: fresh title/excerpt win, every other field is prese
   assert.equal(stats.rederived, 1);
   assert.equal(stats.failed, 0);
   assert.equal(stats.noCorpusFile, 0);
+  assert.equal(stats.missed, 0);
   assert.equal(stats.excerptChanged, 1);
 });
 
@@ -116,6 +117,7 @@ test("mergeRederivedRecords: a record with no corpus file is preserved untouched
   assert.equal(stats.rederived, 0);
   assert.equal(stats.failed, 0);
   assert.equal(stats.noCorpusFile, 1);
+  assert.equal(stats.missed, 0);
 });
 
 test("mergeRederivedRecords: a failed parse preserves the existing record and counts as failed", () => {
@@ -134,6 +136,7 @@ test("mergeRederivedRecords: a failed parse preserves the existing record and co
   assert.equal(stats.rederived, 0);
   assert.equal(stats.failed, 1);
   assert.equal(stats.noCorpusFile, 0);
+  assert.equal(stats.missed, 0);
 });
 
 test("mergeRederivedRecords: the record count never regresses across a mixed batch", () => {
@@ -161,6 +164,27 @@ test("mergeRederivedRecords: the record count never regresses across a mixed bat
   );
 });
 
+test("mergeRederivedRecords: a corpus-covered record missing from worker output is counted as missed", async () => {
+  const current = await getCurrentParserVersion();
+  const previous = current - 1;
+  const existing = existingRecord({ celex: "32020R0001" });
+  const { stats } = mergeRederivedRecords({
+    existingRecords: [existing],
+    rawRecords: [],
+    corpusCoveredKeys: new Set([existing.celex]),
+    enrichSearchRecord,
+  });
+
+  assert.equal(stats.rederived, 0);
+  assert.equal(stats.failed, 0);
+  assert.equal(stats.missed, 1);
+  assert.deepEqual(computeRederiveParserStamp({
+    existingParserVersion: previous,
+    currentParserVersion: current,
+    stats,
+  }), [previous, current]);
+});
+
 test("mergeRederivedRecords: a raw record for a celex not in the existing cache is ignored (never adds new acts)", () => {
   const existing = existingRecord({ celex: "32020R0001" });
   const raw = { celex: "39999R9999", title: "Should not appear", excerpt: "", enrichError: null };
@@ -181,7 +205,7 @@ test("computeRederiveParserStamp: bare current version only when every record wa
   const complete = computeRederiveParserStamp({
     existingParserVersion: 21,
     currentParserVersion: current,
-    stats: { rederived: 5, failed: 0, noCorpusFile: 0, staleUncovered: 0, excerptChanged: 5 },
+    stats: { rederived: 5, failed: 0, noCorpusFile: 0, staleUncovered: 0, missed: 0, excerptChanged: 5 },
   });
   assert.equal(complete, current);
 });
@@ -195,7 +219,7 @@ test("computeRederiveParserStamp: uncovered records without an excerpt are not a
   const stamp = computeRederiveParserStamp({
     existingParserVersion: 21,
     currentParserVersion: current,
-    stats: { rederived: 5, failed: 0, noCorpusFile: 40000, staleUncovered: 0, excerptChanged: 5 },
+    stats: { rederived: 5, failed: 0, noCorpusFile: 40000, staleUncovered: 0, missed: 0, excerptChanged: 5 },
   });
   assert.equal(stamp, current);
 });
@@ -205,7 +229,7 @@ test("computeRederiveParserStamp: merges onto the existing stamp when anything w
   const partialFailed = computeRederiveParserStamp({
     existingParserVersion: 21,
     currentParserVersion: current,
-    stats: { rederived: 4, failed: 1, noCorpusFile: 0, staleUncovered: 0, excerptChanged: 4 },
+    stats: { rederived: 4, failed: 1, noCorpusFile: 0, staleUncovered: 0, missed: 0, excerptChanged: 4 },
   });
   assert.deepEqual(partialFailed, [21, current]);
 
@@ -214,7 +238,7 @@ test("computeRederiveParserStamp: merges onto the existing stamp when anything w
   const partialStale = computeRederiveParserStamp({
     existingParserVersion: 21,
     currentParserVersion: current,
-    stats: { rederived: 4, failed: 0, noCorpusFile: 1, staleUncovered: 1, excerptChanged: 4 },
+    stats: { rederived: 4, failed: 0, noCorpusFile: 1, staleUncovered: 1, missed: 0, excerptChanged: 4 },
   });
   assert.deepEqual(partialStale, [21, current]);
 });
@@ -223,7 +247,7 @@ test("computeRederiveParserStamp: a legacy unstamped payload stays unstamped aft
   const stamp = computeRederiveParserStamp({
     existingParserVersion: undefined,
     currentParserVersion: await getCurrentParserVersion(),
-    stats: { rederived: 0, failed: 0, noCorpusFile: 3, staleUncovered: 3, excerptChanged: 0 },
+    stats: { rederived: 0, failed: 0, noCorpusFile: 3, staleUncovered: 3, missed: 0, excerptChanged: 0 },
   });
   assert.equal(stamp, null);
 });

--- a/backend/search/build-cache-from-corpus.test.js
+++ b/backend/search/build-cache-from-corpus.test.js
@@ -1,0 +1,308 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+// build-cache-from-corpus.js derives CORPUS_DIR/WORK_DIR from these env vars
+// at require time (see the comments beside them in the module), so they must
+// be set BEFORE the first require below — not inside a test. Redirecting both
+// keeps the one integration test (driver() with --rederive) from ever touching
+// the real, huge checked-out corpus under search/data.
+const CORPUS_DIR_FOR_TESTS = fs.mkdtempSync(path.join(os.tmpdir(), "build-cache-corpus-"));
+const WORK_DIR_FOR_TESTS = fs.mkdtempSync(path.join(os.tmpdir(), "build-cache-workdir-"));
+process.env.CORPUS_BUILD_CORPUS_DIR = CORPUS_DIR_FOR_TESTS;
+process.env.CORPUS_BUILD_WORKDIR = WORK_DIR_FOR_TESTS;
+
+const {
+  driver,
+  mergeRederivedRecords,
+  computeRederiveParserStamp,
+} = require("./build-cache-from-corpus.js");
+const { enrichSearchRecord } = require("./search-ranking.js");
+const { writeCorpusXml } = require("./law-corpus-store.js");
+
+// Read from the parser rather than pinned to a literal: these tests assert the
+// merge/overwrite rule, not which version happens to be current.
+const { getCurrentParserVersion } = require("./parser-stamp");
+
+function existingRecord(overrides = {}) {
+  return enrichSearchRecord({
+    celex: "32020R0001",
+    title: "Old Title",
+    excerpt: "Old excerpt text.",
+    date: "2020-01-15",
+    eli: "http://data.europa.eu/eli/reg/2020/1/oj",
+    eurovoc: ["consumer protection"],
+    inForce: true,
+    endOfValidity: null,
+    fmxAvailable: true,
+    fmxUnavailable: false,
+    enrichError: null,
+    ...overrides,
+  });
+}
+
+test("mergeRederivedRecords: fresh title/excerpt win, every other field is preserved exactly", () => {
+  const existing = existingRecord();
+  const raw = {
+    celex: "32020R0001",
+    title: "New Title",
+    excerpt: "New excerpt text.",
+    date: null, // the offline worker never has a date
+    eli: null,
+    type: "regulation",
+    fmxAvailable: true,
+    fmxUnavailable: false,
+    enrichError: null,
+  };
+
+  const { merged, stats } = mergeRederivedRecords({
+    existingRecords: [existing],
+    rawRecords: [raw],
+    corpusCoveredKeys: new Set(["32020R0001"]),
+    enrichSearchRecord,
+  });
+
+  assert.equal(merged.length, 1);
+  const record = merged[0];
+  assert.equal(record.title, "New Title");
+  assert.equal(record.excerpt, "New excerpt text.");
+  // Everything else — SPARQL/enrichment metadata the offline worker can't
+  // reconstruct — must survive untouched.
+  assert.equal(record.date, "2020-01-15");
+  assert.deepEqual(record.eurovoc, ["consumer protection"]);
+  assert.equal(record.inForce, true);
+  assert.equal(record.eli, existing.eli);
+  // Derived fields must be recomputed from the NEW title (enrichSearchRecord
+  // is re-run onto the merged record) — not left over from "Old Title".
+  assert.equal(record.normalizedTitle, enrichSearchRecord({ title: "New Title" }).normalizedTitle);
+  assert.notEqual(record.normalizedTitle, enrichSearchRecord({ title: "Old Title" }).normalizedTitle);
+
+  assert.equal(stats.rederived, 1);
+  assert.equal(stats.failed, 0);
+  assert.equal(stats.noCorpusFile, 0);
+  assert.equal(stats.excerptChanged, 1);
+});
+
+test("mergeRederivedRecords: a fresh empty title does not erase a good existing title", () => {
+  const existing = existingRecord({ title: "Kept Title" });
+  const raw = { celex: "32020R0001", title: null, excerpt: "Refreshed excerpt.", enrichError: null };
+
+  const { merged } = mergeRederivedRecords({
+    existingRecords: [existing],
+    rawRecords: [raw],
+    corpusCoveredKeys: new Set(["32020R0001"]),
+    enrichSearchRecord,
+  });
+
+  assert.equal(merged[0].title, "Kept Title");
+  assert.equal(merged[0].excerpt, "Refreshed excerpt.");
+});
+
+test("mergeRederivedRecords: a record with no corpus file is preserved untouched", () => {
+  const existing = existingRecord({ celex: "31999D0002", title: "Untouched" });
+
+  const { merged, stats } = mergeRederivedRecords({
+    existingRecords: [existing],
+    rawRecords: [], // no corpus file -> nothing was ever parsed for this celex
+    corpusCoveredKeys: new Set(), // not covered by any corpus file
+    enrichSearchRecord,
+  });
+
+  assert.equal(merged.length, 1);
+  assert.deepEqual(merged[0], existing);
+  assert.equal(stats.rederived, 0);
+  assert.equal(stats.failed, 0);
+  assert.equal(stats.noCorpusFile, 1);
+});
+
+test("mergeRederivedRecords: a failed parse preserves the existing record and counts as failed", () => {
+  const existing = existingRecord({ celex: "32021L0005", title: "Kept On Failure" });
+  const raw = { celex: "32021L0005", title: null, excerpt: "", enrichError: "boom" };
+
+  const { merged, stats } = mergeRederivedRecords({
+    existingRecords: [existing],
+    rawRecords: [raw],
+    corpusCoveredKeys: new Set(["32021L0005"]),
+    enrichSearchRecord,
+  });
+
+  assert.equal(merged.length, 1);
+  assert.deepEqual(merged[0], existing);
+  assert.equal(stats.rederived, 0);
+  assert.equal(stats.failed, 1);
+  assert.equal(stats.noCorpusFile, 0);
+});
+
+test("mergeRederivedRecords: the record count never regresses across a mixed batch", () => {
+  const records = [
+    existingRecord({ celex: "32020R0001" }), // rederived successfully
+    existingRecord({ celex: "32021L0002" }), // parse fails
+    existingRecord({ celex: "31999D0003" }), // no corpus file
+  ];
+  const rawRecords = [
+    { celex: "32020R0001", title: "Fresh", excerpt: "Fresh excerpt", enrichError: null },
+    { celex: "32021L0002", title: null, excerpt: "", enrichError: "boom" },
+  ];
+
+  const { merged } = mergeRederivedRecords({
+    existingRecords: records,
+    rawRecords,
+    corpusCoveredKeys: new Set(["32020R0001", "32021L0002"]),
+    enrichSearchRecord,
+  });
+
+  assert.equal(merged.length, records.length);
+  assert.deepEqual(
+    merged.map((r) => r.celex).sort(),
+    records.map((r) => r.celex).sort()
+  );
+});
+
+test("mergeRederivedRecords: a raw record for a celex not in the existing cache is ignored (never adds new acts)", () => {
+  const existing = existingRecord({ celex: "32020R0001" });
+  const raw = { celex: "39999R9999", title: "Should not appear", excerpt: "", enrichError: null };
+
+  const { merged } = mergeRederivedRecords({
+    existingRecords: [existing],
+    rawRecords: [raw],
+    corpusCoveredKeys: new Set(),
+    enrichSearchRecord,
+  });
+
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].celex, "32020R0001");
+});
+
+test("computeRederiveParserStamp: bare current version only when every record was successfully re-derived", async () => {
+  const current = await getCurrentParserVersion();
+  const complete = computeRederiveParserStamp({
+    existingParserVersion: 21,
+    currentParserVersion: current,
+    stats: { rederived: 5, failed: 0, noCorpusFile: 0, staleUncovered: 0, excerptChanged: 5 },
+  });
+  assert.equal(complete, current);
+});
+
+// The cache holds tens of thousands of SPARQL-only acts that are outside the
+// harvested corpus and have never carried an excerpt. Counting those as a gap
+// would put a bare stamp permanently out of reach, so the rule is about stale
+// *parser output* left behind, not about untouched records.
+test("computeRederiveParserStamp: uncovered records without an excerpt are not a gap", async () => {
+  const current = await getCurrentParserVersion();
+  const stamp = computeRederiveParserStamp({
+    existingParserVersion: 21,
+    currentParserVersion: current,
+    stats: { rederived: 5, failed: 0, noCorpusFile: 40000, staleUncovered: 0, excerptChanged: 5 },
+  });
+  assert.equal(stamp, current);
+});
+
+test("computeRederiveParserStamp: merges onto the existing stamp when anything was left untouched", async () => {
+  const current = await getCurrentParserVersion();
+  const partialFailed = computeRederiveParserStamp({
+    existingParserVersion: 21,
+    currentParserVersion: current,
+    stats: { rederived: 4, failed: 1, noCorpusFile: 0, staleUncovered: 0, excerptChanged: 4 },
+  });
+  assert.deepEqual(partialFailed, [21, current]);
+
+  // An uncovered record that *does* carry an excerpt holds parser output from
+  // some earlier version that no corpus file can refresh — a real gap.
+  const partialStale = computeRederiveParserStamp({
+    existingParserVersion: 21,
+    currentParserVersion: current,
+    stats: { rederived: 4, failed: 0, noCorpusFile: 1, staleUncovered: 1, excerptChanged: 4 },
+  });
+  assert.deepEqual(partialStale, [21, current]);
+});
+
+test("computeRederiveParserStamp: a legacy unstamped payload stays unstamped after a partial rederive", async () => {
+  const stamp = computeRederiveParserStamp({
+    existingParserVersion: undefined,
+    currentParserVersion: await getCurrentParserVersion(),
+    stats: { rederived: 0, failed: 0, noCorpusFile: 3, staleUncovered: 3, excerptChanged: 0 },
+  });
+  assert.equal(stamp, null);
+});
+
+const SAMPLE_FMX_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<ACT>
+  <BIB.INSTANCE><LG.DOC>EN</LG.DOC></BIB.INSTANCE>
+  <TITLE><TI><P>Regulation on Rederived Widgets</P></TI></TITLE>
+  <PREAMBLE>
+    <GR.CONSID>
+      <CONSID><NP><NO.P>(1)</NO.P><TXT>Rederived widgets require a harmonised legal framework.</TXT></NP></CONSID>
+    </GR.CONSID>
+  </PREAMBLE>
+  <ENACTING.TERMS>
+    <ARTICLE IDENTIFIER="001">
+      <TI.ART>Article 1</TI.ART>
+      <STI.ART>Subject matter</STI.ART>
+      <ALINEA><P>This Regulation lays down harmonised rules on rederived widgets.</P></ALINEA>
+    </ARTICLE>
+  </ENACTING.TERMS>
+</ACT>`;
+
+test("driver({ rederive: true }) re-parses the corpus-backed record, preserves the corpus-less one, and stamps the header before records", async (t) => {
+  const cachePath = path.join(CORPUS_DIR_FOR_TESTS, "search-cache.json");
+  const withCorpusCelex = "32024R0001";
+  const noCorpusCelex = "31999D0002";
+
+  const withCorpus = existingRecord({
+    celex: withCorpusCelex,
+    title: "Stale Title",
+    excerpt: "Stale excerpt.",
+    eli: "http://data.europa.eu/eli/reg/2024/1/oj",
+  });
+  const noCorpus = existingRecord({
+    celex: noCorpusCelex,
+    title: "Never Touched",
+    excerpt: "Never touched excerpt.",
+    eli: null,
+  });
+
+  fs.writeFileSync(cachePath, JSON.stringify({
+    generatedAt: "2026-01-01T00:00:00.000Z",
+    fromYear: 2024,
+    toYear: 1999,
+    parserVersion: 21,
+    count: 2,
+    records: [withCorpus, noCorpus],
+  }));
+  await writeCorpusXml(CORPUS_DIR_FOR_TESTS, withCorpusCelex, SAMPLE_FMX_XML);
+
+  const originalFetch = global.fetch;
+  global.fetch = async () => {
+    throw new Error("network access is not allowed for --rederive");
+  };
+  t.after(() => {
+    global.fetch = originalFetch;
+  });
+
+  await driver({ rederive: true });
+
+  const written = fs.readFileSync(cachePath, "utf8");
+  const payload = JSON.parse(written);
+
+  assert.equal(payload.records.length, 2);
+  assert.ok(written.indexOf('"parserVersion"') < written.indexOf('"records"'));
+
+  const refreshed = payload.records.find((r) => r.celex === withCorpusCelex);
+  assert.equal(refreshed.title, "Regulation on Rederived Widgets");
+  assert.match(refreshed.excerpt, /Rederived widgets/);
+  // Enrichment fields untouched by the rederive.
+  assert.equal(refreshed.date, "2020-01-15");
+  assert.deepEqual(refreshed.eurovoc, ["consumer protection"]);
+  assert.equal(refreshed.inForce, true);
+
+  const untouched = payload.records.find((r) => r.celex === noCorpusCelex);
+  assert.equal(untouched.title, "Never Touched");
+  assert.equal(untouched.excerpt, "Never touched excerpt.");
+
+  // One record had a corpus file and re-derived cleanly, the other had none —
+  // not a complete rederive, so the stamp must merge onto the prior "21".
+  assert.deepEqual(payload.parserVersion, [21, await getCurrentParserVersion()]);
+});

--- a/backend/search/definition-index-build.js
+++ b/backend/search/definition-index-build.js
@@ -13,6 +13,7 @@ const {
   stripCompleteUppercaseAnnexes,
   writeArtifactAtomic,
 } = require("./citation-graph-build");
+const { getCurrentParserVersion, normalizeParserStamp } = require("./parser-stamp");
 
 const gunzip = promisify(zlib.gunzip);
 const INDEX_VERSION = 2;
@@ -339,10 +340,28 @@ function runDefinitionWorker(files, options = {}) {
   });
 }
 
-async function readCheckpoint(checkpointPath, fsApi = fs) {
+async function readCheckpoint(checkpointPath, fsApi = fs, currentParserVersion = null, log = null) {
   try {
     const checkpoint = JSON.parse(await fsApi.readFile(checkpointPath, "utf8"));
-    return checkpoint.indexVersion === INDEX_VERSION ? checkpoint : null;
+    if (checkpoint.indexVersion !== INDEX_VERSION) return null;
+    // A checkpoint's shards were produced by whatever parser was current when it was
+    // written. Resuming from a checkpoint stamped with an older (or absent, i.e.
+    // pre-this-change) parser version would silently merge stale shards into what is
+    // reported as a current-parser artifact. Only an exact match may resume.
+    const checkpointVersions = normalizeParserStamp(checkpoint.parserVersion);
+    const currentVersions = normalizeParserStamp(currentParserVersion);
+    const matches = checkpointVersions.length > 0 && currentVersions.length > 0
+      && checkpointVersions.length === currentVersions.length
+      && checkpointVersions.every((version, index) => version === currentVersions[index]);
+    if (!matches) {
+      if (log) {
+        log(checkpointVersions.length === 0
+          ? `[definitions] Discarding checkpoint with no recorded parser version (current parser is v${currentVersions.join(",")}); starting clean`
+          : `[definitions] Discarding checkpoint from parser v${checkpointVersions.join(",")} (current parser is v${currentVersions.join(",")}); starting clean`);
+      }
+      return null;
+    }
+    return checkpoint;
   } catch (error) {
     if (error.code === "ENOENT") return null;
     throw error;
@@ -356,13 +375,20 @@ async function buildDefinitionIndex(options = {}) {
   const files = dedupeCorpusFiles(filterCorpusFiles(allFiles, options));
   const outputPath = options.outputPath === undefined ? DEFAULT_OUTPUT_PATH : options.outputPath;
   const checkpointPath = options.checkpointPath || (outputPath ? `${outputPath}.checkpoint` : null);
-  const checkpoint = checkpointPath ? await readCheckpoint(checkpointPath, fsApi) : null;
+  const log = options.progress ? (options.log || console.log) : null;
+  const currentParserVersion = options.currentParserVersion !== undefined
+    ? options.currentParserVersion : await getCurrentParserVersion();
+  // Discarding a checkpoint silently throws away hours of work; say so even
+  // when the caller did not ask for progress output.
+  const checkpointNotice = options.log || console.warn;
+  const checkpoint = checkpointPath
+    ? await readCheckpoint(checkpointPath, fsApi, currentParserVersion, checkpointNotice)
+    : null;
   const processed = new Set(checkpoint?.processedCelex || []);
   const shards = [...(checkpoint?.shards || [])];
   const pending = files.filter((file) => !processed.has(celexForCorpusFile(file)));
   const batchSize = options.batchSize || DEFAULT_BATCH_SIZE;
   const workerRunner = options.workerRunner || runDefinitionWorker;
-  const log = options.progress ? (options.log || console.log) : null;
   let resolverIndex = options.resolverIndex || null;
   if (!resolverIndex) {
     try {
@@ -377,7 +403,7 @@ async function buildDefinitionIndex(options = {}) {
       const shard = await workerRunner(batch, { ...options, resolverIndex });
       shards.push(shard);
       for (const file of batch) processed.add(celexForCorpusFile(file));
-      if (checkpointPath) await writeArtifactAtomic(checkpointPath, { indexVersion: INDEX_VERSION, processedCelex: [...processed], shards }, fsApi);
+      if (checkpointPath) await writeArtifactAtomic(checkpointPath, { indexVersion: INDEX_VERSION, parserVersion: currentParserVersion, processedCelex: [...processed], shards }, fsApi);
       if (log) log(`[definitions] ${processed.size}/${files.length} laws completed; definitions=${shards.reduce((sum, item) => sum + Number(item.stats?.definitions || 0), 0)}`);
     } catch (error) {
       if (batch.length > 1) {
@@ -389,7 +415,7 @@ async function buildDefinitionIndex(options = {}) {
       const celex = celexForCorpusFile(batch[0]);
       shards.push({ parserVersion: null, stats: { corpusFiles: 1, failures: 1 }, failures: [{ celex, type: "worker_failure", error: String(error?.message || error) }], occurrences: [] });
       processed.add(celex);
-      if (checkpointPath) await writeArtifactAtomic(checkpointPath, { indexVersion: INDEX_VERSION, processedCelex: [...processed], shards }, fsApi);
+      if (checkpointPath) await writeArtifactAtomic(checkpointPath, { indexVersion: INDEX_VERSION, parserVersion: currentParserVersion, processedCelex: [...processed], shards }, fsApi);
     }
   }
 

--- a/backend/search/definition-index-build.test.js
+++ b/backend/search/definition-index-build.test.js
@@ -119,6 +119,7 @@ test("resumable build reads its checkpoint and only runs pending laws", async ()
   };
   await fs.writeFile(checkpointPath, JSON.stringify({
     indexVersion: INDEX_VERSION,
+    parserVersion: 22,
     processedCelex: ["32020R0001"],
     shards: [completedShard],
   }));
@@ -127,6 +128,7 @@ test("resumable build reads its checkpoint and only runs pending laws", async ()
     files: ["/laws/2020/32020R0001.xml.gz", "/laws/2021/32021R0002.xml.gz"],
     outputPath,
     batchSize: 1,
+    currentParserVersion: 22,
     now: () => new Date("2026-01-01T00:00:00.000Z"),
     workerRunner: async (files) => {
       seen.push(...files);
@@ -142,6 +144,80 @@ test("resumable build reads its checkpoint and only runs pending laws", async ()
   assert.equal(artifact.stats.uniqueTerms, 1);
   await assert.rejects(fs.access(checkpointPath));
   assert.deepEqual(JSON.parse(await fs.readFile(outputPath, "utf8")), artifact);
+});
+
+test("a checkpoint from a different parser version is discarded, not resumed", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "definition-index-"));
+  const outputPath = path.join(directory, "definitions.json");
+  const checkpointPath = `${outputPath}.checkpoint`;
+  const completedShard = {
+    parserVersion: 18,
+    stats: { corpusFiles: 1, parsedLaws: 1, definitions: 0 },
+    failures: [], occurrences: [],
+  };
+  await fs.writeFile(checkpointPath, JSON.stringify({
+    indexVersion: INDEX_VERSION,
+    parserVersion: 18,
+    processedCelex: ["32020R0001"],
+    shards: [completedShard],
+  }));
+  const seen = [];
+  const logs = [];
+  await buildDefinitionIndex({
+    files: ["/laws/2020/32020R0001.xml.gz", "/laws/2021/32021R0002.xml.gz"],
+    outputPath,
+    batchSize: 1,
+    currentParserVersion: 22,
+    progress: true,
+    log: (message) => logs.push(message),
+    now: () => new Date("2026-01-01T00:00:00.000Z"),
+    workerRunner: async (files) => {
+      seen.push(...files);
+      return {
+        parserVersion: 22,
+        stats: { corpusFiles: 1, parsedLaws: 1, definitions: 0 }, failures: [], occurrences: [],
+      };
+    },
+  });
+  // Both files were reprocessed from scratch: the stale-parser checkpoint was discarded.
+  assert.deepEqual(seen.sort(), ["/laws/2020/32020R0001.xml.gz", "/laws/2021/32021R0002.xml.gz"]);
+  assert.ok(logs.some((message) => message.includes("Discarding checkpoint from parser v18")));
+});
+
+test("a legacy checkpoint with no recorded parser version is discarded, not resumed", async () => {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "definition-index-"));
+  const outputPath = path.join(directory, "definitions.json");
+  const checkpointPath = `${outputPath}.checkpoint`;
+  const completedShard = {
+    parserVersion: 17,
+    stats: { corpusFiles: 1, parsedLaws: 1, definitions: 0 },
+    failures: [], occurrences: [],
+  };
+  await fs.writeFile(checkpointPath, JSON.stringify({
+    indexVersion: INDEX_VERSION,
+    processedCelex: ["32020R0001"],
+    shards: [completedShard],
+  }));
+  const seen = [];
+  const logs = [];
+  await buildDefinitionIndex({
+    files: ["/laws/2020/32020R0001.xml.gz", "/laws/2021/32021R0002.xml.gz"],
+    outputPath,
+    batchSize: 1,
+    currentParserVersion: 22,
+    progress: true,
+    log: (message) => logs.push(message),
+    now: () => new Date("2026-01-01T00:00:00.000Z"),
+    workerRunner: async (files) => {
+      seen.push(...files);
+      return {
+        parserVersion: 22,
+        stats: { corpusFiles: 1, parsedLaws: 1, definitions: 0 }, failures: [], occurrences: [],
+      };
+    },
+  });
+  assert.deepEqual(seen.sort(), ["/laws/2020/32020R0001.xml.gz", "/laws/2021/32021R0002.xml.gz"]);
+  assert.ok(logs.some((message) => message.includes("Discarding checkpoint with no recorded parser version")));
 });
 
 test("CLI accepts corpus build controls", () => {


### PR DESCRIPTION
Stacked on #183. Ships the one-off pass that closes [#180](https://github.com/maastrichtlawtech/legalviz.eu/issues/180): the monthly refresh only ever *adds* acts, so a parser fix reaches new acts and nothing else.

## What's here

- **`build-cache-from-corpus.js --rederive`** — the only offline path that can do this. `backfill --force` harvests over SPARQL, and `reEnrichCurrentCache` falls back to the network on a corpus miss. No year floor; the merge inverts for the two parser-derived fields (`title`, `excerpt`) while EuroVoc, in-force, `date` and the alias fields are preserved.
- **`rederive-parser-assets.yml`** — one job per asset so a timeout costs one rebuild rather than four, fresh output paths throughout, and the freshness guard with no escape hatch gating one complete data release, one fulltext release, and a single PR bumping both Dockerfile pins.
- **Definitions checkpoint keyed to the parser version** that wrote it, so a leftover checkpoint cannot merge stale shards into a rebuild and have the result stamped clean.

## Stamp honesty

A bare current-version stamp is claimed only when nothing stale was left behind: no failed parse, no corpus-covered record missed by the run, and no record still carrying an excerpt that no corpus file could refresh. Records outside the corpus that never held parser output are **not** a gap — there are tens of thousands of them, and counting them would put a bare stamp out of reach forever, leaving the guard permanently red.

## Review

A Codex (`gpt-5.6-sol`) pass found six defects, each verified against the source before fixing — see the second commit. The one that mattered most: a failed worker batch writes no partial file, so its records arrived as neither re-derived nor failed and the stamp could claim the current version over old-parser content. Coverage is now measured against the corpus rather than reconstructed from batch bookkeeping.

Thresholds are calibrated against the currently published artifacts (citation-graph `parseFailures: 0`, definitions `failures: 0`; the graph's `failures: 66` counts deliberate oversized skips, which is why the gate reads `parseFailures`).

## Not yet measured

The re-derive is a cold pass over ~80k corpus files per asset, and the citation graph has no resumable checkpoint. A `dry_run: true` dispatch is the next step and will give the real wall-clock shape; if it looks marginal, running citation-graph locally and uploading it is the fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)