### PR TITLE
Surface IndexedDB meta write failures; version-key digest caches; drop dead exports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,8 @@ Nearly every expensive operation — Formex parsing, TF‑IDF recital mapping, C
 | Offline CJEU detail shape (declarations, `articleRefs`) | `CASE_LAW_CACHE_FILE` → `case-law-cache-vN.json` (keep the offline legacy-migration path) | `backend/shared/law-queries.js` |
 | Recital-title prompt/output format | `CACHE_VERSION` | `backend/shared/recital-title-service.js` |
 | Law-summary cache / JSON schema / prompt | `cacheVersion` / `schemaVersion` / `promptVersion` | `backend/shared/law-summary-cache-version.json` (shared by backend and frontend) |
-| Article-digest JSON schema / prompt | `SCHEMA_VERSION` / `PROMPT_VERSION` | `backend/shared/article-digest-service.js` |
-| Whole-law digest JSON schema / prompt | `SCHEMA_VERSION` / `PROMPT_VERSION` | `backend/shared/case-law-digest-service.js` |
+| Article-digest JSON schema / prompt | `articleDigest.schemaVersion` / `promptVersion` | `backend/shared/digest-cache-version.json` (shared by backend and frontend) |
+| Whole-law digest JSON schema / prompt | `caseLawDigest.schemaVersion` / `promptVersion` | `backend/shared/digest-cache-version.json` (shared by backend and frontend) |
 | Persisted analytics shape (`analytics.json` fields) | `ANALYTICS_SCHEMA_VERSION` | `backend/shared/analytics.js` |
 | Runtime SQLite tables/indexes | `SQLITE_SCHEMA_VERSION` | `backend/search/legal-cache-store.js`, `backend/search/build-sqlite-data.js`, and `backend/search/citation-graph-store.js` (three copies, kept in lock-step) |
 | Full-text `units` schema / builder output shape | `FULLTEXT_SCHEMA_VERSION` | `backend/search/fulltext-index-build.js`, with a lock-step copy in `backend/search/legal-cache-store.js` |
@@ -80,9 +80,11 @@ The full-text index follows the same republish discipline as the data caches —
 
 `PARSER_VERSION` lives in the Formex parser but versions **both** parsers' output. `eurlex-html-parser.js` reads a different document format, yet imports its cross-reference grammar (`extractCrossRefsFromText` and friends) straight from `fmxParser.mjs`, and its definition grammar (`buildMeansRegex` and the other term/definition regex builders) from `formex-parser/languages.mjs` — so a change in either changes what HTML laws yield too, and both parsers stamp the same constant onto their result. Bump it for a fix in *any* of the three files; there is deliberately no second constant to keep in sync.
 
-`PARSER_VERSION` is **shared with the frontend** (imported into `src/utils/formexApi.js`), so bumping it re-parses the browser IndexedDB cache too. When you bump `CASE_LAW_CACHE_FILE`, also update `CASE_LAW_CACHE_VERSION` in `article-digest-service.js` **and** `case-law-digest-service.js` — they are kept in lock-step so digests regenerate when enrichment shape changes.
+`PARSER_VERSION` is **shared with the frontend** (imported into `src/utils/formexApi.js`), so bumping it re-parses the browser IndexedDB cache too. When you bump `CASE_LAW_CACHE_FILE`, also update `caseLawCacheVersion` in `backend/shared/digest-cache-version.json` — both digest services import it from there, so they can never drift and digests regenerate when enrichment shape changes.
 
 The law-summary cache versions are also shared with the frontend through `backend/shared/law-summary-cache-version.json`. `fetchLawSummary` includes all three values in its IndexedDB key, so bumping any backend summary cache/schema/prompt version makes browsers fetch the regenerated summary immediately after loading the updated frontend.
+
+The article and whole-law digest versions are shared with the frontend the same way through `backend/shared/digest-cache-version.json`: `fetchArticleCaseLawDigest` / `fetchCaseLawDigest` fold each feature's `schemaVersion`/`promptVersion` pair into their IndexedDB keys (and validate the `caseLawCacheVersion` stamp), so a backend digest prompt/schema bump stops browsers serving the stale 7-day-cached copy.
 
 **Frontend, browser** (`src/`):
 

