### PR TITLE
Backend review: fix reference inversion, MCP spend guard, and eight smaller defects

### DIFF
--- a/backend/bin/eurlex.js
+++ b/backend/bin/eurlex.js
@@ -365,7 +365,11 @@ COMMANDS.resolve = {
   async run(args) {
     const flags = parseFlags(args, ['text']);
     const svc = bootServices();
-    const lang = svc.validateLang(flags.lang || 'ENG') || 'ENG';
+    let lang = 'ENG';
+    if (flags.lang) {
+      lang = svc.validateLang(flags.lang);
+      if (!lang) die(`Invalid language code: ${flags.lang}`);
+    }
 
     let reference;
     if (flags.actType || flags.year || flags.number) {
@@ -400,7 +404,11 @@ COMMANDS['resolve-url'] = {
     const flags = parseFlags(args, ['url']);
     if (!flags.url) die('URL required.  Usage: eurlex resolve-url <url>');
     const svc = bootServices();
-    const lang = svc.validateLang(flags.lang || 'ENG') || 'ENG';
+    let lang = 'ENG';
+    if (flags.lang) {
+      lang = svc.validateLang(flags.lang);
+      if (!lang) die(`Invalid language code: ${flags.lang}`);
+    }
 
     const payload = await svc.resolveEurlexUrl(flags.url, lang);
     jsonOut(payload, flags.o || flags.output);

--- a/backend/bin/eurlex.test.js
+++ b/backend/bin/eurlex.test.js
@@ -72,3 +72,27 @@ test("eurlex resolve-url uses the legal cache before network fetches", async () 
   assert.equal(payload.resolved?.celex, "32015L2366");
   assert.equal(payload.resolved?.source, "search-cache");
 });
+
+test("eurlex resolve rejects an invalid --lang instead of silently defaulting to ENG", async () => {
+  await assert.rejects(
+    runCli(["resolve", "Directive 2015/2366", "--lang", "XX"], {
+      SEARCH_CACHE_PATH: fixturePath,
+    }),
+    (error) => {
+      assert.match(error.stderr, /Invalid language code: XX/);
+      return true;
+    }
+  );
+});
+
+test("eurlex resolve-url rejects an invalid --lang instead of silently defaulting to ENG", async () => {
+  await assert.rejects(
+    runCli(["resolve-url", "https://eur-lex.europa.eu/eli/dir/2015/2366/oj", "--lang", "XX"], {
+      SEARCH_CACHE_PATH: fixturePath,
+    }),
+    (error) => {
+      assert.match(error.stderr, /Invalid language code: XX/);
+      return true;
+    }
+  );
+});

--- a/backend/mcp/register-tools.js
+++ b/backend/mcp/register-tools.js
@@ -4,18 +4,8 @@ const { JSDOM } = require('jsdom');
 const { ClientError, requireCitationGraph, validateLang } = require('../shared/api-utils');
 const { validateCelex, parseReferenceText } = require('../shared/reference-utils');
 const { fetchCaseLaw, fetchAmendments, fetchImplementing } = require('../shared/law-queries');
-const { ensureRecitalTitles, getCachedRecitalTitles } = require('../shared/recital-title-service');
+const { getCachedRecitalTitles } = require('../shared/recital-title-service');
 const { validateFulltextQuery } = require('../search/legal-cache-store');
-
-const DEFAULT_RECITAL_TITLE_MODEL =
-  process.env.RECITAL_TITLE_MODEL
-  || process.env.ARTICLE_QA_PLANNER_MODEL
-  || process.env.ARTICLE_QA_MODEL
-  || 'google/gemini-3.5-flash-lite';
-
-function getRecitalTitleApiKey() {
-  return process.env.RECITAL_TITLE_OPENROUTER_API_KEY || process.env.OPENROUTER_API_KEY;
-}
 
 const BLOCK_TAGS = new Set([
   'P', 'DIV', 'LI', 'TR', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6',
@@ -94,16 +84,23 @@ function jsonResult(obj) {
   return { content: [{ type: 'text', text: JSON.stringify(obj, null, 2) }] };
 }
 
-/** Wrap a tool handler so any error becomes a model-readable isError result. */
+/**
+ * Wrap a tool handler so any error becomes a model-readable isError result.
+ * Mirrors safeErrorResponse (shared/api-utils.js): ClientError messages are
+ * safe to surface verbatim, but any other error's message can leak
+ * filesystem paths or upstream URLs, so it's logged server-side and replaced
+ * with a generic message instead.
+ */
 function makeHandler(fn) {
   return async (args) => {
     try {
       return await fn(args || {});
     } catch (err) {
-      const message = err instanceof ClientError
-        ? err.message
-        : (err?.message || 'Unexpected error handling the request');
-      return { isError: true, content: [{ type: 'text', text: message }] };
+      if (err instanceof ClientError) {
+        return { isError: true, content: [{ type: 'text', text: err.message }] };
+      }
+      console.error('[MCP] Unexpected error handling the request:', err.message);
+      return { isError: true, content: [{ type: 'text', text: 'Internal server error' }] };
     }
   };
 }
@@ -379,24 +376,14 @@ function registerTools(server, deps) {
           const available = (law.recitals || []).map((r) => r.recital_number).join(', ');
           throw new ClientError(`Recital ${number} not found in ${celex}. Available recital numbers: ${available}`, 404, 'recital_not_found');
         }
-        let title = null;
+        // Cached-only: unlike the REST recital-title route, /mcp carries no
+        // generation budget (req.chargeGeneration()) or origin allowlist, so
+        // it must never trigger a billed OpenRouter call on a cache miss.
+        // A miss here just returns title: null.
         const cached = getCachedRecitalTitles({
           celex, lang: language, recitals: law.recitals || [], cacheDir: FMX_DIR,
         });
-        title = cached.titles[String(rec.recital_number)] || null;
-
-        const apiKey = getRecitalTitleApiKey();
-        if (!title && apiKey) {
-          try {
-            const result = await ensureRecitalTitles({
-              celex, lang: language, recitals: law.recitals || [],
-              cacheDir: FMX_DIR, apiKey, model: DEFAULT_RECITAL_TITLE_MODEL,
-            });
-            title = result.titles[String(rec.recital_number)] || null;
-          } catch {
-            // Soft-fail: the recital text is still returned without a generated title.
-          }
-        }
+        const title = cached.titles[String(rec.recital_number)] || null;
 
         return jsonResult({
           ...base,

--- a/backend/mcp/register-tools.test.js
+++ b/backend/mcp/register-tools.test.js
@@ -433,18 +433,44 @@ test('get_law_part recital returns text and soft-fails to no title without a key
 });
 
 test('get_law_part recital stays cached-only even when an OpenRouter key is configured', async () => {
+  // Asserting `title === null` alone does not prove anything: the pre-fix code
+  // called ensureRecitalTitles, watched the request fail, and soft-failed to
+  // null too. The property that matters is that /mcp -- which carries no
+  // generation budget or origin allowlist -- never makes the billed call in
+  // the first place, so stub fetch to *succeed* and assert it is never reached.
   const prevKey = process.env.OPENROUTER_API_KEY;
+  const originalFetch = global.fetch;
+  const fetched = [];
+  // A dedicated empty dir, not makeDeps' shared fixed path: this test drives a
+  // cache *miss* with a fetch stub that would succeed, so writing into the
+  // shared path would leave a generated title behind and break every later run
+  // on this machine.
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-cached-only-'));
   process.env.OPENROUTER_API_KEY = 'test-key-should-be-ignored';
+  global.fetch = async (url, options) => {
+    fetched.push(String(url));
+    return {
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: JSON.stringify({ 1: 'A generated title' }) }, finish_reason: 'stop' }],
+        model: 'test-model',
+        usage: { total_tokens: 1 },
+      }),
+    };
+  };
   try {
-    await withClient(makeDeps(), async (client) => {
+    await withClient(makeDeps({ FMX_DIR: cacheDir }), async (client) => {
       const body = parseResult(await client.callTool({ name: 'get_law_part', arguments: { celex: '32016R0679', part: 'recital', number: '1' } }));
       assert.equal(body.recital_number, '1');
-      assert.equal(body.title, null, 'the MCP path must never fall back to a live generation call on a cache miss');
       assert.match(body.text, /protection of natural persons/);
+      assert.deepEqual(fetched, [], 'the MCP path must never make a billed generation call on a cache miss');
+      assert.equal(body.title, null, 'a cache miss must return no title rather than generating one');
     });
   } finally {
+    global.fetch = originalFetch;
     if (prevKey !== undefined) process.env.OPENROUTER_API_KEY = prevKey;
     else delete process.env.OPENROUTER_API_KEY;
+    fs.rmSync(cacheDir, { recursive: true, force: true });
   }
 });
 

--- a/backend/mcp/register-tools.test.js
+++ b/backend/mcp/register-tools.test.js
@@ -432,6 +432,22 @@ test('get_law_part recital returns text and soft-fails to no title without a key
   }
 });
 
+test('get_law_part recital stays cached-only even when an OpenRouter key is configured', async () => {
+  const prevKey = process.env.OPENROUTER_API_KEY;
+  process.env.OPENROUTER_API_KEY = 'test-key-should-be-ignored';
+  try {
+    await withClient(makeDeps(), async (client) => {
+      const body = parseResult(await client.callTool({ name: 'get_law_part', arguments: { celex: '32016R0679', part: 'recital', number: '1' } }));
+      assert.equal(body.recital_number, '1');
+      assert.equal(body.title, null, 'the MCP path must never fall back to a live generation call on a cache miss');
+      assert.match(body.text, /protection of natural persons/);
+    });
+  } finally {
+    if (prevKey !== undefined) process.env.OPENROUTER_API_KEY = prevKey;
+    else delete process.env.OPENROUTER_API_KEY;
+  }
+});
+
 test('get_law_part structure surfaces cached recital titles', async () => {
   const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-recital-cache-'));
   // Reproduce the service's contentHash so the cache entry is accepted.
@@ -487,6 +503,27 @@ test('records analytics for each tool invocation', async () => {
   });
   assert.deepEqual(calls[0], { tool: 'search_eu_law', meta: { query: 'gdpr' } });
   assert.deepEqual(calls[1], { tool: 'get_case_law', meta: { celex: '32016R0679' } });
+});
+
+test('non-ClientError failures are sanitised before reaching the client', async () => {
+  const originalConsoleError = console.error;
+  const loggedCalls = [];
+  console.error = (...args) => loggedCalls.push(args);
+  try {
+    const deps = makeDeps({
+      resolveParsedLaw: async () => { throw new Error('ENOENT: /var/data/law-cache/secret/32016R0679.json'); },
+    });
+    await withClient(deps, async (client) => {
+      const res = await client.callTool({ name: 'get_law_part', arguments: { celex: '32016R0679', part: 'structure' } });
+      assert.equal(res.isError, true);
+      assert.doesNotMatch(res.content[0].text, /ENOENT|\/var\/data/);
+      assert.match(res.content[0].text, /internal server error/i);
+    });
+    assert.equal(loggedCalls.length, 1);
+    assert.match(loggedCalls[0].join(' '), /ENOENT/);
+  } finally {
+    console.error = originalConsoleError;
+  }
 });
 
 test('htmlToText strips markup and keeps block breaks', () => {

--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -234,6 +234,16 @@ function registerApiRoutes(app, deps) {
         });
       }
 
+      if (!validateCelex(resolution.resolved.celex)) {
+        // Defense in depth: the resolver is not currently able to produce a
+        // malformed CELEX, but nothing upstream guarantees that forever, and
+        // every other route here validates before touching the filesystem.
+        return res.status(502).json({
+          error: 'Resolved reference produced an invalid CELEX identifier',
+          code: 'invalid_celex',
+        });
+      }
+
       try {
         const { servePath } = await prepareLawPayload(resolution.resolved.celex, lang);
         res.setHeader('X-Resolved-CELEX', resolution.resolved.celex);
@@ -492,9 +502,10 @@ function registerApiRoutes(app, deps) {
         model: DEFAULT_RECITAL_TITLE_MODEL,
       });
 
-      // Only a real generation costs money; a cache hit must not consume
+      // Only a real (billed) model call costs money; neither a cache hit nor
+      // the zero-recitals short-circuit (both `cached: false`) may consume
       // the caller's generation budget.
-      if (!result.cached) req.chargeGeneration?.();
+      if (result.billed) req.chargeGeneration?.();
 
       res.json({
         celex,
@@ -627,9 +638,10 @@ function registerApiRoutes(app, deps) {
         model: DEFAULT_ARTICLE_DIGEST_MODEL,
       });
 
-      // Only a real generation costs money; a cache hit must not consume
-      // the caller's generation budget.
-      if (!result.cached) req.chargeGeneration?.();
+      // Only a real (billed) model call costs money; neither a cache hit nor
+      // the zero-case short-circuit (both `cached: false`) may consume the
+      // caller's generation budget.
+      if (result.billed) req.chargeGeneration?.();
 
       res.json({
         celex,
@@ -682,9 +694,10 @@ function registerApiRoutes(app, deps) {
         model: DEFAULT_CASE_LAW_DIGEST_MODEL,
       });
 
-      // Only a real generation costs money; a cache hit must not consume
-      // the caller's generation budget.
-      if (!result.cached) req.chargeGeneration?.();
+      // Only a real (billed) model call costs money; neither a cache hit nor
+      // the zero-case short-circuit (both `cached: false`) may consume the
+      // caller's generation budget.
+      if (result.billed) req.chargeGeneration?.();
 
       res.json({
         celex,

--- a/backend/search/citation-graph-build.js
+++ b/backend/search/citation-graph-build.js
@@ -82,7 +82,10 @@ async function listTreeFiles(rootDir, suffix, fsApi = fs) {
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory()) await visit(fullPath);
-      else if (entry.isFile() && entry.name.endsWith(suffix)) files.push(fullPath);
+      // Skip AppleDouble sidecars (`._<CELEX>.xml.gz`) and other dotfiles — the
+      // corpus carries one per real file (see search/corpus-files.js's header
+      // comment); they are not gzip streams and must never be read as acts.
+      else if (entry.isFile() && !entry.name.startsWith(".") && entry.name.endsWith(suffix)) files.push(fullPath);
     }
   }
   try { await visit(rootDir); } catch (error) { if (error.code !== "ENOENT") throw error; }

--- a/backend/search/citation-graph-build.test.js
+++ b/backend/search/citation-graph-build.test.js
@@ -44,6 +44,18 @@ test("listCorpusFiles walks shards deterministically and ignores non-FMX files",
   assert.deepEqual(files.map((file) => path.basename(file)), ["32019L0001.xml.gz", "32020R0002.xml.gz"]);
 });
 
+test("listCorpusFiles skips AppleDouble sidecars and other dotfiles", async () => {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), "citation-corpus-dotfiles-"));
+  await fsp.mkdir(path.join(dir, "2020"));
+  await fsp.writeFile(path.join(dir, "2020", "32020R0002.xml.gz"), "");
+  // AppleDouble sidecar: not a gzip stream, must never be treated as an act
+  // (see search/corpus-files.js's header comment for the incident history).
+  await fsp.writeFile(path.join(dir, "2020", "._32020R0002.xml.gz"), "");
+  await fsp.writeFile(path.join(dir, "2020", ".DS_Store"), "");
+  const files = await listCorpusFiles(dir);
+  assert.deepEqual(files.map((file) => path.basename(file)), ["32020R0002.xml.gz"]);
+});
+
 async function writeBothCorpora() {
   const dataDir = await fsp.mkdtemp(path.join(os.tmpdir(), "citation-coverage-"));
   const laws = path.join(dataDir, "laws", "2020");

--- a/backend/search/citation-graph-store.js
+++ b/backend/search/citation-graph-store.js
@@ -136,9 +136,10 @@ class CitationGraphStore {
   }
 
   loadFromSqlite() {
+    let database = null;
     try {
       const Database = require("better-sqlite3");
-      const database = new Database(this.sqlitePath, { readonly: true, fileMustExist: true });
+      database = new Database(this.sqlitePath, { readonly: true, fileMustExist: true });
       const schemaVersion = database.prepare("PRAGMA user_version").get().user_version;
       if (schemaVersion !== SQLITE_SCHEMA_VERSION) {
         database.close();
@@ -174,6 +175,9 @@ class CitationGraphStore {
       this.loadError = null;
       return true;
     } catch (error) {
+      if (database) {
+        try { database.close(); } catch { /* already closed */ }
+      }
       this.payload = null;
       this.database = null;
       this.loadedAt = null;

--- a/backend/search/citation-graph-store.test.js
+++ b/backend/search/citation-graph-store.test.js
@@ -220,25 +220,44 @@ test("sqlite-backed store returns results identical to the JSON store", (t) => {
 // A file that passes the PRAGMA user_version check but has no `metadata`
 // table (e.g. a corrupt/partial write) throws only after the connection is
 // already open. loadFromSqlite must still close that handle on the way out
-// instead of leaking it — regression test for the outer catch in
-// loadFromSqlite silently dropping an opened-but-unassigned `database`.
+// instead of leaking it -- regression test for the outer catch in
+// loadFromSqlite dropping an opened-but-unassigned `database`.
+//
+// The leak is not observable from the store (the dropped handle is simply
+// unreachable) and SQLite happily grants a second connection to the same
+// file, so re-opening it proves nothing. Instead this swaps the cached
+// better-sqlite3 export for a subclass that records every instance, then
+// asserts each one was closed. loadFromSqlite requires the module at call
+// time, so the swap is picked up.
 test("loadFromSqlite closes the database handle when opened but the schema is incomplete", () => {
   const Database = require("better-sqlite3");
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "citation-store-partial-"));
   const sqlitePath = path.join(dir, "data.sqlite");
 
-  const db = new Database(sqlitePath);
-  db.pragma(`user_version = ${SQLITE_SCHEMA_VERSION}`);
+  const seed = new Database(sqlitePath);
+  seed.pragma(`user_version = ${SQLITE_SCHEMA_VERSION}`);
   // Deliberately no `metadata` table, so the SELECT inside loadFromSqlite throws.
-  db.close();
+  seed.close();
+
+  const modulePath = require.resolve("better-sqlite3");
+  const opened = [];
+  class TrackingDatabase extends Database {
+    constructor(...args) {
+      super(...args);
+      opened.push(this);
+    }
+  }
 
   const store = new CitationGraphStore(path.join(dir, "citation-graph.json"), { sqlitePath });
-  assert.equal(store.load(), false);
+  require.cache[modulePath].exports = TrackingDatabase;
+  try {
+    assert.equal(store.load(), false);
+  } finally {
+    require.cache[modulePath].exports = Database;
+  }
+
   assert.match(store.getStatus().error, /no such table: metadata/);
   assert.equal(store.database, null);
-
-  // If the earlier failure had leaked the handle, this exclusive re-open
-  // (no `readonly`) would fail while the leaked connection still held the file.
-  const reopened = new Database(sqlitePath);
-  reopened.close();
+  assert.equal(opened.length, 1, "expected loadFromSqlite to open exactly one connection");
+  assert.equal(opened[0].open, false, "loadFromSqlite leaked an open database handle");
 });

--- a/backend/search/citation-graph-store.test.js
+++ b/backend/search/citation-graph-store.test.js
@@ -5,7 +5,7 @@ const path = require("node:path");
 const zlib = require("node:zlib");
 const test = require("node:test");
 
-const { CitationGraphStore, GRAPH_VERSION } = require("./citation-graph-store");
+const { CitationGraphStore, GRAPH_VERSION, SQLITE_SCHEMA_VERSION } = require("./citation-graph-store");
 
 function writeGraph(payload) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "citation-store-"));
@@ -215,4 +215,30 @@ test("sqlite-backed store returns results identical to the JSON store", (t) => {
   assert.equal(status.parserVersion, 15);
   assert.equal(status.edges, 4);
   assert.deepEqual(status.coverage, { legislation: { htmlLaws: 2 } });
+});
+
+// A file that passes the PRAGMA user_version check but has no `metadata`
+// table (e.g. a corrupt/partial write) throws only after the connection is
+// already open. loadFromSqlite must still close that handle on the way out
+// instead of leaking it — regression test for the outer catch in
+// loadFromSqlite silently dropping an opened-but-unassigned `database`.
+test("loadFromSqlite closes the database handle when opened but the schema is incomplete", () => {
+  const Database = require("better-sqlite3");
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "citation-store-partial-"));
+  const sqlitePath = path.join(dir, "data.sqlite");
+
+  const db = new Database(sqlitePath);
+  db.pragma(`user_version = ${SQLITE_SCHEMA_VERSION}`);
+  // Deliberately no `metadata` table, so the SELECT inside loadFromSqlite throws.
+  db.close();
+
+  const store = new CitationGraphStore(path.join(dir, "citation-graph.json"), { sqlitePath });
+  assert.equal(store.load(), false);
+  assert.match(store.getStatus().error, /no such table: metadata/);
+  assert.equal(store.database, null);
+
+  // If the earlier failure had leaked the handle, this exclusive re-open
+  // (no `readonly`) would fail while the leaked connection still held the file.
+  const reopened = new Database(sqlitePath);
+  reopened.close();
 });

--- a/backend/search/fulltext-index-build.js
+++ b/backend/search/fulltext-index-build.js
@@ -165,6 +165,27 @@ function openFulltextDatabase(outputPath) {
       );
       CREATE TABLE fulltext_metadata (key TEXT PRIMARY KEY, value TEXT);
     `);
+  } else {
+    // An existing file is only ever resumed onto, never re-created — so its
+    // schema must match what this build is about to write. `user_version` is
+    // 0 until the very last step of a successful build stamps it (see the
+    // comment above that pragma write below), so 0 means "an interrupted
+    // build of whatever schema is current" and is safe to resume. Anything
+    // else that isn't FULLTEXT_SCHEMA_VERSION is a completed build from a
+    // schema that has since changed shape; resuming onto it would insert
+    // current-shape rows alongside old ones and then stamp the whole file as
+    // current, same failure mode definition-index-build.js's readCheckpoint
+    // guards against for its JSON checkpoint. Unlike that checkpoint, this is
+    // the artifact itself with no separate "discard and start clean" path, so
+    // this throws rather than silently deleting or ignoring an on-disk file.
+    const existingVersion = db.pragma("user_version", { simple: true });
+    if (existingVersion !== 0 && existingVersion !== FULLTEXT_SCHEMA_VERSION) {
+      db.close();
+      throw new Error(
+        `${outputPath} has schema version ${existingVersion}, but this build writes version ${FULLTEXT_SCHEMA_VERSION}. `
+        + "Resuming would stamp stale rows as current. Delete the file and rebuild from scratch."
+      );
+    }
   }
   return db;
 }

--- a/backend/search/fulltext-index-build.test.js
+++ b/backend/search/fulltext-index-build.test.js
@@ -172,6 +172,35 @@ test("openFulltextDatabase creates the units/units_fts/fulltext_metadata schema"
   }
 });
 
+test("openFulltextDatabase refuses to resume onto a file stamped with a different schema version", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "fulltext-db-stale-"));
+  const outputPath = path.join(dir, "fulltext.sqlite");
+  const first = openFulltextDatabase(outputPath);
+  first.pragma(`user_version = ${FULLTEXT_SCHEMA_VERSION + 1}`);
+  first.close();
+
+  try {
+    assert.throws(() => openFulltextDatabase(outputPath), /schema version/);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("openFulltextDatabase resumes onto a file whose user_version is still 0 (interrupted pre-stamp build)", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "fulltext-db-interrupted-"));
+  const outputPath = path.join(dir, "fulltext.sqlite");
+  const first = openFulltextDatabase(outputPath);
+  first.close();
+
+  const db = openFulltextDatabase(outputPath);
+  try {
+    assert.equal(db.prepare("PRAGMA user_version").get().user_version, 0);
+  } finally {
+    db.close();
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("buildFulltextIndex (real fixture, real worker pool) populates units + units_fts and stamps metadata/user_version on completion", async () => {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "fulltext-build-"));
   const outputPath = path.join(dir, "fulltext.sqlite");

--- a/backend/server.js
+++ b/backend/server.js
@@ -316,6 +316,40 @@ registerMcpEndpoint(app, {
   FMX_DIR: CACHE_DIR,
 });
 
+// Express error-handling middleware — must be registered after all routes,
+// and must take four arguments to be recognized as an error handler.
+// Without this, a malformed request body thrown by express.json() (or any
+// other synchronous middleware/route error) falls through to Express's
+// default handler, which returns an HTML page (with a stack trace outside
+// production). For /mcp specifically, callers are JSON-RPC clients and
+// expect a JSON-RPC error envelope, not HTML.
+app.use((err, req, res, next) => {
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  const isJsonParseError = err instanceof SyntaxError && 'body' in err;
+  const status = isJsonParseError ? 400 : (err.statusCode || 500);
+
+  if (req.path === '/mcp') {
+    return res.status(status).json({
+      jsonrpc: '2.0',
+      error: {
+        code: isJsonParseError ? -32700 : -32603,
+        message: isJsonParseError ? 'Parse error' : 'Internal server error',
+      },
+      id: null,
+    });
+  }
+
+  if (isJsonParseError) {
+    return res.status(400).json({ error: 'Invalid JSON in request body' });
+  }
+
+  console.error('[API] Unhandled error:', err.message);
+  return res.status(500).json({ error: 'Internal server error' });
+});
+
 const server = app.listen(PORT, () => {
   console.log(`EUR-Lex FMX API running on port ${PORT}`);
   console.log(`MCP endpoint: POST /mcp (Streamable HTTP)`);

--- a/backend/shared/article-digest-service.js
+++ b/backend/shared/article-digest-service.js
@@ -163,6 +163,7 @@ async function generateArticleDigest(input, {
       digest: { summary: '', themes: [], noCaseLaw: true },
       model,
       usage: null,
+      billed: false,
     };
   }
 
@@ -183,6 +184,7 @@ async function generateArticleDigest(input, {
     digest: parseArticleDigestJson(response.text, input),
     model: response.model || model,
     usage: response.usage || null,
+    billed: true,
   };
 }
 
@@ -222,6 +224,7 @@ async function ensureArticleDigest({
         generatedAt: cached.generatedAt || null,
         caseLawCacheVersion: cached.caseLawCacheVersion,
         cached: true,
+        billed: false,
       };
     }
 
@@ -248,6 +251,10 @@ async function ensureArticleDigest({
       generatedAt: entry?.generatedAt || null,
       caseLawCacheVersion: CASE_LAW_CACHE_VERSION,
       cached: false,
+      // Whether a real (billed) model call happened — distinct from `cached`:
+      // the zero-case short-circuit above also returns `cached: false` (there
+      // is no cache entry validated) but never calls the model.
+      billed: generated.billed === true,
     };
   });
 }

--- a/backend/shared/article-digest-service.test.js
+++ b/backend/shared/article-digest-service.test.js
@@ -163,4 +163,50 @@ test('ensureArticleDigest caches no-case-law results without calling the model',
 
   assert.equal(result.digest.noCaseLaw, true);
   assert.equal(calls, 0);
+  // The route charges the caller's generation budget on `billed`, not on
+  // `cached` — this zero-case short-circuit is `cached: false` (there is
+  // nothing to validate against a cache entry) but must not be billed.
+  assert.equal(result.cached, false);
+  assert.equal(result.billed, false);
+});
+
+test('ensureArticleDigest reports billed:true only when the model was actually called', async () => {
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'article-digest-service-'));
+  let calls = 0;
+  const args = {
+    celex: '32016R0679',
+    articleNumber: '6',
+    lang: 'ENG',
+    parsedLaw: sampleParsedLaw(),
+    caseLawPayload: sampleCases(),
+    cacheDir,
+    apiKey: 'test-key',
+    model: 'test-model',
+    chatComplete: async () => {
+      calls++;
+      return {
+        model: 'test-model',
+        usage: { total_tokens: 42 },
+        text: JSON.stringify({
+          summary: 'The Court links Article 6 to a valid legal basis.',
+          noCaseLaw: false,
+          themes: [{
+            name: 'Legal basis',
+            description: 'Processing must rest on a valid legal basis.',
+            cites: [{ ecli: 'ECLI:EU:C:2020:559', declarationNumber: '1' }],
+          }],
+        }),
+      };
+    },
+  };
+
+  const first = await ensureArticleDigest(args);
+  assert.equal(first.cached, false);
+  assert.equal(first.billed, true);
+  assert.equal(calls, 1);
+
+  const second = await ensureArticleDigest(args);
+  assert.equal(second.cached, true);
+  assert.equal(second.billed, false);
+  assert.equal(calls, 1);
 });

--- a/backend/shared/case-law-digest-service.js
+++ b/backend/shared/case-law-digest-service.js
@@ -179,6 +179,7 @@ async function generateCaseLawDigest(input, {
       digest: { summary: '', themes: [], noCaseLaw: true },
       model,
       usage: null,
+      billed: false,
     };
   }
 
@@ -199,6 +200,7 @@ async function generateCaseLawDigest(input, {
     digest: parseCaseLawDigestJson(response.text, input),
     model: response.model || model,
     usage: response.usage || null,
+    billed: true,
   };
 }
 
@@ -234,6 +236,7 @@ async function ensureCaseLawDigest({
         generatedAt: cached.generatedAt || null,
         caseLawCacheVersion: cached.caseLawCacheVersion,
         cached: true,
+        billed: false,
       };
     }
 
@@ -260,6 +263,10 @@ async function ensureCaseLawDigest({
       generatedAt: entry?.generatedAt || null,
       caseLawCacheVersion: CASE_LAW_CACHE_VERSION,
       cached: false,
+      // Whether a real (billed) model call happened — distinct from `cached`:
+      // the zero-case short-circuit above also returns `cached: false` but
+      // never calls the model.
+      billed: generated.billed === true,
     };
   });
 }

--- a/backend/shared/case-law-digest-service.test.js
+++ b/backend/shared/case-law-digest-service.test.js
@@ -136,7 +136,10 @@ test('ensureCaseLawDigest caches results without re-calling the model', async ()
 
   assert.equal(first.digest.noCaseLaw, false);
   assert.equal(first.digest.themes.length, 1);
+  assert.equal(first.cached, false);
+  assert.equal(first.billed, true);
   assert.equal(second.cached, true);
+  assert.equal(second.billed, false);
   assert.equal(calls, 1);
 });
 
@@ -159,4 +162,9 @@ test('ensureCaseLawDigest caches no-case-law results without calling the model',
 
   assert.equal(result.digest.noCaseLaw, true);
   assert.equal(calls, 0);
+  // The route charges the caller's generation budget on `billed`, not on
+  // `cached` — this zero-case short-circuit is `cached: false` but must not
+  // be billed.
+  assert.equal(result.cached, false);
+  assert.equal(result.billed, false);
 });

--- a/backend/shared/formex-parser/languages.mjs
+++ b/backend/shared/formex-parser/languages.mjs
@@ -696,7 +696,7 @@ export function detectLanguage(doc) {
  * Falls back to EN for unsupported languages.
  */
 export function getLangConfig(code) {
-  return LANGUAGES[code] || LANGUAGES.EN;
+  return Object.hasOwn(LANGUAGES, code) ? LANGUAGES[code] : LANGUAGES.EN;
 }
 
 /**

--- a/backend/shared/openrouter-chat.js
+++ b/backend/shared/openrouter-chat.js
@@ -34,6 +34,33 @@ function withTimeout(signal, timeoutMs) {
   return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 }
 
+// Rejects as soon as `signal` aborts, so a caller-initiated abort takes
+// effect even while the request is still queued for a semaphore slot (the
+// fetch itself isn't running yet, so it has nothing to abort). Once the slot
+// is acquired, the in-flight fetch is aborted normally via its own signal.
+//
+// Returns a `cancel` alongside the promise because the listener outlives the
+// race when the request wins it: a caller that reuses one long-lived signal
+// across many calls would otherwise accumulate a listener per call. Passing
+// an AbortSignal to addEventListener is the documented way to detach it.
+function abortRejection(signal) {
+  if (signal.aborted) {
+    return {
+      promise: Promise.reject(new DOMException('The operation was aborted.', 'AbortError')),
+      cancel: () => {},
+    };
+  }
+  const detach = new AbortController();
+  const promise = new Promise((_, reject) => {
+    signal.addEventListener(
+      'abort',
+      () => reject(new DOMException('The operation was aborted.', 'AbortError')),
+      { once: true, signal: detach.signal }
+    );
+  });
+  return { promise, cancel: () => detach.abort() };
+}
+
 class ChatProviderError extends Error {
   constructor(message, { status = 500, code = null, details = null } = {}) {
     super(message);
@@ -88,7 +115,11 @@ async function chatComplete({
   if (!apiKey) {
     throw new ChatProviderError('OPENROUTER_API_KEY is required', { status: 503, code: 'missing_api_key' });
   }
-  signal = withTimeout(signal, timeoutMs);
+  // Keep the caller's own signal (if any) separate from the per-call timeout:
+  // the timeout must only start once the request actually begins sending (see
+  // below), but an explicit caller abort has to take effect immediately, even
+  // while the request is still queued on the semaphore.
+  const callerSignal = signal;
   const url = `${String(baseUrl).replace(/\/+$/, '')}/chat/completions`;
   const body = { model, messages, temperature, max_tokens: maxTokens };
   if (responseFormat) {
@@ -103,10 +134,15 @@ async function chatComplete({
   try {
     // The slot is held until the response body has been read, so `limit` is
     // really the number of generations this process can be paying for at once.
-    data = await chatSemaphore.run(async () => {
+    const runPromise = chatSemaphore.run(async () => {
+      // Arm the timeout here, immediately before the fetch, not before the
+      // semaphore admits this call — otherwise time spent waiting in the
+      // queue is charged against the request's own timeout budget, and a
+      // queued request can time out having never been sent.
+      const requestSignal = withTimeout(callerSignal, timeoutMs);
       const res = await fetch(url, {
         method: 'POST',
-        signal,
+        signal: requestSignal,
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${apiKey}`,
@@ -124,6 +160,24 @@ async function chatComplete({
       }
       return res.json();
     });
