### PR TITLE
Fulltext build: index the HTML corpus (--corpusDir discovery bug)

### DIFF
--- a/.github/workflows/rederive-parser-assets.yml
+++ b/.github/workflows/rederive-parser-assets.yml
@@ -627,7 +627,7 @@ jobs:
           pnpm rebuild better-sqlite3
           node -e "const D = require('better-sqlite3'); new D(':memory:').close()"
 
-      - name: Download corpus and build the merged fulltext corpus tree
+      - name: Download corpus
         shell: bash
         run: |
           set -euo pipefail
@@ -643,9 +643,6 @@ jobs:
           done
           test -d backend/search/data/laws
           test -d backend/search/data/laws-html
-          mkdir -p backend/search/data/fulltext-corpus
-          cp -al backend/search/data/laws/. backend/search/data/fulltext-corpus/
-          cp -al backend/search/data/laws-html/. backend/search/data/fulltext-corpus/
 
       - name: Download search-cache resolver input
         shell: bash
@@ -715,7 +712,7 @@ jobs:
             "${{ github.workspace }}/.github/scripts/memory-watch.sh" fulltext -- \
             timeout --signal=INT 300m \
             node --max-old-space-size=3072 search/fulltext-index-build.js \
-              --corpusDir search/data/fulltext-corpus \
+              --corpusDir search/data/laws \
               --pool 2 \
               --workerHeapMb 512 \
               --out ../rederive-output/fulltext.sqlite \

--- a/.github/workflows/refresh-fulltext.yml
+++ b/.github/workflows/refresh-fulltext.yml
@@ -142,9 +142,6 @@ jobs:
           tar -xf refresh-inputs/laws-html.tar -C backend/search/data
           test -d backend/search/data/laws
           test -d backend/search/data/laws-html
-          mkdir -p backend/search/data/fulltext-corpus
-          cp -al backend/search/data/laws/. backend/search/data/fulltext-corpus/
-          cp -al backend/search/data/laws-html/. backend/search/data/fulltext-corpus/
 
       - name: Restore and validate the current fulltext index
         shell: bash
@@ -265,7 +262,7 @@ jobs:
           SEARCH_CACHE_PATH="$PWD/search/data/search-cache.json.gz" \
             timeout --signal=INT 250m \
             node --max-old-space-size=3072 search/fulltext-index-build.js \
-              --corpusDir search/data/fulltext-corpus \
+              --corpusDir search/data/laws \
               --pool 2 \
               --workerHeapMb 512 \
               --out ../refresh-output/fulltext.sqlite \


### PR DESCRIPTION
Closes #186 (route 2 — the class fix). Route 1 (re-harvesting FMX for the 15 recoverable acts) stays independent and is not part of this PR.

## The bug

`listAllCorpusFiles()` (`backend/search/citation-graph-build.js:62`) lists `.xml.gz` from `--corpusDir`, then adds `.html.gz` from a **sibling** directory that `htmlCorpusDirFor()` resolves only when `basename(corpusDir) === "laws"`.

Both fulltext workflows merged the two corpus trees into one directory and passed it as `--corpusDir search/data/fulltext-corpus`. Basename isn't `laws`, so sibling resolution returned null and **zero HTML paths were ever listed** — the logged `universe=80536 acts; 28009 corpus files matched` is exactly the Formex count. All 52,523 HTML-only corpus acts have therefore never been indexed, and the 40 acts from #186 fell out at the cold rebuild.

Everything downstream was already HTML-ready: `dedupeCorpusFiles()` keeps HTML-only acts (FMX preferred per CELEX) and `buildFulltextShard()` parses them through `parseEurlexHtmlToCombined`. Only discovery was broken.

## The fix

Workflow-only, no product code:

- Delete the `mkdir/cp -al` merge into `fulltext-corpus` in both workflows (the trees are extracted side by side anyway, so the merge bought nothing).
- Point the build at `--corpusDir search/data/laws`, exactly like the citation-graph and definitions builds already do.

No schema change (`FULLTEXT_SCHEMA_VERSION` stays 1), no parser-version implications beyond what's stamped per row today.

## What to expect after merge (heal mechanics)

- Healing is incremental and automatic: `doneCelex` skips already-indexed acts, interrupted runs checkpoint cleanly, nothing drops rows.
- Backlog ≈ 52.5k mostly-small pre-2000 HTML acts ≈ 3–4 h of parse time at the current rate (~106 min / 28k FMX acts). Each run has a 250-min build budget, so expect **1–2 runs** to converge — dispatch manually back-to-back to finish within a day rather than waiting for the monthly train (`refresh-corpus` cron on the 5th → data → fulltext).
- Steady-state cost afterwards is unchanged; new HTML-only acts should stay rare.
- Permanent changes: cold rebuilds ~2–3x longer (~5 h, leaning on checkpoint/resume or a raised timeout), release artifact roughly doubles (currently 157 MB gz), index grows to ~80k acts.

## How to test (workflow deploy)

1. **Merge this PR**, then trigger a measured dry run: `gh workflow run refresh-fulltext` (or *Run workflow* in the Actions tab) **without** checking the publish input. It downloads the corpus + current index and rebuilds into an artifact without touching any release.
2. **Watch the discovery line** in the "Build" step log:
   `[fulltext] universe=… acts; NNNNN corpus files matched`
   Before this PR it printed `28009`; expected now ≈ **80,5xx** (28,010 Formex + ~52.5k HTML).
3. **Confirm progress counters**: the step log's periodic lines show `parsed` climbing with `failures` near zero. A first run will likely hit its 250-min budget mid-backlog — that's by design ("unfinished backlog ends this step cleanly"), the partial index is uploaded as a checkpoint, and the next run resumes. Dispatch again until the summary reports the full set.
4. **Validate the result** on the finished artifact:
   - Summary line: `[fulltext] done: N units … across ~80,xxx acts`.
   - Spot-check the headline acts from #186 are indexed from both variants:
     ```sql
     SELECT unit_type, COUNT(*) FROM units WHERE celex='32014R0833' GROUP BY 1;
     -- and one permanently-HTML act:
     SELECT COUNT(*) FROM units WHERE celex='32010D0144';
     ```
   - Manifest sanity: `act_count` ≈ 80k, `parser_version` unchanged, note new `bytes` vs the current 680 MB / 157 MB gz for sizing the release asset.
5. **Publish deliberately**: once numbers look right, dispatch with `publish: true` (or let the next scheduled train do it), bump `FULLTEXT_RELEASE_TAG` in `backend/Dockerfile` in the same commit per the release discipline, deploy, and confirm `api.legalviz.eu/api/search` finds body text from a previously unindexed act (e.g., search terms unique to `32010D0144`).
6. **Rederive path** (optional check): the same fix applies to `rederive-parser-assets.yml`; the next asset rederive produces a full-coverage candidate instead of a 28k one.

## Deliberately out of scope

- Re-harvesting FMX for the 15 recoverable acts of #186 (`32014R0833` et al.) — they'll re-enter the index as HTML through this fix; upgrading them to Formex parsing is a separate corpus-repair chore at the next republish.
- Any timeout/pool retuning — measure first from the test runs above; raise the 250-min budget only if convergence needs more than two runs.