--- a/backend/shared/article-digest-service.js
+++ b/backend/shared/article-digest-service.js
@@ -10,11 +10,16 @@ const {
   normalizeCites,
 } = require('./ai-digest-utils');
 
+const {
+  caseLawCacheVersion: CASE_LAW_CACHE_VERSION,
+  articleDigest: {
+    schemaVersion: SCHEMA_VERSION,
+    promptVersion: PROMPT_VERSION,
+  },
+} = require('./digest-cache-version.json');
+
 const CACHE_FILE = 'article-digest-cache-v1.json';
 const CACHE_VERSION = 1;
-const SCHEMA_VERSION = 2;
-const PROMPT_VERSION = 1;
-const CASE_LAW_CACHE_VERSION = 'case-law-cache-v5';
 const MAX_ARTICLE_TEXT_CHARS = 5500;
 const MAX_DECLARATION_CHARS = 1800;
 

--- a/backend/shared/case-law-digest-service.js
+++ b/backend/shared/case-law-digest-service.js
@@ -11,14 +11,16 @@ const {
   normalizeCites,
 } = require('./ai-digest-utils');
 
+const {
+  caseLawCacheVersion: CASE_LAW_CACHE_VERSION,
+  caseLawDigest: {
+    schemaVersion: SCHEMA_VERSION,
+    promptVersion: PROMPT_VERSION,
+  },
+} = require('./digest-cache-version.json');
+
 const CACHE_FILE = 'case-law-digest-cache-v1.json';
 const CACHE_VERSION = 1;
-const SCHEMA_VERSION = 1;
-const PROMPT_VERSION = 1;
-// Kept in lock-step with law-queries' CASE_LAW_CACHE_FILE so the digest is
-// regenerated whenever the underlying enrichment (declarations, article refs)
-// changes shape.
-const CASE_LAW_CACHE_VERSION = 'case-law-cache-v5';
 
 const MAX_CASES = 60;
 const MAX_DECLARATION_CHARS = 1200;

--- a/backend/shared/digest-cache-version.json
+++ b/backend/shared/digest-cache-version.json
@@ -1,0 +1,11 @@
+{
+  "caseLawCacheVersion": "case-law-cache-v5",
+  "articleDigest": {
+    "schemaVersion": 2,
+    "promptVersion": 1
+  },
+  "caseLawDigest": {
+    "schemaVersion": 1,
+    "promptVersion": 1
+  }
+}

--- a/src/utils/caseLawCache.js
+++ b/src/utils/caseLawCache.js
@@ -19,7 +19,3 @@ export function loadCaseLaw(celex) {
   }
   return cache.get(celex);
 }
-
-export function peekCaseLaw(celex) {
-  return cache.get(celex) || null;
-}

--- a/src/utils/formexApi.cacheEnvelopes.test.js
+++ b/src/utils/formexApi.cacheEnvelopes.test.js
@@ -225,11 +225,10 @@ describe("parsed-law envelope (PARSER_VERSION)", () => {
   });
 
   it("ignores a poisoned raw entry that is not a Formex document", async () => {
-    const { getCachedFormex, getCachedLawPayload, hasCachedFormex } = await importFormexApi();
+    const { getCachedFormex, getCachedLawPayload } = await importFormexApi();
     await seedCache(CACHE_KEY, HTML_ERROR_PAGE);
 
     expect(await getCachedFormex(CELEX, "EN")).toBeNull();
-    expect(await hasCachedFormex(CELEX, "EN")).toBe(false);
     expect(await getCachedLawPayload(CELEX, "EN")).toBeNull();
   });
 
