### PR TITLE
Add characterization tests for viewer interactions, cross-references, and case-law cache

### DIFF
--- a/src/components/CrossReferences.test.jsx
+++ b/src/components/CrossReferences.test.jsx
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createElement } from "react";
+import { createRoot } from "react-dom/client";
+
+vi.mock("../i18n/useI18n.js", () => ({
+  useI18n: () => ({ t: (key) => key }),
+}));
+
+import { CrossReferences } from "./CrossReferences.jsx";
+
+let container;
+let root;
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  document.body.innerHTML = "";
+});
+
+function render(props) {
+  root = createRoot(container);
+  act(() => {
+    root.render(createElement(CrossReferences, {
+      articleNumber: "1",
+      crossReferences: {},
+      compact: true,
+      ...props,
+    }));
+  });
+}
+
+function buttonLabels() {
+  return Array.from(container.querySelectorAll("button")).map((b) => b.textContent);
+}
+
+describe("CrossReferences", () => {
+  it("renders nothing when crossReferences is missing", () => {
+    render({ crossReferences: undefined });
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders nothing when there are no refs at all", () => {
+    render({ crossReferences: { "1": [] } });
+    expect(container.textContent).toBe("");
+  });
+
+  it("computes back-references from article keys, skipping recital_ and annex_ prefixes", () => {
+    const crossReferences = {
+      "1": [{ type: "article", target: "2" }],
+      "2": [{ type: "article", target: "1" }],
+      "5": [{ type: "article", target: "1" }],
+      "recital_1": [{ type: "article", target: "1" }],
+      "annex_1": [{ type: "article", target: "1" }],
+    };
+    render({
+      articleNumber: "1",
+      crossReferences,
+      articles: [
+        { article_number: "1", article_title: "Subject matter" },
+        { article_number: "2", article_title: "Definitions" },
+        { article_number: "5", article_title: "Transparency" },
+      ],
+    });
+
+    const labels = buttonLabels();
+
+    // Forward ref from article 1 to article 2, plus back refs from 2 and 5.
+    // Button text is "Art. N" followed by the article title when present.
+    expect(labels.filter((label) => label.startsWith("Art. 2")).length).toBe(2);
+    expect(labels.some((label) => label.startsWith("Art. 5"))).toBe(true);
+    // recital_/annex_ keys are not back-reference sources.
+    expect(labels.some((label) => label.includes("recital_1"))).toBe(false);
+    expect(labels.some((label) => label.includes("annex_1"))).toBe(false);
+    // One forward (Art. 2) + two back (Art. 2, Art. 5) buttons.
+    expect(container.querySelectorAll("button").length).toBe(3);
+  });
+
+  it("skips the article's own key as a back-reference source", () => {
+    render({
+      articleNumber: "1",
+      crossReferences: {
+        "1": [{ type: "article", target: "2" }],
+        "2": [{ type: "article", target: "1" }],
+      },
+    });
+
+    const labels = buttonLabels();
+    expect(labels.filter((label) => label === "Art. 1").length).toBe(0);
+    expect(labels.filter((label) => label === "Art. 2").length).toBe(2);
+  });
+
+  it("omits back-references when showBackReferences is false", () => {
+    render({
+      articleNumber: "1",
+      crossReferences: {
+        "2": [{ type: "article", target: "1" }],
+        "1": [{ type: "article", target: "2" }],
+      },
+      showBackReferences: false,
+    });
+
+    expect(buttonLabels()).toEqual(["Art. 2"]);
+  });
+
+  it("calls onSelectArticle with the forward-ref target", () => {
+    const onSelectArticle = vi.fn();
+    render({
+      articleNumber: "1",
+      crossReferences: {
+        "1": [{ type: "article", target: "7" }],
+      },
+      onSelectArticle,
+    });
+
+    const forwardButton = Array.from(container.querySelectorAll("button"))
+      .find((b) => b.textContent.includes("Art. 7"));
+    act(() => forwardButton.click());
+    expect(onSelectArticle).toHaveBeenCalledWith("7");
+  });
+
+  it("truncates long raw strings on external refs to 57 chars plus an ellipsis", () => {
+    const longRaw = "x".repeat(80);
+    render({
+      crossReferences: {
+        "1": [{ type: "external", raw: longRaw }],
+      },
+    });
+
+    const label = buttonLabels()[0];
+    expect(label.length).toBe(58);
+    expect(label.endsWith("…")).toBe(true);
+    expect(label).toBe(`${"x".repeat(57)}…`);
+  });
+
+  it("keeps short external refs untruncated", () => {
+    render({
+      crossReferences: {
+        "1": [{ type: "external", raw: "short reference" }],
+      },
+    });
+
+    expect(buttonLabels()).toEqual(["short reference"]);
+  });
+
+  it("does not truncate oj_ref raw strings", () => {
+    const longRaw = "y".repeat(70);
+    render({
+      crossReferences: {
+        "1": [{ type: "oj_ref", raw: longRaw }],
+      },
+    });
+
+    expect(buttonLabels()).toEqual([longRaw]);
+  });
+
+  it("renders the oj_ref button even when its URL cannot be built, and opening does nothing", () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    render({
+      crossReferences: {
+        "1": [{ type: "oj_ref", raw: "OJ L 123, 5.6.2021" }],
+      },
+    });
+
+    const button = container.querySelector("button");
+    expect(button).not.toBeNull();
+    expect(button.disabled).toBe(false);
+
+    act(() => button.click());
+    expect(openSpy).not.toHaveBeenCalled();
+
+    openSpy.mockRestore();
+  });
+
+  it("opens the search URL for external refs when no handler is provided", () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    render({
+      crossReferences: {
+        "1": [{ type: "external", raw: "Regulation (EU) 2016/679" }],
+      },
+    });
+
+    act(() => container.querySelector("button").click());
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    const [url, target, features] = openSpy.mock.calls[0];
+    expect(url).toMatch(/^https:\/\/eur-lex\.europa\.eu\/search\.html\?/);
+    expect(target).toBe("_blank");
+    expect(features).toBe("noopener,noreferrer");
+
+    openSpy.mockRestore();
+  });
+
+  it("disables the external button while the reference is pending", () => {
+    render({
+      crossReferences: {
+        "1": [{ type: "external", raw: "Regulation (EU) 2016/679" }],
+      },
+      isExternalReferencePending: () => true,
+    });
+
+    const button = container.querySelector("button");
+    expect(button.disabled).toBe(true);
+  });
+
+  it("renders the external ref through onOpenExternalReference when provided", () => {
+    const onOpenExternalReference = vi.fn();
+    render({
+      crossReferences: {
+        "1": [{ type: "external", raw: "Regulation (EU) 2016/679" }],
+      },
+      onOpenExternalReference,
+    });
+
+    act(() => container.querySelector("button").click());
+    expect(onOpenExternalReference).toHaveBeenCalledWith({ type: "external", raw: "Regulation (EU) 2016/679" });
+  });
+
+  it("collapses content behind the header until opened, with a total count badge", () => {
+    render({
+      compact: false,
+      crossReferences: {
+        "1": [{ type: "article", target: "2" }],
+        "2": [{ type: "article", target: "1" }],
+      },
+    });
+
+    // Header button only — content hidden.
+    expect(container.querySelectorAll("button").length).toBe(1);
+    expect(container.textContent).toContain("2");
+    expect(buttonLabels()[0]).not.toContain("Art.");
+
+    act(() => container.querySelector("button").click());
+    const labels = buttonLabels();
+    expect(labels.filter((label) => label.includes("Art.")).length).toBe(2);
+  });
+
+  it("shows the paragraph suffix and article title on forward refs", () => {
+    render({
+      articleNumber: "1",
+      crossReferences: {
+        "1": [{ type: "article", target: "2", paragraph: "1" }],
+      },
+      articles: [
+        { article_number: "2", article_title: "Definitions" },
+      ],
+    });
+
+    const button = container.querySelector("button");
+    expect(button.textContent).toContain("Art. 2");
+    expect(button.textContent).toContain("(1)");
+    expect(button.textContent).toContain("Definitions");
+  });
+});