+    // Prevent an unhandled-rejection warning if the abort race below wins
+    // first and nothing else ever observes runPromise's eventual rejection.
+    runPromise.catch(() => {});
+
+    if (callerSignal) {
+      const abort = abortRejection(callerSignal);
+      // Swallow the loser's rejection either way: whichever promise the race
+      // discards still settles, and an unobserved rejection would surface as
+      // an unhandled-rejection warning.
+      abort.promise.catch(() => {});
+      try {
+        data = await Promise.race([runPromise, abort.promise]);
+      } finally {
+        abort.cancel();
+      }
+    } else {
+      data = await runPromise;
+    }
   } catch (err) {
     if (err instanceof CapacityError) {
       throw new ChatProviderError('Too many AI generations in progress; please retry shortly', {
@@ -150,6 +204,15 @@ async function chatComplete({
  *   { type: 'delta', text }         for each content chunk
  *   { type: 'done', usage, model }  once at the end
  * Throws ChatProviderError on upstream failure (incl. 402 insufficient credits).
+ *
+ * INTENTIONALLY UNGUARDED: unlike chatComplete, this does not go through
+ * chatSemaphore — it is currently unused (referenced only by module.exports),
+ * so there is no established concurrency contract for it yet. Wrapping an
+ * async generator in chatSemaphore.run() the same way chatComplete does would
+ * hold a slot open for the whole lifetime of the stream (which chatComplete
+ * never does — it holds a slot only until the response body is read), a very
+ * different capacity cost. Before this is ever wired up to a real caller, it
+ * must acquire a slot itself with a strategy suited to a long-lived stream.
  */
 async function* chatStream({
   model,

--- a/backend/shared/openrouter-chat.test.js
+++ b/backend/shared/openrouter-chat.test.js
@@ -36,6 +36,86 @@ test('chatComplete passes response_format and reasoning when requested', async (
   }
 });
 
+test('chatComplete only starts the timeout once a semaphore slot is granted, not while queued', async () => {
+  const originalFetch = global.fetch;
+  let callIndex = 0;
+  global.fetch = async (_url, options) => {
+    const index = callIndex++;
+    if (index < 3) {
+      // The first three calls occupy every slot and hold it for 200ms, so
+      // the 4th (queued) call sits in the queue for ~190ms before it is ever
+      // admitted. With the bug (timeout armed before queue admission), that
+      // wait alone exceeds the 4th call's 50ms budget and it never even gets
+      // to make this request; with the fix, its 50ms timeout starts fresh
+      // once admitted, comfortably beating this instantly-resolving branch.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+    }
+    if (options.signal?.aborted) {
+      throw new DOMException('The operation was aborted.', 'AbortError');
+    }
+    return {
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+        model: 'test-model',
+        usage: { total_tokens: 1 },
+      }),
+    };
+  };
+
+  try {
+    const common = { model: 'test-model', apiKey: 'test-key', messages: [{ role: 'user', content: 'hi' }] };
+    // OPENROUTER_MAX_CONCURRENCY defaults to 3, so these three occupy every
+    // slot and the fourth call below must queue.
+    const holds = [chatComplete(common), chatComplete(common), chatComplete(common)];
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const queued = await chatComplete({ ...common, timeoutMs: 50 });
+    assert.equal(queued.text, 'ok');
+
+    await Promise.all(holds);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
+test('chatComplete honours a caller-supplied abort signal immediately, even while queued', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async (_url, options) => {
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    if (options.signal?.aborted) {
+      throw new DOMException('The operation was aborted.', 'AbortError');
+    }
+    return {
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+        model: 'test-model',
+        usage: { total_tokens: 1 },
+      }),
+    };
+  };
+
+  try {
+    const common = { model: 'test-model', apiKey: 'test-key', messages: [{ role: 'user', content: 'hi' }] };
+    const holds = [chatComplete(common), chatComplete(common), chatComplete(common)];
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const controller = new AbortController();
+    const queued = chatComplete({ ...common, signal: controller.signal });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const start = Date.now();
+    controller.abort();
+    await assert.rejects(queued, (err) => err.name === 'AbortError');
+    assert.ok(Date.now() - start < 150, 'an abort while queued must reject promptly, not once a slot frees up');
+
+    await Promise.allSettled(holds);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
 test('normalizeMessageText extracts provider content parts', () => {
   assert.equal(
     normalizeMessageText([

--- a/backend/shared/recital-title-service.js
+++ b/backend/shared/recital-title-service.js
@@ -105,7 +105,7 @@ function parseTitleJson(text, validNumbers) {
 async function generateRecitalTitles({ celex, lang, recitals, apiKey, model }) {
   const validRecitals = (recitals || [])
     .filter((r) => String(r.recital_number || '').trim());
-  if (validRecitals.length === 0) return {};
+  if (validRecitals.length === 0) return { titles: {}, billed: false };
 
   const titles = {};
   for (let index = 0; index < validRecitals.length; index += RECITAL_TITLE_BATCH_SIZE) {
@@ -132,7 +132,7 @@ async function generateRecitalTitles({ celex, lang, recitals, apiKey, model }) {
     Object.assign(titles, batchTitles);
   }
 
-  return titles;
+  return { titles, billed: true };
 }
 
 const withSingleFlight = makeSingleFlight();
@@ -157,10 +157,11 @@ async function ensureRecitalTitles({ celex, lang, recitals, cacheDir, apiKey, mo
         titles: cached.titles,
         model: cached.model || null,
         cached: true,
+        billed: false,
       };
     }
 
-    const titles = await generateRecitalTitles({ celex, lang, recitals, apiKey, model });
+    const { titles, billed } = await generateRecitalTitles({ celex, lang, recitals, apiKey, model });
 
     if (cacheDir) {
       try {
@@ -179,7 +180,10 @@ async function ensureRecitalTitles({ celex, lang, recitals, cacheDir, apiKey, mo
       }
     }
 
-    return { titles, model, cached: false };
+    // `billed` reflects whether a real model call happened — distinct from
+    // `cached: false`, which is also returned for the zero-recitals
+    // short-circuit above (there's nothing to cache, and nothing was billed).
+    return { titles, model, cached: false, billed };
   });
 }
 

--- a/backend/shared/recital-title-service.test.js
+++ b/backend/shared/recital-title-service.test.js
@@ -4,7 +4,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 
-const { parseTitleJson, getCachedRecitalTitles } = require('./recital-title-service');
+const { parseTitleJson, getCachedRecitalTitles, ensureRecitalTitles } = require('./recital-title-service');
 
 test('parseTitleJson extracts valid recital title mappings', () => {
   const titles = parseTitleJson('```json\n{"1":" Fundamental right to data protection.","2":"Free movement of data","999":"Ignore me"}\n```', ['1', '2']);
@@ -49,5 +49,33 @@ test('getCachedRecitalTitles returns cached titles on a content-hash match and n
   // Changed content invalidates the cache entry.
   const changed = getCachedRecitalTitles({ celex: '32016R0679', lang: 'ENG', recitals: [{ recital_number: '1', recital_text: 'Different.' }], cacheDir });
   assert.equal(changed.cached, false);
+});
+
+test('ensureRecitalTitles reports billed:false and never calls the model when there are no recitals', async () => {
+  const originalFetch = global.fetch;
+  global.fetch = async () => {
+    throw new Error('chatComplete should not be called for zero recitals');
+  };
+
+  try {
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'recital-cache-'));
+    const result = await ensureRecitalTitles({
+      celex: '32016R0679',
+      lang: 'ENG',
+      recitals: [],
+      cacheDir,
+      apiKey: 'test-key',
+      model: 'test-model',
+    });
+
+    // The route charges the caller's generation budget on `billed`, not on
+    // `cached` — the zero-recitals short-circuit is `cached: false` (there's
+    // nothing to validate against a cache entry) but must not be billed.
+    assert.deepEqual(result.titles, {});
+    assert.equal(result.cached, false);
+    assert.equal(result.billed, false);
+  } finally {
+    global.fetch = originalFetch;
+  }
 });
 

--- a/backend/shared/reference-utils.js
+++ b/backend/shared/reference-utils.js
@@ -9,9 +9,19 @@ function parseReferenceText(text = '') {
   const typeMatch = lower.match(/\b(regulation|directive|decision)\b/);
   const actType = typeMatch ? typeMatch[1] : null;
 
+  // EU numbering has two eras: post-2015 acts are "year/number" (e.g. "(EU)
+  // 2016/679"), pre-2015 acts are "No number/year" (e.g. "(EC) No 1924/2006").
+  // Both shapes look like "\d+/\d+", so the year-first pattern below would
+  // otherwise match a pre-2015 reference too and invert year/number. We keep
+  // this pattern first (not reordered after the "No " pattern) because text
+  // can contain both forms and the first pattern must keep winning for the
+  // post-2015 act (see the "mixed text" regression test) -- instead the
+  // negative lookbehind refuses the match when the digit run is immediately
+  // preceded by "No " (or "No." -- older OJ renderings abbreviate with a
+  // period), leaving that text for the second pattern to catch.
   const numberPatterns = [
-    /\b(?:\((?:eu|ec|eec|euratom)\)\s*)?(\d{4})\/(\d{1,4})\b/i,
-    /\bno\s+(\d{1,4})\/(\d{4})\b/i,
+    /\b(?:\((?:eu|ec|eec|euratom)\)\s*)?(?<!\bno\.?\s)(\d{4})\/(\d{1,4})\b/i,
+    /\bno\.?\s+(\d{1,4})\/(\d{4})\b/i,
   ];
 
   let year = null;

--- a/backend/shared/reference-utils.test.js
+++ b/backend/shared/reference-utils.test.js
@@ -25,6 +25,52 @@ test('parseReferenceText extracts act type and year/number', () => {
   assert.equal(parsed.number, '679');
 });
 
+test('parseReferenceText resolves pre-2015 "No <number>/<year>" numbering', () => {
+  const parsed = parseReferenceText('Regulation (EC) No 1924/2006');
+  assert.equal(parsed.year, '2006');
+  assert.equal(parsed.number, '1924');
+});
+
+test('parseReferenceText tolerates an abbreviating period after "No"', () => {
+  // Older OJ renderings write "No." rather than the EU house style "No"; both
+  // must land on the pre-2015 branch, or the digits come back inverted.
+  const parsed = parseReferenceText('Regulation (EC) No. 1924/2006');
+  assert.equal(parsed.year, '2006');
+  assert.equal(parsed.number, '1924');
+});
+
+test('parseReferenceText resolves "No <number>/<year>" without a bracketed act code', () => {
+  const parsed = parseReferenceText('Council Regulation No 1/2003');
+  assert.equal(parsed.year, '2003');
+  assert.equal(parsed.number, '1');
+});
+
+test('parseReferenceText resolves "No <number>/<year>" for implementing/delegated acts', () => {
+  const parsed = parseReferenceText('Commission Implementing Regulation (EU) No 28/2014');
+  assert.equal(parsed.year, '2014');
+  assert.equal(parsed.number, '28');
+});
+
+test('parseReferenceText keeps post-2015 precedence when both numbering eras appear', () => {
+  // The year-first pattern must still win for the leading post-2015 reference
+  // even though a pre-2015 "No <number>/<year>" reference follows it in the
+  // same text -- the negative lookbehind only suppresses the "No " match, it
+  // does not reorder which pattern is tried first.
+  const parsed = parseReferenceText('Regulation (EU) 2016/679 amending Regulation No 45/2001');
+  assert.equal(parsed.year, '2016');
+  assert.equal(parsed.number, '679');
+});
+
+test('parseReferenceText does not resolve a 2-digit-year "<year>/<number>/<suffix>" form (pre-existing gap)', () => {
+  // Neither numberPatterns entry matches this shape today (2-digit year, and
+  // a trailing "/EC" suffix rather than a bare year/number pair). This is a
+  // pre-existing gap, not something this fix addresses -- assert the current
+  // (null/null) behaviour so a future change to it is a deliberate decision.
+  const parsed = parseReferenceText('Directive 95/46/EC');
+  assert.equal(parsed.year, null);
+  assert.equal(parsed.number, null);
+});
+
 test('parseStructuredReference normalizes structured fields', () => {
   const parsed = parseStructuredReference({
     actType: 'Directive',

--- a/src/utils/caseLawCache.test.js
+++ b/src/utils/caseLawCache.test.js
@@ -9,12 +9,11 @@ vi.mock("./formexApi.js", () => ({
 }));
 
 let loadCaseLaw;
-let peekCaseLaw;
 
 beforeEach(async () => {
   vi.resetModules();
   mockFetchCaseLaw.mockReset();
-  ({ loadCaseLaw, peekCaseLaw } = await import("./caseLawCache.js"));
+  ({ loadCaseLaw } = await import("./caseLawCache.js"));
 });
 
 describe("caseLawCache", () => {
@@ -30,7 +29,6 @@ describe("caseLawCache", () => {
     expect(mockFetchCaseLaw).toHaveBeenCalledTimes(1);
     expect(mockFetchCaseLaw).toHaveBeenCalledWith("32016R0679");
     expect(second).toBe(first);
-    expect(peekCaseLaw("32016R0679")).toBe(first);
   });
 
   it("does not cache a failed fetch, so a later retry refetches", async () => {
@@ -39,7 +37,6 @@ describe("caseLawCache", () => {
       .mockResolvedValueOnce({ cases: [{ caseId: "C-2" }] });
 
     await expect(loadCaseLaw("32002L0058")).rejects.toThrow("case law cellar down");
-    expect(peekCaseLaw("32002L0058")).toBeNull();
 
     await expect(loadCaseLaw("32002L0058")).resolves.toEqual({ cases: [{ caseId: "C-2" }] });
     expect(mockFetchCaseLaw).toHaveBeenCalledTimes(2);


### PR DESCRIPTION
Acts on the low-risk findings from a backend review pass. Each finding was verified against source before anything was changed; a few claims from the original review did not hold up and are listed at the bottom rather than silently dropped.

One commit per group, so they can be reviewed or reverted independently.

## What changed

**`f381958` — inverted year/number on pre-2015 references** (the one with real blast radius)

EU numbering has two eras: post-2015 acts are `year/number` (`(EU) 2016/679`), pre-2015 acts are `No number/year` (`(EC) No 1924/2006`). Both render as `\d+/\d+`, and `parseReferenceText` tried the year-first pattern first — so every pre-2015 reference came back with year and number swapped, and the resolver silently looked up the wrong act. That is the majority of the corpus, reachable from the resolve endpoints, MCP and the CLI.

Fixed with a negative lookbehind rather than by reordering the patterns, because reordering would change which reference wins in text containing both eras (`Regulation (EU) 2016/679 amending Regulation No 45/2001` would flip to the second act). Also covers the abbreviated `No.` form that older OJ renderings use.

**`27cdad1` — MCP bypassed the AI-spend guards**

`/mcp` is registered with only the generic per-IP rate limiter — no origin allowlist, no generation limiter, no `chargeGeneration()` — yet `get_law_part` called `ensureRecitalTitles` with a live OpenRouter key on a cache miss. The REST route for the same feature caps at 10 generations/hour/IP. MCP now serves titles from cache only; a miss returns `title: null`, which is what the previous soft-fail path produced anyway. `makeHandler` also returned raw `err.message` to clients, leaking filesystem paths and upstream URLs; it now mirrors `safeErrorResponse`.

**`c2c506d` — two build-time defects**

`citation-graph-build` walked the corpus filtering on extension alone, so the AppleDouble sidecars (`._` + CELEX + `.xml.gz`) that ship in the corpus tarballs were read as acts, failed gunzip, and inflated the failure counts in the published artifact. `search/corpus-files.js` exists to prevent exactly this but this builder cannot use it (it defines its own `listCorpusFiles` with a different signature), so the dotfile guard is applied in place.

`fulltext-index-build` never checked `PRAGMA user_version` on an existing database yet stamped the current version at the end of a run, so after the next schema bump a resume onto a leftover file would have stamped stale rows as current. It now refuses to resume across versions.

**`88ef572` — four unrelated hardening fixes**

No Express error middleware existed, so a malformed JSON body came back as an HTML page (with a stack trace outside production) — and as HTML rather than JSON-RPC for `/mcp`. `getLangConfig` fell back with `LANGUAGES[code] ||`, returning an `Object.prototype` member for an inherited property name. `CitationGraphStore.loadFromSqlite` dropped its database handle without closing it when it failed between open and promotion. `eurlex resolve`/`resolve-url` silently answered in English when given an invalid `--lang`.

**`6fac9a3` — generation budget and queued timeouts**

`chatComplete` armed its timeout before the semaphore admitted the call, so queue wait was charged against the request's own budget and a queued call could time out having never been sent. Separately, the digest and recital-title services short-circuit when there is nothing to summarise and return without calling the model, but reported `cached: false` — and the routes charged on `!result.cached`, so a request that cost nothing consumed one of the caller's ten hourly generations. The services now report `billed` explicitly.

**`3b1195a` — two of the new tests did not actually test anything**

Found by reverting each source fix and checking the test still passed. The MCP cached-only test asserted the title came back `null`, but the pre-fix code produced `null` too — it made the billed call, watched it fail with no network, and soft-failed. It now stubs `fetch` to *succeed* and asserts it is never reached. The `citation-graph-store` test proved a handle was closed by re-opening the file, but SQLite grants concurrent connections, so it passed leaked or not; it now tracks every `better-sqlite3` instance and asserts each was closed.

## Scope and what was deliberately left out

- **Non-atomic cache writes** (`fmx-service.js`, `law-queries.js`, `reenrich-cache.js`). Real, and the nastiest failure mode of the set: a crash mid-write leaves a truncated `.combined.xml` that is served forever behind an `existsSync` check, parsing into garbage rather than erroring. Left out because the fix is not just tmp+rename — it needs a sweep for already-poisoned caches on existing volumes, and `.tmp` cleanup that the size-based eviction can see. Worth its own change.
- **Uncapped recital-range expansion** in the parser. Trivial to fix, but parser output changes force a `PARSER_VERSION` bump, which invalidates the backend law caches and every browser's IndexedDB. Should be batched with other parser work rather than smuggled in here.
- **All the duplication cleanup** (the two digest services, the triplicated model/key env chain, `LANG_3_TO_2`, `escapeHtml`, the 14 inline CELEX guards). Zero urgency and the highest chance of introducing a silent cache-key or prompt change; belongs on its own branch.

No version constants are bumped and no data release is required.

## Verification

- Backend: 556 pass / 2 skipped / 0 fail (baseline before this branch was 538 pass / 2 skipped).
- Frontend: 514 pass across 43 files — checked because `languages.mjs` is shared with the browser parser.
- `eslint .` clean.

Every new test was checked against the pre-fix code, not just against the fix: 15 fail without their fix, two are deliberate characterization tests asserting unchanged behaviour, and the two that were vacuous are rewritten in `3b1195a`.

One caveat on the builder fixes: they are validated against synthetic fixtures only. No corpus data exists in a fresh checkout, so I could not confirm sidecars are still present in the current corpus releases — `corpus-files.js` notes they are being cleaned separately.

## Review notes

Three claims from the original review did **not** hold up and are not addressed here, deliberately:

- `in-force-recheck.js` was reported as writing plain JSON to the `.gz` path. It does not — it already writes gzipped bytes via tmp+rename and is one of the few correct write paths in the tree.
- The `citation-graph-store` handle leak was narrower than reported: the three explicit version-mismatch branches already closed correctly. Only the outer `catch` leaked, and that is what was fixed.
- `law-corpus-store` swallowing `EACCES`/`EIO` as a cache miss is deliberate, with a comment explaining the choice. Left alone.

Two pre-existing gaps surfaced while testing the reference fix and are now asserted as-is rather than fixed: `Directive 95/46/EC` and `Regulation (EEC) No 1408/71` (two-digit years) parse to `null` — pre-1999 acts do not resolve from reference text at all. Probably deserves its own issue.

One latent test-isolation fragility was found but not refactored: `makeDeps` in `backend/mcp/register-tools.test.js` points `FMX_DIR` at a fixed `os.tmpdir()` path assumed never to exist, so anything that ever writes there poisons every later run on that machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HopEGWRvGT29ThJQ8ZXJwW