@@ -387,14 +386,23 @@ describe("law-text fetch body validation", () => {
 describe("API JSON envelope (API_JSON_CACHE_VERSION)", () => {
   const CITED_BY_KEY = `${CELEX}_cited_by_act`;
 
-  async function seedApiJson({ version, cachedAt = Date.now(), payload = { citingLaws: ["cached"] } }) {
+  const ACT_CITED_BY_PAYLOAD = {
+    celex: CELEX,
+    actOnly: { provisions: 1, judgments: 0, total: 1 },
+    article: { provisions: 0, judgments: 0, total: 0 },
+    articles: [],
+    citingLaws: { total: 1, laws: [{ celex: "32020R0002", title: "Other Regulation", date: "2020-01-01", provisions: 1 }] },
+    totals: { provisions: 1, judgments: 0, total: 1 },
+  };
+
+  async function seedApiJson({ version, cachedAt = Date.now(), payload = ACT_CITED_BY_PAYLOAD }) {
     await seedCache(CITED_BY_KEY, { format: "api-json-v1", version, cachedAt, payload });
   }
 
   async function currentApiJsonVersion() {
     // Read it back off a freshly written envelope rather than hard-coding it,
     // so a bump doesn't need this test edited.
-    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ citingLaws: ["network"] })));
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse(ACT_CITED_BY_PAYLOAD)));
     const { fetchLawCitedBy } = await importFormexApi();
     await fetchLawCitedBy(CELEX);
     const written = await readCache(CITED_BY_KEY);
@@ -411,7 +419,7 @@ describe("API JSON envelope (API_JSON_CACHE_VERSION)", () => {
     const { fetchLawCitedBy } = await importFormexApi();
 
     const result = await fetchLawCitedBy(CELEX);
-    expect(result).toMatchObject({ citingLaws: ["cached"], localCached: true });
+    expect(result).toMatchObject({ citingLaws: { laws: [{ celex: "32020R0002" }] }, localCached: true });
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -419,11 +427,11 @@ describe("API JSON envelope (API_JSON_CACHE_VERSION)", () => {
     const version = await currentApiJsonVersion();
     await seedApiJson({ version: version - 1 });
 
-    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ citingLaws: ["network"] }));
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(ACT_CITED_BY_PAYLOAD));
     vi.stubGlobal("fetch", fetchMock);
     const { fetchLawCitedBy } = await importFormexApi();
 
-    expect(await fetchLawCitedBy(CELEX)).toMatchObject({ citingLaws: ["network"] });
+    expect(await fetchLawCitedBy(CELEX)).toMatchObject({ citingLaws: { laws: [{ celex: "32020R0002" }] } });
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
@@ -432,11 +440,11 @@ describe("API JSON envelope (API_JSON_CACHE_VERSION)", () => {
     const eightDaysAgo = Date.now() - 8 * 24 * 60 * 60 * 1000;
     await seedApiJson({ version, cachedAt: eightDaysAgo });
 
-    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ citingLaws: ["network"] }));
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse(ACT_CITED_BY_PAYLOAD));
     vi.stubGlobal("fetch", fetchMock);
     const { fetchLawCitedBy } = await importFormexApi();
 
-    expect(await fetchLawCitedBy(CELEX)).toMatchObject({ citingLaws: ["network"] });
+    expect(await fetchLawCitedBy(CELEX)).toMatchObject({ citingLaws: { laws: [{ celex: "32020R0002" }] } });
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 
@@ -447,7 +455,7 @@ describe("API JSON envelope (API_JSON_CACHE_VERSION)", () => {
     await seedApiJson({ version, cachedAt: eightDaysAgo });
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ error: "boom" }, { ok: false, status: 503 })));
     const failing = await importFormexApi();
-    expect(await failing.fetchLawCitedBy(CELEX)).toMatchObject({ citingLaws: ["cached"], localCached: true });
+    expect(await failing.fetchLawCitedBy(CELEX)).toMatchObject({ citingLaws: { laws: [{ celex: "32020R0002" }] }, localCached: true });
 
     await seedApiJson({ version, cachedAt: eightDaysAgo });
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({ error: "gone" }, { ok: false, status: 404 })));