--- a/src/hooks/law-viewer/useLawViewerInteractions.test.jsx
+++ b/src/hooks/law-viewer/useLawViewerInteractions.test.jsx
@@ -1,0 +1,433 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockNavigate, mockResolveOfficialReference, mockSaveLawMeta } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockResolveOfficialReference: vi.fn(),
+  mockSaveLawMeta: vi.fn(),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock("../../utils/formexApi.js", async () => {
+  const actual = await vi.importActual("../../utils/formexApi.js");
+  return {
+    ...actual,
+    resolveOfficialReference: mockResolveOfficialReference,
+  };
+});
+
+vi.mock("../../utils/library.js", () => ({
+  saveLawMeta: mockSaveLawMeta,
+}));
+
+import { useLawViewerInteractions } from "./useLawViewerInteractions.js";
+
+const data = {
+  articles: [
+    { article_number: "1", article_html: "<p>1</p>" },
+    { article_number: "2", article_html: "<p>2</p>" },
+    { article_number: "3", article_html: "<p>3</p>" },
+  ],
+  recitals: [
+    { recital_number: "10", recital_html: "<p>r10</p>" },
+    { recital_number: "11", recital_html: "<p>r11</p>" },
+  ],
+  annexes: [
+    { annex_id: "I", annex_html: "<p>annex I</p>" },
+  ],
+};
+
+function createDeferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useLawViewerInteractions", () => {
+  let container;
+  let root;
+  let latestValue;
+  let onPrevNext;
+
+  function Probe(props) {
+    latestValue = useLawViewerInteractions(props);
+    return null;
+  }
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    latestValue = null;
+    onPrevNext = vi.fn();
+    mockNavigate.mockReset();
+    mockSaveLawMeta.mockReset().mockResolvedValue(null);
+    mockResolveOfficialReference.mockReset();
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root.unmount();
+      });
+    }
+    container?.remove();
+    document.body.innerHTML = "";
+  });
+
+  function render(props = {}) {
+    return act(async () => {
+      root.render(
+        <Probe
+          data={data}
+          selected={{ kind: "article", id: "2" }}
+          onPrevNext={onPrevNext}
+          currentContentLang="EN"
+          locale="en"
+          {...props}
+        />
+      );
+    });
+  }
+
+  function pressKey(init) {
+    act(() => {
+      window.dispatchEvent(new KeyboardEvent("keydown", init));
+    });
+  }
+
+  describe("keyboard navigation", () => {
+    it("navigates forward with j and backward with k", async () => {
+      await render();
+
+      pressKey({ key: "j" });
+      expect(onPrevNext).toHaveBeenLastCalledWith("article", 2);
+
+      pressKey({ key: "k" });
+      expect(onPrevNext).toHaveBeenLastCalledWith("article", 0);
+    });
+
+    it("ignores j/k when a modifier key is held", async () => {
+      await render();
+
+      for (const init of [
+        { key: "j", metaKey: true },
+        { key: "j", ctrlKey: true },
+        { key: "j", altKey: true },
+        { key: "j", shiftKey: true },
+        { key: "k", metaKey: true },
+        { key: "k", ctrlKey: true },
+        { key: "k", altKey: true },
+        { key: "k", shiftKey: true },
+      ]) {
+        pressKey(init);
+      }
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+    });
+
+    it("navigates with plain ArrowLeft/ArrowRight", async () => {
+      await render();
+
+      pressKey({ key: "ArrowRight" });
+      expect(onPrevNext).toHaveBeenLastCalledWith("article", 2);
+
+      pressKey({ key: "ArrowLeft" });
+      expect(onPrevNext).toHaveBeenLastCalledWith("article", 0);
+    });
+
+    it("does not navigate past the first entry", async () => {
+      await render({ selected: { kind: "article", id: "1" } });
+
+      pressKey({ key: "ArrowLeft" });
+      pressKey({ key: "k" });
+      pressKey({ key: "ArrowLeft" });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+    });
+
+    it("does not navigate past the last entry", async () => {
+      await render({ selected: { kind: "article", id: "3" } });
+
+      pressKey({ key: "ArrowRight" });
+      pressKey({ key: "j" });
+      pressKey({ key: "ArrowRight" });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+    });
+
+    it("ignores keys pressed inside an INPUT", async () => {
+      await render();
+      const input = document.createElement("input");
+      document.body.appendChild(input);
+
+      act(() => {
+        input.dispatchEvent(new KeyboardEvent("keydown", { key: "j", bubbles: true }));
+      });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+      input.remove();
+    });
+
+    it("ignores keys pressed inside a TEXTAREA", async () => {
+      await render();
+      const textarea = document.createElement("textarea");
+      document.body.appendChild(textarea);
+
+      act(() => {
+        textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "j", bubbles: true }));
+      });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+      textarea.remove();
+    });
+
+    it("yields navigation keys to the search modal when a dialog is open", async () => {
+      await render();
+      const dialog = document.createElement("div");
+      dialog.setAttribute("role", "dialog");
+      document.body.appendChild(dialog);
+
+      pressKey({ key: "j" });
+      pressKey({ key: "k" });
+      pressKey({ key: "ArrowLeft" });
+      pressKey({ key: "ArrowRight" });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+      dialog.remove();
+    });
+
+    it("navigates recitals with the same j/k and arrow keys", async () => {
+      await render({ selected: { kind: "recital", id: "10" } });
+
+      pressKey({ key: "j" });
+      expect(onPrevNext).toHaveBeenLastCalledWith("recital", 1);
+
+      pressKey({ key: "ArrowRight" });
+      expect(onPrevNext).toHaveBeenLastCalledWith("recital", 1);
+
+      await render({ selected: { kind: "recital", id: "11" } });
+
+      pressKey({ key: "k" });
+      expect(onPrevNext).toHaveBeenLastCalledWith("recital", 0);
+
+      pressKey({ key: "ArrowLeft" });
+      expect(onPrevNext).toHaveBeenLastCalledWith("recital", 0);
+    });
+
+    it("does nothing when the selected kind has no list entries", async () => {
+      await render({ selected: { kind: "annex", id: "I" } });
+
+      pressKey({ key: "j" });
+      pressKey({ key: "k" });
+      pressKey({ key: "ArrowLeft" });
+      pressKey({ key: "ArrowRight" });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("touch swipes", () => {
+    it("navigates forward on a left swipe past the horizontal threshold", async () => {
+      await render({ selected: { kind: "article", id: "2" } });
+
+      act(() => {
+        latestValue.onTouchStart({ targetTouches: [{ clientX: 300 }] });
+        latestValue.onTouchMove({ targetTouches: [{ clientX: 200 }] });
+      });
+      act(() => {
+        latestValue.onTouchEnd();
+      });
+
+      expect(onPrevNext).toHaveBeenCalledWith("article", 2);
+    });
+
+    it("navigates backward on a right swipe past the horizontal threshold", async () => {
+      await render({ selected: { kind: "article", id: "2" } });
+
+      act(() => {
+        latestValue.onTouchStart({ targetTouches: [{ clientX: 200 }] });
+        latestValue.onTouchMove({ targetTouches: [{ clientX: 300 }] });
+      });
+      act(() => {
+        latestValue.onTouchEnd();
+      });
+
+      expect(onPrevNext).toHaveBeenCalledWith("article", 0);
+    });
+
+    it("does not navigate when the horizontal distance is exactly the 50px threshold", async () => {
+      await render();
+
+      act(() => {
+        latestValue.onTouchStart({ targetTouches: [{ clientX: 300 }] });
+        latestValue.onTouchMove({ targetTouches: [{ clientX: 250 }] });
+      });
+      act(() => {
+        latestValue.onTouchEnd();
+      });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+    });
+
+    it("does not navigate when the horizontal distance is below the threshold", async () => {
+      await render();
+
+      act(() => {
+        latestValue.onTouchStart({ targetTouches: [{ clientX: 300 }] });
+        latestValue.onTouchMove({ targetTouches: [{ clientX: 280 }] });
+      });
+      act(() => {
+        latestValue.onTouchEnd();
+      });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+    });
+
+    it("does not navigate backward from the first entry", async () => {
+      await render({ selected: { kind: "article", id: "1" } });
+
+      act(() => {
+        latestValue.onTouchStart({ targetTouches: [{ clientX: 200 }] });
+        latestValue.onTouchMove({ targetTouches: [{ clientX: 400 }] });
+      });
+      act(() => {
+        latestValue.onTouchEnd();
+      });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+    });
+
+    it("does not navigate forward from the last entry", async () => {
+      await render({ selected: { kind: "article", id: "3" } });
+
+      act(() => {
+        latestValue.onTouchStart({ targetTouches: [{ clientX: 400 }] });
+        latestValue.onTouchMove({ targetTouches: [{ clientX: 200 }] });
+      });
+      act(() => {
+        latestValue.onTouchEnd();
+      });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+    });
+
+    it("ignores vertical drift when deciding the swipe", async () => {
+      await render({ selected: { kind: "article", id: "2" } });
+
+      act(() => {
+        latestValue.onTouchStart({ targetTouches: [{ clientX: 300, clientY: 100 }] });
+        latestValue.onTouchMove({ targetTouches: [{ clientX: 200, clientY: 900 }] });
+      });
+      act(() => {
+        latestValue.onTouchEnd();
+      });
+
+      expect(onPrevNext).toHaveBeenCalledWith("article", 2);
+    });
+
+    it("does not navigate when only vertical movement occurred", async () => {
+      await render();
+
+      act(() => {
+        latestValue.onTouchStart({ targetTouches: [{ clientX: 300, clientY: 100 }] });
+        latestValue.onTouchMove({ targetTouches: [{ clientX: 300, clientY: 900 }] });
+      });
+      act(() => {
+        latestValue.onTouchEnd();
+      });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when no touch start was recorded", async () => {
+      await render();
+
+      act(() => {
+        latestValue.onTouchMove({ targetTouches: [{ clientX: 200 }] });
+      });
+      act(() => {
+        latestValue.onTouchEnd();
+      });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when no touch move was recorded", async () => {
+      await render();
+
+      act(() => {
+        latestValue.onTouchStart({ targetTouches: [{ clientX: 300 }] });
+      });
+      act(() => {
+        latestValue.onTouchEnd();
+      });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("external reference resolution", () => {
+    const refA = { raw: "Regulation (EU) 2016/679", actType: "R", year: "2016", number: "679" };
+    const refB = { raw: "Directive (EU) 2015/2366", actType: "L", year: "2015", number: "2366" };
+
+    it("lets a newer resolution supersede a stale one without clearing pending state", async () => {
+      const deferredA = createDeferred();
+      const deferredB = createDeferred();
+      mockResolveOfficialReference
+        .mockReturnValueOnce(deferredA.promise)
+        .mockReturnValueOnce(deferredB.promise);
+
+      await render();
+
+      let promiseA;
+      let promiseB;
+      act(() => {
+        promiseA = latestValue.handleOpenExternalLaw(refA);
+        promiseB = latestValue.handleOpenExternalLaw(refB);
+      });
+      expect(latestValue.pendingExternalReferenceLabel).toBe(refB.raw);
+
+      await act(async () => {
+        deferredA.resolve({ resolved: { celex: "32016R0679" } });
+        await promiseA;
+      });
+
+      expect(latestValue.isResolvingExternalLaw).toBe(true);
+      expect(latestValue.pendingExternalReferenceLabel).toBe(refB.raw);
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        deferredB.resolve({ resolved: { celex: "32015L2366" } });
+        await promiseB;
+      });
+
+      expect(latestValue.isResolvingExternalLaw).toBe(false);
+      expect(latestValue.pendingExternalReferenceLabel).toBe("");
+    });
+
+    it("clears pending state immediately when the reference has no act details", async () => {
+      const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+      await render();
+      await act(async () => {
+        await latestValue.handleOpenExternalLaw({ raw: "not a legal reference" });
+      });
+
+      expect(latestValue.isResolvingExternalLaw).toBe(false);
+      expect(latestValue.pendingExternalReferenceLabel).toBe("");
+      expect(mockResolveOfficialReference).not.toHaveBeenCalled();
+      expect(openSpy).toHaveBeenCalledTimes(1);
+
+      openSpy.mockRestore();
+    });
+  });
+});

--- a/src/utils/caseLawCache.test.js
+++ b/src/utils/caseLawCache.test.js
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFetchCaseLaw } = vi.hoisted(() => ({
+  mockFetchCaseLaw: vi.fn(),
+}));
+
+vi.mock("./formexApi.js", () => ({
+  fetchCaseLaw: mockFetchCaseLaw,
+}));
+
+let loadCaseLaw;
+let peekCaseLaw;
+
+beforeEach(async () => {
+  vi.resetModules();
+  mockFetchCaseLaw.mockReset();
+  ({ loadCaseLaw, peekCaseLaw } = await import("./caseLawCache.js"));
+});
+
+describe("caseLawCache", () => {
+  it("caches a successful fetch for the rest of the session", async () => {
+    mockFetchCaseLaw.mockResolvedValue({ cases: [{ caseId: "C-1" }] });
+
+    const first = loadCaseLaw("32016R0679");
+    const second = loadCaseLaw("32016R0679");
+
+    await expect(first).resolves.toEqual({ cases: [{ caseId: "C-1" }] });
+    await expect(second).resolves.toEqual({ cases: [{ caseId: "C-1" }] });
+
+    expect(mockFetchCaseLaw).toHaveBeenCalledTimes(1);
+    expect(mockFetchCaseLaw).toHaveBeenCalledWith("32016R0679");
+    expect(second).toBe(first);
+    expect(peekCaseLaw("32016R0679")).toBe(first);
+  });
+
+  it("does not cache a failed fetch, so a later retry refetches", async () => {
+    mockFetchCaseLaw
+      .mockRejectedValueOnce(new Error("case law cellar down"))
+      .mockResolvedValueOnce({ cases: [{ caseId: "C-2" }] });
+
+    await expect(loadCaseLaw("32002L0058")).rejects.toThrow("case law cellar down");
+    expect(peekCaseLaw("32002L0058")).toBeNull();
+
+    await expect(loadCaseLaw("32002L0058")).resolves.toEqual({ cases: [{ caseId: "C-2" }] });
+    expect(mockFetchCaseLaw).toHaveBeenCalledTimes(2);
+  });
+
+  it("normalises a successful response to { cases } even when the payload has no cases field", async () => {
+    mockFetchCaseLaw.mockResolvedValue({});
+
+    await expect(loadCaseLaw("32022R1925")).resolves.toEqual({ cases: [] });
+    expect(mockFetchCaseLaw).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns an empty result without fetching for a falsy celex", async () => {
+    await expect(loadCaseLaw("")).resolves.toEqual({ cases: [] });
+    await expect(loadCaseLaw(undefined)).resolves.toEqual({ cases: [] });
+    expect(mockFetchCaseLaw).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Follow-up to the frontend code review — closes the highest-value coverage gaps among the untested hotspots.

## What's covered (41 new tests)
- `useLawViewerInteractions.test.jsx` (22): j/k + modifier guard, ArrowLeft/Right nav, INPUT/TEXTAREA skip, `[role=dialog]` yield, 50px swipe threshold incl. current vertical-drift-ignored behavior, stale external-resolution ref semantics.
- `CrossReferences.test.jsx` (15): back-ref computation skipping recital_/annex_/self keys, inert OJ buttons when URL builders return null, >60-char truncation, pending-disabled buttons, collapsible header count badge.
- `caseLawCache.test.js` (4): session Map caching/single-flight, failed-fetch eviction so retries refetch, falsy-celex short-circuit.

Characterization only — asserts current behavior; no source files modified. Known bugs flagged by the review (vertical drift flipping articles, missing arrow-key modifier guard) are deliberately pinned as-is and should be fixed in a follow-up that flips these assertions.

**Skipped:** `ToolsMenu` — non-exported inner function of TopBar.jsx; testing it in isolation requires the god-file split first (see review). SearchBox remains covered by its four dedicated test files.

## Verification
- `npx vitest run`: 46 files / **555 tests green** (514 → 555); `npm run lint` clean.

🤖 Generated with opencode CLI (deepseek-v4-flash), reviewed and verified by ox-alpha.