--- a/src/utils/formexApi.cacheHygiene.test.js
+++ b/src/utils/formexApi.cacheHygiene.test.js
@@ -109,7 +109,6 @@ describe("formexApi cache hygiene", () => {
       // Nothing was written to the cache.
       expect(await getLawEntry(indexedDb, CACHE_KEY)).toBeUndefined();
       expect(await api.getCachedFormex("32016R0679", "EN")).toBeNull();
-      expect(await api.hasCachedFormex("32016R0679", "EN")).toBe(false);
     });
 
     it("rejects a JSON envelope that does not contain Formex XML without caching it", async () => {
@@ -151,7 +150,6 @@ describe("formexApi cache hygiene", () => {
 
       // Every read path must agree with getCachedLawPayload: miss, not hit.
       expect(await api.getCachedFormex("32016R0679", "EN")).toBeNull();
-      expect(await api.hasCachedFormex("32016R0679", "EN")).toBe(false);
       expect(await api.getCachedLawPayload("32016R0679", "EN")).toBeNull();
 
       // fetchFormex must not serve the poisoned string; it refetches and

--- a/src/utils/formexApi.indexedDb.test.js
+++ b/src/utils/formexApi.indexedDb.test.js
@@ -68,6 +68,65 @@ describe("Formex IndexedDB connection lifecycle", () => {
   });
 });
 
+describe("law meta persistence failures", () => {
+  it("rejects when the meta store transaction errors instead of resolving silently", async () => {
+    const putError = new Error("quota exceeded");
+    const store = {
+      get: vi.fn(() => {
+        const req = { result: null };
+        queueMicrotask(() => req.onsuccess?.());
+        return req;
+      }),
+      put: vi.fn(() => {
+        tx.error = putError;
+        queueMicrotask(() => tx.onerror?.());
+        return {};
+      }),
+    };
+    const tx = {
+      objectStore: () => store,
+      oncomplete: null,
+      onerror: null,
+      onabort: null,
+    };
+    const db = { transaction: vi.fn(() => tx) };
+    const request = { result: db };
+    vi.stubGlobal("indexedDB", { open: vi.fn(() => request) });
+
+    const { upsertLawMeta } = await importFormexApi();
+    const result = upsertLawMeta("32016R0679", { label: "GDPR" });
+
+    request.onsuccess();
+    await expect(result).rejects.toMatchObject({ message: "quota exceeded" });
+  });
+
+  it("rejects when the meta store write cannot be set up", async () => {
+    const store = {
+      get: vi.fn(() => {
+        const req = { result: null };
+        queueMicrotask(() => req.onsuccess?.());
+        return req;
+      }),
+      put: vi.fn(),
+    };
+    const tx = { objectStore: () => store };
+    const db = {
+      transaction: vi.fn((name, mode) => {
+        if (mode === "readwrite") throw new Error("InvalidStateError: database closed");
+        return tx;
+      }),
+    };
+    const request = { result: db };
+    vi.stubGlobal("indexedDB", { open: vi.fn(() => request) });
+
+    const { upsertLawMeta } = await importFormexApi();
+    const result = upsertLawMeta("32016R0679", { label: "GDPR" });
+
+    request.onsuccess();
+    await expect(result).rejects.toMatchObject({ message: "InvalidStateError: database closed" });
+  });
+});
+
 describe("law summary cache versioning", () => {
   it("uses the backend cache, schema, and prompt versions in the browser key", async () => {
     const { makeLawSummaryCacheKey } = await importFormexApi();
@@ -91,6 +150,41 @@ describe("law summary cache versioning", () => {
 
     const { fetchLawSummary } = await importFormexApi();
     await expect(fetchLawSummary("32016R0679")).rejects.toMatchObject({
+      code: "cache_version_mismatch",
+      status: 409,
+    });
+  });
+});
+
+describe("AI digest cache versioning", () => {
+  it("folds the article-digest schema/prompt versions into the browser key", async () => {
+    const { makeArticleCaseLawDigestCacheKey } = await importFormexApi();
+
+    expect(makeArticleCaseLawDigestCacheKey("32016R0679", "6", "EN"))
+      .toBe("32016R0679_ENG_digest_6_schema2_prompt1");
+  });
+
+  it("folds the whole-law digest schema/prompt versions into the browser key", async () => {
+    const { makeCaseLawDigestCacheKey } = await importFormexApi();
+
+    expect(makeCaseLawDigestCacheKey("32016R0679", "EN"))
+      .toBe("32016R0679_ENG_case_law_digest_schema1_prompt1");
+  });
+
+  it("does not cache a digest stamped by a mismatched case-law enrichment version", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        celex: "32016R0679",
+        articleNumber: "6",
+        lang: "ENG",
+        caseLawCacheVersion: "case-law-cache-v4",
+        digest: { summary: "stale", themes: [], noCaseLaw: false },
+      }),
+    }));
+
+    const { fetchArticleCaseLawDigest } = await importFormexApi();
+    await expect(fetchArticleCaseLawDigest("32016R0679", "6", "EN")).rejects.toMatchObject({
       code: "cache_version_mismatch",
       status: 409,
     });

--- a/src/utils/formexApi.js
+++ b/src/utils/formexApi.js
@@ -7,6 +7,7 @@
 
 import { PARSER_VERSION, parseFmxToCombined, isFmxDocument } from "./fmxParser.js";
 import lawSummaryCacheVersion from "../../backend/shared/law-summary-cache-version.json" with { type: "json" };
+import digestCacheVersion from "../../backend/shared/digest-cache-version.json" with { type: "json" };
 
 export const API_BASE = (() => {
   if (typeof import.meta !== "undefined" && import.meta.env?.VITE_FORMEX_API_BASE) {
@@ -450,19 +451,20 @@ async function metaGet(celex) {
   }
 }
 
+// Persists user data (library entries, resume positions), so failures must
+// surface as rejections rather than silently masquerading as success — a save
+// that vanishes under quota pressure/private browsing would otherwise be
+// indistinguishable from one that succeeded.
 async function metaPut(value) {
-  try {
-    const db = await openDb();
-    return new Promise((resolve) => {
-      const tx = db.transaction(META_STORE_NAME, "readwrite");
-      const store = tx.objectStore(META_STORE_NAME);
-      store.put(value);
-      tx.oncomplete = () => resolve(value);
-      tx.onerror = () => resolve(value);
-    });
-  } catch {
-    return value;
-  }
+  const db = await openDb();
+  return new Promise((resolve, reject) => {
+    const tx = db.transaction(META_STORE_NAME, "readwrite");
+    const store = tx.objectStore(META_STORE_NAME);
+    store.put(value);
+    tx.oncomplete = () => resolve(value);
+    tx.onerror = () => reject(tx.error || new Error("IndexedDB meta write failed"));
+    tx.onabort = () => reject(tx.error || new Error("IndexedDB meta write aborted"));
+  });
 }
 
 async function metaDelete(celex) {
@@ -812,7 +814,9 @@ export async function fetchFormex(celex, lang = "EN") {
 
     if (hasContent) {
       await cacheSet(cacheKey, xmlText);
-      await upsertLawMeta(celex, { cachedAt: Date.now() });
+      await upsertLawMeta(celex, { cachedAt: Date.now() }).catch((err) => {
+        console.warn(`[FormexAPI] Failed to persist library metadata for ${celex}:`, err);
+      });
       await pruneCacheIfNeeded(celex, PROTECTED_BUNDLED_CELEXES);
       if (typeof window !== "undefined") {
         window.dispatchEvent(new CustomEvent("legalviz-formex-cache-updated", {
@@ -833,10 +837,6 @@ export async function getCachedFormex(celex, lang = "EN") {
   if (typeof cached === "string") return isFmxDocument(cached) ? cached : null;
   if (isCombinedLawEnvelope(cached) && cached.rawXml) return cached.rawXml;
   return null;
-}
-
-export async function hasCachedFormex(celex, lang = "EN") {
-  return (await getCachedFormex(celex, lang)) != null;
 }
 
 export async function getCachedLawPayload(celex, lang = "EN") {
@@ -1026,14 +1026,56 @@ export async function fetchLawSummary(celex) {
   }));
 }
 
+export function makeArticleCaseLawDigestCacheKey(celex, articleNumber, lang = "EN") {
+  const { schemaVersion, promptVersion } = digestCacheVersion.articleDigest;
+  return `${celex}_${toApiLang(lang)}_digest_${articleNumber}_schema${schemaVersion}_prompt${promptVersion}`;
+}
+
+export function makeCaseLawDigestCacheKey(celex, lang = "EN") {
+  const { schemaVersion, promptVersion } = digestCacheVersion.caseLawDigest;
+  return `${celex}_${toApiLang(lang)}_case_law_digest_schema${schemaVersion}_prompt${promptVersion}`;
+}
+
+// Digest responses don't stamp schema/prompt versions — the key above folds
+// them in — but they do stamp the case-law enrichment version, so a stale
+// enrichment shape is still rejected rather than served from cache.
+function isCurrentArticleCaseLawDigestPayload(payload) {
+  return payload?.caseLawCacheVersion === digestCacheVersion.caseLawCacheVersion;
+}
+
+function isCurrentCaseLawDigestPayload(payload) {
+  return payload?.caseLawCacheVersion === digestCacheVersion.caseLawCacheVersion;
+}
+
+// Cited-by payloads carry no version fields, so their keys are not versioned;
+// the structural checks only guard against caching a non-conforming body.
+function isArticleCitedByPayload(payload) {
+  return !!payload
+    && typeof payload === "object"
+    && Array.isArray(payload.citingProvisions)
+    && Array.isArray(payload.citingJudgments)
+    && !!payload.counts
+    && Number.isFinite(payload.counts.total);
+}
+
+function isLawCitedByPayload(payload) {
+  return !!payload
+    && typeof payload === "object"
+    && !!payload.citingLaws
+    && Array.isArray(payload.citingLaws.laws)
+    && !!payload.totals
+    && Number.isFinite(payload.totals.total);
+}
+
 export async function fetchArticleCaseLawDigest(celex, articleNumber, lang = "EN") {
   const apiLang = toApiLang(lang);
-  const key = `${celex}_${apiLang}_digest_${articleNumber}`;
+  const key = makeArticleCaseLawDigestCacheKey(celex, articleNumber, lang);
   return getInFlightRequest(`article-case-law-digest:${key}`, () => fetchJsonWithCache({
     cacheKey: key,
     url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/articles/${encodeURIComponent(articleNumber)}/case-law-digest?lang=${apiLang}`,
     errorLabel: "Article case-law digest fetch failed",
     cacheFirst: true,
+    validatePayload: isCurrentArticleCaseLawDigestPayload,
   }));
 }
 
@@ -1044,6 +1086,7 @@ export async function fetchArticleCitedBy(celex, articleNumber) {
     url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/articles/${encodeURIComponent(articleNumber)}/cited-by?limit=200`,
     errorLabel: "Article cited-by fetch failed",
     cacheFirst: true,
+    validatePayload: isArticleCitedByPayload,
   }));
 }
 
@@ -1054,17 +1097,19 @@ export async function fetchLawCitedBy(celex) {
     url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/cited-by?citingLaws=10`,
     errorLabel: "Law cited-by fetch failed",
     cacheFirst: true,
+    validatePayload: isLawCitedByPayload,
   }));
 }
 
 export async function fetchCaseLawDigest(celex, lang = "EN") {
   const apiLang = toApiLang(lang);
-  const key = `${celex}_${apiLang}_case_law_digest`;
+  const key = makeCaseLawDigestCacheKey(celex, lang);
   return getInFlightRequest(`case-law-digest:${key}`, () => fetchJsonWithCache({
     cacheKey: key,
     url: `${API_BASE}/api/laws/${encodeURIComponent(celex)}/case-law-digest?lang=${apiLang}`,
     errorLabel: "Case-law digest fetch failed",
     cacheFirst: true,
+    validatePayload: isCurrentCaseLawDigestPayload,
   }));
 }
 
@@ -1187,18 +1232,6 @@ export async function fetchTopicsForCelexes(celexes, { signal } = {}) {
   return payload?.topics && typeof payload.topics === "object" ? payload.topics : {};
 }
 
-export async function fetchFormexByReference(reference, lang = "EN") {
-  const query = buildReferenceQuery(reference, lang);
-  const url = `${API_BASE}/api/laws/by-reference?${query}`;
-  const res = await apiFetch(url);
-
-  if (!res.ok) {
-    await readApiError(res, `Formex reference fetch failed (${res.status})`);
-  }
-
-  return res.text();
-}
-
 // `version` — only the literal "current" is meaningful today (#149's first
 // slice; the backend 400s on anything else) — asks the backend for the
 // consolidated ("as amended") reading instead of the act as adopted. It is
@@ -1245,7 +1278,9 @@ export async function fetchParsedLaw(celex, lang = "EN", { version = null } = {}
       || (payload.version === "current" && !payload.versionUnavailable);
     if (payloadHasContent(payload) && cacheablePayload) {
       await cacheSet(cacheKey, createCombinedLawEnvelope(payload));
-      await upsertLawMeta(celex, { cachedAt: Date.now() });
+      await upsertLawMeta(celex, { cachedAt: Date.now() }).catch((err) => {
+        console.warn(`[FormexAPI] Failed to persist library metadata for ${celex}:`, err);
+      });
       await pruneCacheIfNeeded(celex, PROTECTED_BUNDLED_CELEXES);
       if (typeof window !== "undefined") {
         window.dispatchEvent(new CustomEvent("legalviz-formex-cache-updated", {

--- a/src/utils/lawRouting.js
+++ b/src/utils/lawRouting.js
@@ -160,10 +160,6 @@ export function buildImportedLawCandidate(entry = {}) {
   };
 }
 
-export function getActTypeChoices() {
-  return Array.from(VALID_ACT_TYPES);
-}
-
 // Sector-3 CELEX shape: "3" + 4-digit year + act-type letter + 1-4 digit
 // number, with an optional "(NN)" disambiguation suffix (e.g. "32016R0679").
 const SECTOR3_CELEX = /^3(\d{4})([RLD])(\d{1,4})(\(\d+\))?$/;

--- a/src/utils/lawRouting.test.js
+++ b/src/utils/lawRouting.test.js
@@ -8,7 +8,6 @@ import {
   findBundledLawBySlug,
   getCanonicalLawRoute,
   buildImportedLawCandidate,
-  getActTypeChoices,
   parseOfficialReferenceSlug,
   parseCelexQuery,
 } from "./lawRouting.js";
@@ -178,16 +177,6 @@ describe("buildImportedLawCandidate", () => {
     });
     expect(result.celex).toBe("32021R0123");
     expect(result.slug).toBe("regulation-2021-123");
-  });
-});
-
-describe("getActTypeChoices", () => {
-  it("returns regulation, directive, decision", () => {
-    const choices = getActTypeChoices();
-    expect(choices).toContain("regulation");
-    expect(choices).toContain("directive");
-    expect(choices).toContain("decision");
-    expect(choices).toHaveLength(3);
   });
 });
 

--- a/src/utils/library.js
+++ b/src/utils/library.js
@@ -61,7 +61,14 @@ function enqueueLawMetaUpsert(celex, updates) {
   const previous = pendingUpserts.get(celex) || Promise.resolve();
   const next = previous
     .catch(() => {})
-    .then(() => upsertLawMeta(celex, updates));
+    .then(() => upsertLawMeta(celex, updates))
+    .catch((err) => {
+      // A failing IndexedDB put (quota pressure, private browsing) must not
+      // surface as an unhandled rejection or crash the caller — log it once
+      // and resolve null so the chain stays quiet and UX stays non-crashing.
+      console.warn(`[Library] Failed to persist library metadata for ${celex}:`, err);
+      return null;
+    });
   pendingUpserts.set(celex, next);
   next.finally(() => {
     if (pendingUpserts.get(celex) === next) pendingUpserts.delete(celex);

--- a/src/utils/library.test.js
+++ b/src/utils/library.test.js
@@ -70,6 +70,18 @@ describe("saveLawMeta", () => {
     const updates = upsertLawMeta.mock.calls[0][1];
     expect(updates).not.toHaveProperty("topics");
   });
+
+  it("warns and resolves null when the underlying meta write rejects", async () => {
+    upsertLawMeta.mockRejectedValueOnce(new Error("quota exceeded"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const saved = await saveLawMeta({ celex: "32016R0679", label: "GDPR" });
+      expect(saved).toBeNull();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });
 
 describe("markLawOpened", () => {

--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,1 +1,5 @@
-export * from "../../backend/shared/formex-parser/url.mjs";
+export {
+  buildEurlexCelexUrl,
+  buildEurlexOjUrl,
+  buildEurlexSearchUrl,
+} from "../../backend/shared/formex-parser/url.mjs";

--- a/src/utils/url.test.js
+++ b/src/utils/url.test.js
@@ -1,37 +1,9 @@
 import { describe, it, expect } from "vitest";
 import {
-  getLawSlugFromPath,
   buildEurlexSearchUrl,
   buildEurlexOjUrl,
   buildEurlexCelexUrl,
 } from "./url.js";
-
-describe("getLawSlugFromPath", () => {
-  it("extracts slug from simple path", () => {
-    expect(getLawSlugFromPath("/gdpr")).toBe("gdpr");
-  });
-
-  it("extracts slug ignoring trailing segments", () => {
-    expect(getLawSlugFromPath("/gdpr/article/5")).toBe("gdpr");
-  });
-
-  it("returns null for root path", () => {
-    expect(getLawSlugFromPath("/")).toBeNull();
-  });
-
-  it("excludes /law/ prefix", () => {
-    expect(getLawSlugFromPath("/law/gdpr")).toBeNull();
-  });
-
-  it("excludes /import paths", () => {
-    expect(getLawSlugFromPath("/import")).toBeNull();
-    expect(getLawSlugFromPath("/import/something")).toBeNull();
-  });
-
-  it("handles regulation-style slugs", () => {
-    expect(getLawSlugFromPath("/regulation-2016-679")).toBe("regulation-2016-679");
-  });
-});
 
 describe("buildEurlexSearchUrl", () => {
   it("builds valid URL with text and language", () => {


### PR DESCRIPTION
Follow-up to the frontend code review.

## Fixes
- **Silent library-data loss**: `metaPut` (src/utils/formexApi.js) resolved success on transaction error/abort, so library saves and resume positions vanished under quota pressure / private browsing. It now rejects; the library upsert serializer and fire-and-forget callers catch + `console.warn` so nothing becomes an unhandled rejection and UX stays non-crashing.
- **Unversioned AI-digest caches** (review finding #2): article/whole-law digest keys carried no schema/prompt version, so prompt or schema bumps kept serving stale digests for up to 7 days. New `backend/shared/digest-cache-version.json` is the single source of truth (mirrors the law-summary-cache-version.json precedent), consumed by both backend services and the frontend key builders (`…_schemaN_promptM`). Old entries orphan → existing prune handles it; expect a one-time digest refetch after deploy.
- Cited-by payloads carry no version stamps, so their keys are unchanged — cheap structural validators added instead.
- CLAUDE.md cache-version table updated to point at the new JSON file.

## Cleanup
- Dead exports removed: `fetchFormexByReference`, `hasCachedFormex`, `peekCaseLaw`, `getActTypeChoices`, `getLawSlugFromPath` re-export (+ dependent test cases). `backend/shared/formex-parser/url.mjs` untouched.

## Verification
- `npx vitest run`: 43 files / 513 tests green; `npm run lint` clean (run in this worktree).
- Backend suite not run here (backend/node_modules absent); the two touched services only re-source identical constant values from JSON — diff reviewed byte-for-byte.

🤖 Generated with opencode CLI (deepseek-v4-flash), reviewed and verified by ox-alpha.