### PR TITLE
Split the TopBar god-file into hooks, modal, and result components

### DIFF
--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -55,7 +55,6 @@ export function Landing({ forcedLocale = null }) {
   const {
     allLawsData,
     handleSearchOpen,
-    hasSearchInitialized,
     isSearchLoading,
     searchableLawCount,
   } = useLandingSearchIndex({
@@ -168,7 +167,6 @@ export function Landing({ forcedLocale = null }) {
         eurlexUrl={null}
         showPrint={false}
         onSearchOpen={handleSearchOpen}
-        hasSearchInitialized={hasSearchInitialized}
         isSearchLoading={isSearchLoading}
         formexLang={formexLang}
         searchableLawCount={searchableLawCount}
@@ -202,7 +200,6 @@ export function Landing({ forcedLocale = null }) {
               lists={allLawsData}
               onNavigate={handleSearchNavigate}
               onSearchOpen={handleSearchOpen}
-              hasSearchInitialized={hasSearchInitialized}
               isSearchLoading={isSearchLoading}
               activeLanguage={formexLang}
               searchableLawCount={searchableLawCount}

--- a/src/components/LawViewer.jsx
+++ b/src/components/LawViewer.jsx
@@ -155,7 +155,6 @@ export function LawViewer() {
   const {
     allLawsData,
     handleSearchOpen,
-    hasSearchInitialized,
     isSearchLoading,
     searchableLawCount,
   } = useLandingSearchIndex({
@@ -356,7 +355,6 @@ export function LawViewer() {
           onPrint={() => printState.setPrintModalOpen(true)}
           showPrint={!derived.isSideBySide}
           onSearchOpen={handleSearchOpen}
-          hasSearchInitialized={hasSearchInitialized}
           isSearchLoading={isSearchLoading}
           onToggleSidebar={() => preferences.setIsSidebarOpen((current) => !current)}
           isSidebarOpen={preferences.isSidebarOpen}

--- a/src/components/SearchBox.local-modes.test.jsx
+++ b/src/components/SearchBox.local-modes.test.jsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { createElement } from "react";
+import { MemoryRouter } from "react-router-dom";
+
+const { SearchBox } = await import("./TopBar.jsx");
+const { I18nProvider } = await import("../i18n/I18nProvider.jsx");
+
+let container;
+let root;
+
+const emptyLists = { articles: [], recitals: [], annexes: [] };
+const lists = {
+  articles: [{
+    article_number: "1",
+    article_title: "Personal data",
+    article_html: "<p>The protection of personal data is fundamental.</p>",
+    law_key: "gdpr",
+    law_slug: "gdpr",
+  }],
+  recitals: [],
+  annexes: [],
+};
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  vi.useFakeTimers();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  document.body.innerHTML = "";
+  vi.clearAllTimers();
+  vi.useRealTimers();
+  delete globalThis.IS_REACT_ACT_ENVIRONMENT;
+});
+
+function typeInto(input, value) {
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+    setter.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+// Mirrors the LawViewer invocation: the law reader defaults to "current" mode,
+// which must render without crashing (the busy flags live in a hook whose
+// state arrives only after that hook has run).
+function renderLawReaderSearchBox() {
+  root = createRoot(container);
+  act(() => {
+    root.render(createElement(
+      MemoryRouter,
+      null,
+      createElement(I18nProvider, null, createElement(SearchBox, {
+        lists,
+        onNavigate: () => {},
+        onSearchOpen: () => Promise.resolve(emptyLists),
+        searchableLawCount: 3,
+        triggerVariant: "hero",
+        searchModes: ["laws", "matches", "definitions", "fulltext", "current"],
+        defaultSearchMode: "current",
+      })),
+    ));
+  });
+}
+
+describe("SearchBox — current and matches modes", () => {
+  it("renders current mode by default and clears results when the query shrinks below two characters", async () => {
+    renderLawReaderSearchBox();
+
+    const heroInput = container.querySelector("input");
+    typeInto(heroInput, "data");
+    const dialogInput = document.body.querySelector('[role="dialog"] input');
+    expect(dialogInput).not.toBeNull();
+
+    // The current-law index builds through a setTimeout(100).
+    await act(async () => vi.advanceTimersByTimeAsync(150));
+    expect(document.body.textContent).toContain("Art. 1");
+
+    typeInto(dialogInput, "d");
+    expect(document.body.textContent).not.toContain("Art. 1");
+  });
+
+  it("switches to matches mode without crashing", async () => {
+    renderLawReaderSearchBox();
+
+    const heroInput = container.querySelector("input");
+    typeInto(heroInput, "zz");
+    const tab = Array.from(document.body.querySelectorAll('[role="tab"]'))
+      .find((element) => element.textContent === "Opened laws");
+    expect(tab).toBeTruthy();
+
+    act(() => tab.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+    expect(document.body.querySelector('[role="dialog"] input')).not.toBeNull();
+
+    await act(async () => vi.advanceTimersByTimeAsync(150));
+    expect(document.body.querySelector('[role="dialog"]')).not.toBeNull();
+  });
+
+  it("clears matches results when the query shrinks below two characters", async () => {
+    renderLawReaderSearchBox();
+
+    const heroInput = container.querySelector("input");
+    typeInto(heroInput, "zz");
+    const tab = Array.from(document.body.querySelectorAll('[role="tab"]'))
+      .find((element) => element.textContent === "Opened laws");
+    act(() => tab.dispatchEvent(new MouseEvent("click", { bubbles: true })));
+
+    const dialogInput = document.body.querySelector('[role="dialog"] input');
+    typeInto(dialogInput, "data");
+    await act(async () => vi.advanceTimersByTimeAsync(150));
+    expect(document.body.textContent).toContain("Art. 1");
+
+    typeInto(dialogInput, "d");
+    expect(document.body.textContent).not.toContain("Art. 1");
+  });
+});

--- a/src/components/ToolsMenu.jsx
+++ b/src/components/ToolsMenu.jsx
@@ -1,0 +1,144 @@
+import { useState, useEffect, useRef } from "react";
+import { ExternalLink, Printer, PanelLeftClose, PanelLeftOpen, Minus, Plus, MoreVertical, RotateCcw } from "lucide-react";
+import { ThemeToggle } from "./ThemeToggle.jsx";
+import { useI18n } from "../i18n/useI18n.js";
+
+export function ToolsMenu({
+  onPrint,
+  showPrint,
+  onIncreaseFont,
+  onDecreaseFont,
+  fontSize,
+  eurlexUrl,
+  onToggleSidebar,
+  isSidebarOpen,
+  onToggleSecondLanguage,
+  isSideBySide,
+  onResetApp,
+}) {
+  const { t } = useI18n();
+  const [isOpen, setIsOpen] = useState(false);
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event) => {
+      if (menuRef.current && !menuRef.current.contains(event.target)) {
+        setIsOpen(false);
+      }
+    };
+    if (isOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className={`p-2 rounded-lg transition-colors ${isOpen ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-white' : 'text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white'}`}
+        title={t("topBar.moreTools")}
+      >
+        <MoreVertical size={20} />
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 top-full mt-2 w-56 p-2 bg-white rounded-xl shadow-xl ring-1 ring-black/5 dark:bg-gray-900 dark:ring-white/10 flex flex-col gap-1 z-50 animate-in fade-in zoom-in-95 duration-100">
+
+          {onToggleSidebar && (
+            <button
+              onClick={() => { onToggleSidebar(); setIsOpen(false); }}
+              className="hidden md:flex items-center gap-3 w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+            >
+              {isSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
+              <span>{isSidebarOpen ? t("topBar.hideSidebar") : t("topBar.showSidebar")}</span>
+            </button>
+          )}
+
+          {showPrint && (
+            <button
+              onClick={() => { onPrint(); setIsOpen(false); }}
+              className="flex items-center gap-3 w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+            >
+              <Printer size={18} />
+              <span>{t("topBar.printPdf")}</span>
+            </button>
+          )}
+
+          {onToggleSecondLanguage && (
+            <button
+              type="button"
+              onClick={() => {
+                onToggleSecondLanguage();
+                setIsOpen(false);
+              }}
+              className="flex items-center gap-3 w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+            >
+              <PanelLeftOpen size={18} />
+              <span>
+                {isSideBySide
+                  ? t("topBar.closeSideBySide")
+                  : t("topBar.openSideBySide")}
+              </span>
+            </button>
+          )}
+
+          {eurlexUrl && (
+            <a
+              href={eurlexUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={() => setIsOpen(false)}
+              className="flex items-center gap-3 w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+            >
+              <ExternalLink size={18} />
+              <span>{t("topBar.viewOnEurlex")}</span>
+            </a>
+          )}
+
+          {onResetApp && (
+            <button
+              type="button"
+              onClick={() => {
+                onResetApp();
+                setIsOpen(false);
+              }}
+              className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+            >
+              <RotateCcw size={18} />
+              <span className="min-w-0 flex-1 text-left">{t("resetFooter.button")}</span>
+            </button>
+          )}
+
+          <div className="px-3 py-2">
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-gray-700 dark:text-gray-200">{t("common.theme")}</span>
+              <ThemeToggle />
+            </div>
+          </div>
+
+          {/* Font Size */}
+          <div className="px-3 py-2">
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={onDecreaseFont}
+                className="rounded-lg p-1 text-gray-500 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+              >
+                <Minus size={16} />
+              </button>
+              <span className="text-xs font-medium text-gray-500 dark:text-gray-400">{fontSize}%</span>
+              <button
+                type="button"
+                onClick={onIncreaseFont}
+                className="rounded-lg p-1 text-gray-500 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+              >
+                <Plus size={16} />
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ToolsMenu.test.jsx
+++ b/src/components/ToolsMenu.test.jsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { createElement } from "react";
+import { MemoryRouter } from "react-router-dom";
+
+const { ToolsMenu } = await import("./ToolsMenu.jsx");
+const { I18nProvider } = await import("../i18n/I18nProvider.jsx");
+const { ThemeProvider } = await import("./ThemeProvider.jsx");
+
+let container;
+let root;
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  document.body.innerHTML = "";
+  window.localStorage.clear();
+  delete globalThis.IS_REACT_ACT_ENVIRONMENT;
+});
+
+function renderToolsMenu(props = {}) {
+  root = createRoot(container);
+  act(() => {
+    root.render(
+      createElement(
+        MemoryRouter,
+        null,
+        createElement(
+          I18nProvider,
+          null,
+          createElement(ThemeProvider, { defaultTheme: "light" }, createElement(ToolsMenu, props))
+        )
+      )
+    );
+  });
+}
+
+function triggerButton() {
+  return container.querySelector('button[title="More tools"]');
+}
+
+function openMenu() {
+  act(() => triggerButton().click());
+}
+
+describe("ToolsMenu", () => {
+  it("opens and closes the menu on the trigger button", () => {
+    renderToolsMenu();
+
+    expect(container.querySelector(".absolute.right-0")).toBeNull();
+    openMenu();
+    expect(container.querySelector(".absolute.right-0")).not.toBeNull();
+    act(() => triggerButton().click());
+    expect(container.querySelector(".absolute.right-0")).toBeNull();
+  });
+
+  it("calls the sidebar toggle callback and closes the menu", () => {
+    const onToggleSidebar = vi.fn();
+    renderToolsMenu({ onToggleSidebar, isSidebarOpen: false });
+
+    openMenu();
+    const item = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent.includes("Show sidebar"));
+    act(() => item.click());
+
+    expect(onToggleSidebar).toHaveBeenCalledTimes(1);
+    expect(container.querySelector(".absolute.right-0")).toBeNull();
+  });
+
+  it("hides the print item when showPrint is false", () => {
+    renderToolsMenu({ showPrint: false, onPrint: vi.fn() });
+    openMenu();
+
+    const menuText = container.querySelector(".absolute.right-0").textContent;
+    expect(menuText).not.toContain("Print / PDF");
+  });
+
+  it("shows the print item when showPrint is true and invokes onPrint", () => {
+    const onPrint = vi.fn();
+    renderToolsMenu({ showPrint: true, onPrint });
+    openMenu();
+
+    const item = Array.from(container.querySelectorAll("button"))
+      .find((button) => button.textContent.includes("Print / PDF"));
+    expect(item).toBeTruthy();
+    act(() => item.click());
+    expect(onPrint).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders an EUR-Lex link when eurlexUrl is given", () => {
+    renderToolsMenu({ eurlexUrl: "https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679" });
+    openMenu();
+
+    const link = container.querySelector('a[href^="https://eur-lex.europa.eu"]');
+    expect(link).toBeTruthy();
+    expect(link.target).toBe("_blank");
+    expect(link.textContent).toContain("View on EUR-Lex");
+  });
+});

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
-import { createPortal } from "react-dom";
 import { Link, useNavigate } from "react-router-dom";
-import { ChevronLeft, Search, X, Loader2 } from "lucide-react";
+import { Search } from "lucide-react";
 import { Button } from "./Button.jsx";
 import { ThemeToggle } from "./ThemeToggle.jsx";
 import { LanguageSelector } from "./LanguageSelector.jsx";
@@ -13,45 +12,17 @@ import {
 } from "../utils/formexApi.js";
 import { parseCelexQuery } from "../utils/lawRouting.js";
 import { inferOfficialReferenceFromCelex } from "../utils/library.js";
+import { formatOfficialReference } from "../utils/lawDisplay.js";
 import { useSearchNavigation } from "../hooks/useSearchNavigation.js";
 import { useNetworkedSearch } from "../hooks/search/useNetworkedSearch.js";
 import { useLocalSearchIndexes } from "../hooks/search/useLocalSearchIndexes.js";
 import { ToolsMenu } from "./ToolsMenu.jsx";
-import { cleanLawTitle, extractShortLawTitle, formatOfficialReference } from "../utils/lawDisplay.js";
-import { lawStatus } from "../utils/lawStatus.js";
-import { DefinitionSearchResult } from "./search/DefinitionSearchResult.jsx";
-import { FulltextSearchResult } from "./search/FulltextSearchResult.jsx";
 import { McpTopBarButton } from "./McpPromo.jsx";
+import { SearchModal } from "./search/SearchModal.jsx";
 
 // Law search hits the network per query, so wait for a typing pause before
 // firing to avoid a request per keystroke (which trips the API rate limiter).
 const LAW_SEARCH_DEBOUNCE_MS = 300;
-
-function getLawResultDisplay(item) {
-  const officialReference = inferOfficialReferenceFromCelex(item.celex);
-  const referenceLabel = formatOfficialReference(officialReference);
-  const rawTitle = String(item.title || "").replace(/\s+/g, " ").trim();
-  const cleanedTitle = cleanLawTitle(rawTitle, referenceLabel);
-  const shortTitle = extractShortLawTitle(cleanedTitle || rawTitle);
-  const primaryTitle = shortTitle && referenceLabel
-    ? `${shortTitle} — ${referenceLabel}`
-    : shortTitle
-      ? shortTitle
-      : referenceLabel || rawTitle || item.celex;
-  const secondaryTitle = cleanedTitle && cleanedTitle !== primaryTitle
-    ? cleanedTitle
-    : rawTitle && rawTitle !== primaryTitle
-      ? rawTitle
-      : "";
-  const metaLine = [item.date, item.celex].filter(Boolean).join(" · ");
-
-  return {
-    primaryTitle,
-    secondaryTitle,
-    referenceLabel,
-    metaLine,
-  };
-}
 
 export function SearchBox({
   lists,
@@ -105,8 +76,6 @@ export function SearchBox({
 
   const containerRef = useRef(null);
   const heroInputRef = useRef(null);
-  const modalInputRef = useRef(null);
-  const resultsRef = useRef(null);
   const pendingSearchRef = useRef(null);
 
   const handleSearchResults = useCallback((nextResults) => {
@@ -324,18 +293,6 @@ export function SearchBox({
     }
   }, [persistenceKey, query, searchMode]);
 
-  const focusModalInput = useCallback(() => {
-    if (!isOpen) return;
-
-    window.requestAnimationFrame(() => {
-      const input = modalInputRef.current;
-      if (!input) return;
-      input.focus();
-      const length = input.value.length;
-      input.setSelectionRange(length, length);
-    });
-  }, [isOpen]);
-
   const executeSearch = useCallback((mode, nextQuery) => {
     if (mode === "laws") {
       pendingSearchRef.current = null;
@@ -472,91 +429,12 @@ export function SearchBox({
     return () => mediaQuery.removeListener(handleChange);
   }, []);
 
-  useEffect(() => {
-    if (!isOpen) return;
-    focusModalInput();
-  }, [focusModalInput, isOpen, searchMode]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleWindowFocus = () => {
-      focusModalInput();
-    };
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === "visible") {
-        focusModalInput();
-      }
-    };
-
-    window.addEventListener("focus", handleWindowFocus);
-    document.addEventListener("visibilitychange", handleVisibilityChange);
-
-    return () => {
-      window.removeEventListener("focus", handleWindowFocus);
-      document.removeEventListener("visibilitychange", handleVisibilityChange);
-    };
-  }, [focusModalInput, isOpen]);
-
   const handleSelect = useCallback((item) => {
     Promise.resolve(onNavigate(item));
     // setQuery(""); // Keep search term
     // setResults([]); // Keep results
     setIsOpen(false);
   }, [onNavigate]);
-
-  // Close when pressing Escape
-  useEffect(() => {
-    const handleKeyDown = (e) => {
-      if (e.key === "Escape") {
-        setIsOpen(false);
-        modalInputRef.current?.blur();
-      }
-      // Command/Ctrl + K to open
-      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
-        e.preventDefault();
-        setIsOpen(true);
-      }
-    };
-    document.addEventListener("keydown", handleKeyDown);
-    return () => document.removeEventListener("keydown", handleKeyDown);
-  }, []);
-
-  // Keyboard navigation within modal
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const handleKeyDown = (e) => {
-      if (results.length === 0) return;
-
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setSelectedIndex(prev => (prev + 1) % results.length);
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setSelectedIndex(prev => (prev - 1 + results.length) % results.length);
-      } else if (e.key === "Enter") {
-        e.preventDefault();
-        if (selectedIndex >= 0 && selectedIndex < results.length) {
-          handleSelect(results[selectedIndex]);
-        }
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [handleSelect, isOpen, results, selectedIndex]);
-
-  // Auto-scroll to selected item
-  useEffect(() => {
-    if (selectedIndex >= 0 && resultsRef.current) {
-      const selectedEl = resultsRef.current.querySelector(`[data-result-index="${selectedIndex}"]`);
-      if (selectedEl?.scrollIntoView) {
-        selectedEl.scrollIntoView({ block: "nearest", behavior: "smooth" });
-      }
-    }
-  }, [selectedIndex]);
 
   const handleSearch = (e) => {
     const q = e.target.value;
@@ -604,92 +482,6 @@ export function SearchBox({
     executeSearch(searchMode, query);
   }, [executeSearch, isCurrentMode, isLawMode, isMatchesMode, isOpen, query, scheduleLawSearch, clearLawSearchError, clearDefinitionSearchError, clearFulltextSearchError, searchMode]);
 
-  const modeSummary = isCurrentMode
-    ? t("search.searchingCurrentLaw", { law: currentLawLabel || t("search.currentLawFallback") })
-    : isLawMode
-      ? t("search.searchingLaws")
-      : isDefinitionsMode
-        ? t("search.searchingDefinitions")
-        : isFulltextMode
-          ? t("search.searchingFulltext")
-      : t("search.searchingMatches", {
-        count: searchableLawCount,
-        lawWord: searchableLawCount === 1 ? t("search.law") : t("search.laws"),
-        language: activeLanguage,
-      });
-
-  // Short muted scope sentence shown beneath the mode segmented control. For
-  // laws mode the secondary-acts caveat lives in the footer instead, so the
-  // scope line stays terse.
-  const scopeSentence = isCurrentMode
-    ? t("search.searchingCurrentLaw", { law: currentLawLabel || t("search.currentLawFallback") })
-    : isLawMode
-      ? t("search.scopeLaws")
-      : isDefinitionsMode
-        ? t("search.searchingDefinitions")
-        : isFulltextMode
-          ? t("search.scopeFulltext")
-      : t("search.searchingMatches", {
-        count: searchableLawCount,
-        lawWord: searchableLawCount === 1 ? t("search.law") : t("search.laws"),
-        language: activeLanguage,
-      });
-
-  const modeLabel = (mode) => (
-    mode === "current"
-      ? t("search.segCurrent")
-      : mode === "laws"
-        ? t("search.segLaws")
-        : mode === "definitions"
-          ? t("search.segDefinitions")
-          : mode === "fulltext"
-            ? t("search.segFulltext")
-        : t("search.segMatches")
-  );
-
-  // Cycle the active mode with Tab / Shift+Tab while the dialog is open.
-  const cycleMode = useCallback((direction) => {
-    if (availableModes.length < 2) return;
-    const currentIdx = availableModes.indexOf(searchMode);
-    const nextIdx = (currentIdx + direction + availableModes.length) % availableModes.length;
-    setSearchMode(availableModes[nextIdx]);
-    setSelectedIndex(-1);
-    clearLawSearchError();
-    clearDefinitionSearchError();
-    clearFulltextSearchError();
-    focusModalInput();
-  }, [availableModes, focusModalInput, searchMode, clearLawSearchError, clearDefinitionSearchError, clearFulltextSearchError]);
-
-  // Split laws-mode results into a "Best match" group (the synthetic
-  // direct-open CELEX result, when present, plus the top backend hit) and an
-  // "All results" group for the remainder. The concatenated render order is
-  // identical to `results`, so keyboard selectedIndex still maps 1:1.
-  const resultGroups = useMemo(() => {
-    if (!isLawMode || results.length === 0) {
-      return [{ label: null, items: results }];
-    }
-    const directResults = results.filter((r) => r.directCelex);
-    const nonDirect = results.filter((r) => !r.directCelex);
-    const bestItems = [...directResults, ...nonDirect.slice(0, 1)];
-    const restItems = nonDirect.slice(1);
-    const groups = [{ label: t("search.groupBestMatch"), items: bestItems }];
-    if (restItems.length > 0) {
-      groups.push({ label: t("search.groupAllResults"), items: restItems });
-    }
-    return groups;
-  }, [isLawMode, results, t]);
-
-  const inputPlaceholder = isBusy
-    ? t("search.initializing")
-    : isCurrentMode
-      ? t("search.placeholderCurrentLaw", { law: currentLawLabel || t("search.currentLawFallback") })
-      : isLawMode
-        ? t("search.placeholderLaws")
-        : isDefinitionsMode
-          ? t("search.placeholderDefinitions")
-          : isFulltextMode
-            ? t("search.placeholderFulltext")
-        : t("search.placeholderMatches");
   const heroSearchPlaceholder = isSmallViewport
     ? t("landing.searchPlaceholderMobile")
     : t("landing.searchPlaceholder");
@@ -698,19 +490,32 @@ export function SearchBox({
     : isMatchesMode
       ? (isBuildingGlobal || isSearchLoading)
       : false;
-  const lawSearchError = lawSearch.error
-    ? lawSearch.error?.message || t("search.apiUnavailable")
-    : "";
-  const definitionSearchError = definitionSearch.error
-    ? definitionSearch.error?.message || t("search.definitionApiUnavailable")
-    : "";
-  const searchErrorMessage = isFulltextMode && fulltextSearch.error
-    ? (fulltextSearch.error.status === 503 || fulltextSearch.error.code === "fulltext_index_unavailable"
-      ? t("search.fulltextApiUnavailable")
-      : fulltextSearch.error.message || t("search.fulltextApiUnavailable"))
-    : isDefinitionsMode
-      ? definitionSearchError
-      : lawSearchError;
+
+  const handleOpenSearch = useCallback(() => setIsOpen(true), []);
+  const handleCloseSearch = useCallback(() => setIsOpen(false), []);
+
+  const handleClearErrors = useCallback(() => {
+    clearLawSearchError();
+    clearDefinitionSearchError();
+    clearFulltextSearchError();
+  }, [clearLawSearchError, clearDefinitionSearchError, clearFulltextSearchError]);
+
+  const handleClear = useCallback(() => {
+    setQuery("");
+    setResults([]);
+    setDefinitionDiscoveryFilter("");
+    resetFulltextSearch();
+  }, [resetFulltextSearch]);
+
+  const handleDefinitionDiscovery = useCallback((id) => {
+    setQuery("");
+    if (id) {
+      executeDefinitionSearch("", { filter: id });
+    } else {
+      resetDefinitionSearch();
+      setDefinitionDiscoveryFilter("");
+    }
+  }, [executeDefinitionSearch, resetDefinitionSearch]);
 
   return (
     <>
@@ -771,445 +576,38 @@ export function SearchBox({
           </div>
         )}
       </div>
-
       {/* Spotlight Modal Overlay (Rendered in Portal to cover whole screen) */}
-      {isOpen && createPortal(
-        <div
-          className="fixed inset-0 z-[100] flex items-start justify-center bg-black/20 transition-all md:p-4 md:pt-[15vh]"
-          onClick={() => setIsOpen(false)}
-        >
-          <div
-            role="dialog"
-            aria-modal="true"
-            aria-label={t("search.trigger")}
-            className="w-full max-w-2xl flex flex-col h-full md:h-auto md:max-h-[70vh] bg-white shadow-2xl ring-1 ring-black/5 animate-in fade-in zoom-in-95 duration-100 overflow-hidden fixed inset-0 md:static md:inset-auto md:rounded-2xl dark:bg-gray-900 dark:ring-white/10"
-            onClick={(e) => e.stopPropagation()}
-          >
-            {/* Header with Auto-focused Input */}
-            <div className="flex-none border-b border-gray-100 bg-white px-4 py-3 dark:border-gray-800 dark:bg-gray-900">
-              <div className="flex items-center gap-3">
-                <button
-                  onClick={() => setIsOpen(false)}
-                  className="p-1 -ml-1 text-gray-500 hover:text-gray-900 md:hidden"
-                >
-                  <ChevronLeft size={24} />
-                </button>
-                <div className="flex min-w-0 flex-1 items-center gap-3">
-                  <Search size={18} className="hidden shrink-0 text-gray-400 md:block" />
-                  <div className="relative min-w-0 flex-1">
-                    <input
-                      ref={modalInputRef}
-                      type="text"
-                      value={query}
-                      onChange={handleSearch}
-                      onKeyDown={(e) => {
-                        if (e.key === "Tab" && availableModes.length > 1) {
-                          e.preventDefault();
-                          cycleMode(e.shiftKey ? -1 : 1);
-                          return;
-                        }
-                        if (isLawMode && e.key === "Enter" && selectedIndex < 0) {
-                          e.preventDefault();
-                          executeLawSearch(query);
-                        }
-                      }}
-                      placeholder={inputPlaceholder}
-                      disabled={isInputDisabled}
-                      className="h-10 w-full bg-transparent pr-8 text-base font-medium text-gray-900 outline-none placeholder:text-gray-400 disabled:opacity-50 md:text-[1.05rem] dark:text-white dark:placeholder:text-gray-600"
-                    />
-                    {isBusy ? (
-                      <div className="absolute right-0 top-1/2 -translate-y-1/2">
-                        <Loader2 className="animate-spin text-blue-600" size={20} />
-                      </div>
-                    ) : query && (
-                      <button
-                        onClick={() => {
-                          setQuery("");
-                          setResults([]);
-                          setDefinitionDiscoveryFilter("");
-                          resetFulltextSearch();
-                          focusModalInput();
-                        }}
-                        className="absolute right-0 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
-                        title={t("search.clear")}
-                      >
-                        <X size={16} />
-                      </button>
-                    )}
-                  </div>
-                </div>
-                <div className="hidden shrink-0 items-center md:flex">
-                  <button
-                    onClick={() => setIsOpen(false)}
-                    title={t("common.close")}
-                    className="rounded-md border border-gray-200 bg-gray-50 px-2 py-1 font-mono text-[10px] text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-500 dark:hover:text-gray-300"
-                  >
-                    esc
-                  </button>
-                </div>
-              </div>
-            </div>
-
-            {hasGlobalSearch && availableModes.length > 1 && (
-              <div className="flex-none border-b border-gray-100 bg-gray-50/80 px-4 py-2.5 dark:border-gray-800 dark:bg-gray-950/60">
-                <div className="flex flex-wrap items-center gap-3">
-                  <div
-                    role="tablist"
-                    aria-label={t("search.modeLabel")}
-                    className="inline-flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-950"
-                  >
-                    {availableModes.map((mode) => {
-                      const active = searchMode === mode;
-                      return (
-                        <button
-                          key={mode}
-                          type="button"
-                          role="tab"
-                          aria-selected={active}
-                          onClick={() => {
-                            setSearchMode(mode);
-                            setSelectedIndex(-1);
-                            clearLawSearchError();
-                            clearDefinitionSearchError();
-                            clearFulltextSearchError();
-                            focusModalInput();
-                          }}
-                          className={`rounded-md px-3 py-1 text-xs font-medium transition ${
-                            active
-                              ? "bg-white text-gray-900 shadow-sm dark:bg-gray-800 dark:text-white"
-                              : "text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-                          }`}
-                        >
-                          {modeLabel(mode)}
-                        </button>
-                      );
-                    })}
-                  </div>
-                  <span className="min-w-0 flex-1 truncate text-[11.5px] text-gray-500 dark:text-gray-400">
-                    {scopeSentence}
-                  </span>
-                </div>
-              </div>
-            )}
-
-            <div className="flex-1 overflow-y-auto p-2 scroll-smooth bg-gray-50/30 dark:bg-gray-950/50">
-              {isDefinitionsMode ? (
-                <div className="flex flex-wrap items-center gap-1.5 px-2 pb-1 pt-1" aria-label={t("search.definitionDiscoveryLabel")}>
-                  {[
-                    { id: "", label: t("search.definitionDiscoveryAll") },
-                    { id: "different", label: t("search.definitionDiscoveryDifferent") },
-                    { id: "reused", label: t("search.definitionDiscoveryReused") },
-                  ].map((entry) => (
-                    <button
-                      key={entry.id || "all"}
-                      type="button"
-                      aria-pressed={definitionDiscoveryFilter === entry.id}
-                      onClick={() => {
-                        setQuery("");
-                        if (entry.id) executeDefinitionSearch("", { filter: entry.id });
-                        else {
-                          resetDefinitionSearch();
-                          setDefinitionDiscoveryFilter("");
-                        }
-                        focusModalInput();
-                      }}
-                      className={`rounded-full border px-2.5 py-1 text-[11px] font-medium transition ${
-                        definitionDiscoveryFilter === entry.id
-                          ? "border-eu-blue bg-eu-blue-soft text-eu-blue dark:border-eu-blue-bright dark:bg-eu-blue-soft-dark dark:text-eu-blue-bright"
-                          : "border-gray-200 bg-white text-gray-500 hover:text-gray-800 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
-                      }`}
-                    >
-                      {entry.label}
-                    </button>
-                  ))}
-                </div>
-              ) : null}
-              {searchErrorMessage ? (
-                <div className="flex flex-col items-center justify-center py-16 text-gray-400">
-                  <Search size={48} className="opacity-10 mb-4" />
-                  <p className="max-w-sm text-center text-sm">{searchErrorMessage}</p>
-                </div>
-              ) : isBusy ? (
-                <div className="flex flex-col items-center justify-center py-16 text-gray-400">
-                  <Search size={48} className="opacity-20 mb-4 animate-pulse" />
-                  <p className="text-sm text-center max-w-sm">{modeSummary}</p>
-                </div>
-              ) : results.length > 0 ? (
-                <div className="flex flex-col p-2 w-full" ref={resultsRef}>
-                  {(() => {
-                    let flatIndex = -1;
-                    return resultGroups.map((group, gi) => (
-                      <div key={group.label || `group-${gi}`} className="flex flex-col">
-                        {group.label ? (
-                          <div className="px-3 pb-1 pt-2 text-[10.5px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
-                            {group.label}
-                          </div>
-                        ) : null}
-                        <div className="flex flex-col gap-1">
-                          {group.items.map((item) => {
-                            flatIndex += 1;
-                            const idx = flatIndex;
-                            const isSelected = idx === selectedIndex;
-                            const dense = gi > 0;
-                            const lawDisplay = item.search_kind === "law" ? getLawResultDisplay(item) : null;
-                            return (
-                              <button
-                                type="button"
-                                key={`${item.search_kind || item.type}-${item.id}-${idx}`}
-                                data-result-index={idx}
-                                onClick={() => handleSelect(item)}
-                                className={`group flex w-full flex-col gap-1 rounded-xl px-3 text-left transition-colors ${dense ? "py-2" : "py-2.5"} ${
-                                  isSelected
-                                    ? "bg-eu-blue-soft dark:bg-eu-blue-soft-dark"
-                                    : "hover:bg-eu-blue-soft/60 dark:hover:bg-eu-blue-soft-dark/60"
-                                }`}
-                              >
-                                {item.search_kind === "definition" ? (
-                                  <DefinitionSearchResult item={item} query={query} t={t} />
-                                ) : item.search_kind === "fulltext" ? (
-                                  <FulltextSearchResult item={item} t={t} />
-                                ) : item.search_kind === "law" ? (
-                                  <>
-                                    <div className="flex w-full min-w-0 items-baseline gap-2">
-                                      <span className={`min-w-0 flex-1 truncate font-display font-bold ${dense ? "text-[14px]" : "text-[15px]"} ${
-                                        lawStatus(item) === "notInForce"
-                                          ? "text-gray-400 dark:text-gray-500"
-                                          : "text-eu-navy dark:text-white"
-                                      }`}>
-                                        {lawDisplay?.primaryTitle || item.title}
-                                      </span>
-                                      {item.directCelex && (
-                                        <span className="flex-shrink-0 rounded-full bg-eu-gold-soft px-2 py-0.5 text-[10px] font-medium text-eu-gold-deep dark:bg-eu-gold-soft-dark dark:text-eu-gold-bright">
-                                          {t("search.openDirectly")}
-                                        </span>
-                                      )}
-                                      {item.law_label && (
-                                        <span className="flex-shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-                                          {item.law_label}
-                                        </span>
-                                      )}
-                                      {/* Four states, and `null` is one of them: Cellar has no
-                                          status for ~13% of the corpus, and drawing nothing is the
-                                          only honest answer there. See lawStatus() for why `false`
-                                          alone is not enough to say "no longer". */}
-                                      {lawStatus(item) === "inForce" && (
-                                        <span className="inline-flex flex-shrink-0 items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
-                                          <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 dark:bg-emerald-400" aria-hidden="true" />
-                                          {t("search.inForce")}
-                                        </span>
-                                      )}
-                                      {lawStatus(item) === "notYetInForce" && (
-                                        <span
-                                          className="inline-flex flex-shrink-0 items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
-                                          title={t("search.entryIntoForce").replace("{date}", item.entryIntoForce)}
-                                        >
-                                          <span className="h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-400" aria-hidden="true" />
-                                          {t("search.notYetInForce")}
-                                        </span>
-                                      )}
-                                      {lawStatus(item) === "notInForce" && (
-                                        <span
-                                          className="flex-shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-gray-500 dark:bg-gray-800 dark:text-gray-400"
-                                          title={item.endOfValidity ? t("search.endOfValidity").replace("{date}", item.endOfValidity) : undefined}
-                                        >
-                                          {t("search.notInForce")}
-                                        </span>
-                                      )}
-                                    </div>
-                                    {lawDisplay?.secondaryTitle ? (
-                                      <p className={`text-xs leading-relaxed line-clamp-2 ${
-                                        lawStatus(item) === "notInForce"
-                                          ? "text-gray-400 dark:text-gray-500"
-                                          : "text-gray-500 dark:text-gray-400"
-                                      }`}>
-                                        {lawDisplay.secondaryTitle}
-                                      </p>
-                                    ) : null}
-                                    {lawDisplay?.metaLine ? (
-                                      <p className="font-mono text-[11px] text-gray-400 dark:text-gray-500">
-                                        {lawDisplay.metaLine}
-                                      </p>
-                                    ) : null}
-                                    {Array.isArray(item.topics) && item.topics.length > 0 ? (
-                                      <div className="flex flex-wrap gap-1">
-                                        {item.topics.slice(0, 3).map((topic) => (
-                                          <span
-                                            key={topic}
-                                            className="max-w-[10rem] flex-shrink-0 truncate rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
-                                          >
-                                            {topic}
-                                          </span>
-                                        ))}
-                                      </div>
-                                    ) : null}
-                                  </>
-                                ) : (
-                                  <>
-                                    <div className="flex w-full min-w-0 items-center gap-2.5">
-                                      <span className={`flex-shrink-0 rounded-md border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
-                                        item.type === "article"
-                                          ? "border-blue-100 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-900/40 dark:text-blue-200"
-                                          : item.type === "recital"
-                                            ? "border-purple-100 bg-purple-50 text-purple-700 dark:border-purple-800 dark:bg-purple-900/40 dark:text-purple-200"
-                                            : "border-orange-100 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-900/40 dark:text-orange-200"
-                                      }`}>
-                                        {item.type}
-                                      </span>
-                                      <span className="min-w-0 flex-1 truncate font-semibold text-base text-gray-900 group-hover:text-eu-blue dark:text-gray-100 dark:group-hover:text-eu-blue-bright">
-                                        {item.title}
-                                      </span>
-                                      {item.score > 100 && (
-                                        <span className="flex-shrink-0 rounded-full bg-green-100 px-1.5 text-[10px] font-medium text-green-700 dark:bg-green-900/50 dark:text-green-200">{t("search.bestMatch")}</span>
-                                      )}
-                                      {item.law_label && (
-                                        <span className="flex-shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-                                          {item.law_label}
-                                        </span>
-                                      )}
-                                    </div>
-                                    <p className="pl-1 text-sm leading-relaxed text-gray-500 line-clamp-2 dark:text-gray-300">
-                                      <span className="opacity-70">...</span>
-                                      {item.preview}
-                                      <span className="opacity-70">...</span>
-                                    </p>
-                                  </>
-                                )}
-                              </button>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    ));
-                  })()}
-                </div>
-              ) : (
-                <div className="flex flex-col items-center justify-center py-16 text-gray-400">
-                  {isFulltextMode && fulltextSearch.lastQuery.length < 2 ? (
-                    <>
-                      <Search size={48} className="opacity-10 mb-4" />
-                      <p className="text-sm text-center max-w-sm">{t("search.typeFulltext")}</p>
-                    </>
-                  ) : isFulltextMode ? (
-                    <>
-                      <Search size={48} className="opacity-20 mb-4" />
-                      <p className="text-sm text-center max-w-sm">
-                        {t("search.noResultsFulltext", { query: fulltextSearch.lastQuery })}
-                      </p>
-                    </>
-                  ) : isDefinitionsMode && definitionSearch.lastQuery.length < 2 ? (
-                    <>
-                      <Search size={48} className="opacity-10 mb-4" />
-                      <p className="text-sm text-center max-w-sm">{t("search.typeDefinitions")}</p>
-                    </>
-                  ) : isDefinitionsMode ? (
-                    <>
-                      <Search size={48} className="opacity-20 mb-4" />
-                      <p className="text-sm text-center max-w-sm">
-                        {t("search.noResultsDefinitions", { query: definitionSearch.lastQuery })}
-                      </p>
-                    </>
-                  ) : isLawMode && lawSearch.lastQuery.length < 2 ? (
-                    <>
-                      <Search size={48} className="opacity-10 mb-4" />
-                      <p className="text-sm text-center max-w-sm">
-                        {t("search.typeLaws")}
-                      </p>
-                    </>
-                  ) : isLawMode ? (
-                    <>
-                      <Search size={48} className="opacity-20 mb-4" />
-                      <p className="text-sm text-center max-w-sm">
-                        {t("search.noResultsLaws", { query: lawSearch.lastQuery })}
-                      </p>
-                    </>
-                  ) : isCurrentMode && query.length < 2 ? (
-                    <>
-                      <Search size={48} className="opacity-10 mb-4" />
-                      <p className="text-sm text-center max-w-sm">
-                        {t("search.typeCurrentLaw", { law: currentLawLabel || t("search.currentLawFallback") })}
-                      </p>
-                    </>
-                  ) : isCurrentMode ? (
-                    <>
-                      <Search size={48} className="opacity-20 mb-4" />
-                      <p className="text-sm text-center max-w-sm">
-                        {t("search.noResultsCurrentLaw", { query, law: currentLawLabel || t("search.currentLawFallback") })}
-                      </p>
-                    </>
-                  ) : isMatchesMode && searchableLawCount === 0 ? (
-                    <>
-                      <Search size={48} className="opacity-10 mb-4" />
-                      <p className="text-sm text-center max-w-sm">
-                        {t("search.noCached", { language: activeLanguage })}
-                      </p>
-                    </>
-                  ) : isMatchesMode && query.length < 2 ? (
-                    <>
-                      <Search size={48} className="opacity-10 mb-4" />
-                      <p className="text-sm text-center max-w-sm">
-                        {t("search.typeCached", {
-                          count: searchableLawCount,
-                          lawWord: searchableLawCount === 1 ? t("search.law") : t("search.laws"),
-                          language: activeLanguage,
-                        })}
-                      </p>
-                    </>
-                  ) : !hasGlobalSearch && query.length < 2 ? (
-                    <>
-                      <Search size={48} className="opacity-10 mb-4" />
-                      <p className="text-sm">{t("search.typeToStart")}</p>
-                    </>
-                  ) : isMatchesMode ? (
-                    <>
-                      <Search size={48} className="opacity-20 mb-4" />
-                      <p className="text-sm text-center max-w-sm">
-                        {t("search.noResultsCached", {
-                          query,
-                          count: searchableLawCount,
-                          lawWord: searchableLawCount === 1 ? t("search.law") : t("search.laws"),
-                          language: activeLanguage,
-                        })}
-                      </p>
-                    </>
-                  ) : (
-                    <>
-                      <Search size={48} className="opacity-20 mb-4" />
-                      <p className="text-sm">{t("search.noResults", { query })}</p>
-                    </>
-                  )}
-                </div>
-              )}
-            </div>
-
-            <div className="hidden md:flex flex-none items-center gap-4 border-t border-gray-100 bg-gray-50 px-4 py-2 text-[10px] text-gray-400 dark:bg-gray-900 dark:border-gray-800 dark:text-gray-500">
-              <span className="flex items-center gap-1.5">
-                <kbd className="rounded border border-gray-200 bg-white px-1 font-mono dark:border-gray-700 dark:bg-gray-800">↑↓</kbd>
-                {t("search.footNavigate")}
-              </span>
-              <span className="flex items-center gap-1.5">
-                <kbd className="rounded border border-gray-200 bg-white px-1 font-mono dark:border-gray-700 dark:bg-gray-800">↵</kbd>
-                {t("search.footOpen")}
-              </span>
-              {availableModes.length > 1 && (
-                <span className="flex items-center gap-1.5">
-                  <kbd className="rounded border border-gray-200 bg-white px-1 font-mono dark:border-gray-700 dark:bg-gray-800">⇥</kbd>
-                  {t("search.footMode")}
-                </span>
-              )}
-              <span className="flex items-center gap-1.5">
-                <kbd className="rounded border border-gray-200 bg-white px-1 font-mono dark:border-gray-700 dark:bg-gray-800">esc</kbd>
-                {t("search.footClose")}
-              </span>
-              {isFulltextMode ? (
-                <span className="ml-auto text-gray-400 dark:text-gray-500">{t("search.fulltextEnglishOnly")}</span>
-              ) : isLawMode ? (
-                <span className="ml-auto text-gray-400 dark:text-gray-500">{t("search.secondaryNotIndexed")}</span>
-              ) : null}
-            </div>
-          </div>
-        </div>,
-        document.body
-      )}
+      <SearchModal
+        isOpen={isOpen}
+        onOpen={handleOpenSearch}
+        onClose={handleCloseSearch}
+        query={query}
+        onQueryChange={handleSearch}
+        onClear={handleClear}
+        results={results}
+        selectedIndex={selectedIndex}
+        onSelectedIndexChange={setSelectedIndex}
+        onSelect={handleSelect}
+        searchMode={searchMode}
+        onSearchModeChange={setSearchMode}
+        onClearErrors={handleClearErrors}
+        availableModes={availableModes}
+        onExecuteLawSearch={executeLawSearch}
+        definitionDiscoveryFilter={definitionDiscoveryFilter}
+        onDefinitionDiscovery={handleDefinitionDiscovery}
+        isBusy={isBusy}
+        isInputDisabled={isInputDisabled}
+        hasGlobalSearch={hasGlobalSearch}
+        lawError={lawSearch.error}
+        definitionError={definitionSearch.error}
+        fulltextError={fulltextSearch.error}
+        searchableLawCount={searchableLawCount}
+        activeLanguage={activeLanguage}
+        currentLawLabel={currentLawLabel}
+        lawLastQuery={lawSearch.lastQuery}
+        definitionLastQuery={definitionSearch.lastQuery}
+        fulltextLastQuery={fulltextSearch.lastQuery}
+      />
     </>
   );
 }

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
-import { Link, useLocation, useNavigate } from "react-router-dom";
-import { ChevronLeft, Search, X, ExternalLink, Printer, Loader2, PanelLeftClose, PanelLeftOpen, Minus, Plus, MoreVertical, RotateCcw } from "lucide-react";
+import { Link, useNavigate } from "react-router-dom";
+import { ChevronLeft, Search, X, Loader2 } from "lucide-react";
 import { Button } from "./Button.jsx";
 import { ThemeToggle } from "./ThemeToggle.jsx";
 import { LanguageSelector } from "./LanguageSelector.jsx";
@@ -12,8 +12,10 @@ import {
   searchFulltext as searchFulltextApi,
   searchLaws as searchLawsApi,
 } from "../utils/formexApi.js";
-import { buildImportedLawCandidate, getCanonicalLawRoute, parseCelexQuery } from "../utils/lawRouting.js";
-import { inferOfficialReferenceFromCelex, saveLawMeta } from "../utils/library.js";
+import { parseCelexQuery } from "../utils/lawRouting.js";
+import { inferOfficialReferenceFromCelex } from "../utils/library.js";
+import { useSearchNavigation } from "../hooks/useSearchNavigation.js";
+import { ToolsMenu } from "./ToolsMenu.jsx";
 import { cleanLawTitle, extractShortLawTitle, formatOfficialReference } from "../utils/lawDisplay.js";
 import { lawStatus } from "../utils/lawStatus.js";
 import { DefinitionSearchResult } from "./search/DefinitionSearchResult.jsx";
@@ -1460,85 +1462,9 @@ export function TopBar({
   defaultSearchMode = null,
 }) {
   const navigate = useNavigate();
-  const location = useLocation();
   const { locale, localizePath, t } = useI18n();
 
-  const onNavigate = async (item) => {
-    if (item.search_kind === "definition") {
-      const source = item.representativeSource || {};
-      if (!source.celex) return;
-      const sourceArticle = source.article ?? source.sourceArticle;
-      const targetLaw = buildImportedLawCandidate({
-        celex: source.celex,
-        title: source.title || source.law?.title,
-        officialReference: inferOfficialReferenceFromCelex(source.celex),
-      });
-      const route = getCanonicalLawRoute(
-        targetLaw,
-        sourceArticle ? "article" : null,
-        sourceArticle || null,
-        locale,
-      );
-      const separator = route.includes("?") ? "&" : "?";
-      const term = item.normalizedTerm || item.term;
-      const params = new URLSearchParams({ definition: term });
-      params.set("definitionSource", `${String(source.celex).toUpperCase()}:${String(sourceArticle ?? "")}${source.sourcePoint ? `:${String(source.sourcePoint)}` : ""}`);
-      navigate(`${route}${separator}${params.toString()}`);
-      return;
-    }
-
-    if (item.search_kind === "fulltext") {
-      const celex = String(item.celex || "").trim();
-      const unitType = String(item.unitType || "").trim().toLowerCase();
-      const number = item.number == null ? "" : String(item.number).trim();
-      if (!celex || !number || (unitType !== "article" && unitType !== "recital")) return;
-
-      const officialReference = inferOfficialReferenceFromCelex(celex);
-      const targetLaw = buildImportedLawCandidate({
-        celex,
-        title: item.title,
-        officialReference,
-      });
-      if (officialReference) {
-        saveLawMeta({
-          celex,
-          label: item.title,
-          officialReference,
-        }).catch(() => {});
-      }
-      navigate(getCanonicalLawRoute(targetLaw, unitType, number, locale));
-      return;
-    }
-
-    if (item.search_kind === "law") {
-      const officialReference = inferOfficialReferenceFromCelex(item.celex);
-      const targetLaw = buildImportedLawCandidate({
-        celex: item.celex,
-        title: item.title,
-        officialReference,
-      });
-
-      if (officialReference) {
-        // Best-effort bookkeeping: never let a stuck IndexedDB block navigation.
-        saveLawMeta({
-          celex: item.celex,
-          label: item.title,
-          officialReference,
-        }).catch(() => {});
-      }
-
-      navigate(getCanonicalLawRoute(targetLaw, null, null, locale));
-      return;
-    }
-
-    // Ensure ID is a string before encoding
-    const safeId = encodeURIComponent(String(item.id));
-    const targetLawSlug = item.law_slug || item.law_key || lawKey;
-
-    if (targetLawSlug) {
-      navigate(`${localizePath(`/${targetLawSlug}/${item.type}/${safeId}`, locale)}${location.search}`);
-    }
-  };
+  const onNavigate = useSearchNavigation(lawKey);
 
   return (
     <header className="sticky top-0 z-20 border-b border-gray-100 bg-white/95 backdrop-blur-sm supports-[backdrop-filter]:bg-white/80 dark:bg-gray-900/95 dark:supports-[backdrop-filter]:bg-gray-900/80 dark:border-gray-800">
@@ -1662,145 +1588,5 @@ export function TopBar({
         </div>
       </div>
     </header>
-  );
-}
-
-function ToolsMenu({
-  onPrint,
-  showPrint,
-  onIncreaseFont,
-  onDecreaseFont,
-  fontSize,
-  eurlexUrl,
-  onToggleSidebar,
-  isSidebarOpen,
-  onToggleSecondLanguage,
-  isSideBySide,
-  onResetApp,
-}) {
-  const { t } = useI18n();
-  const [isOpen, setIsOpen] = useState(false);
-  const menuRef = useRef(null);
-
-  useEffect(() => {
-    const handleClickOutside = (event) => {
-      if (menuRef.current && !menuRef.current.contains(event.target)) {
-        setIsOpen(false);
-      }
-    };
-    if (isOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isOpen]);
-
-  return (
-    <div className="relative" ref={menuRef}>
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className={`p-2 rounded-lg transition-colors ${isOpen ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-white' : 'text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white'}`}
-        title={t("topBar.moreTools")}
-      >
-        <MoreVertical size={20} />
-      </button>
-
-      {isOpen && (
-        <div className="absolute right-0 top-full mt-2 w-56 p-2 bg-white rounded-xl shadow-xl ring-1 ring-black/5 dark:bg-gray-900 dark:ring-white/10 flex flex-col gap-1 z-50 animate-in fade-in zoom-in-95 duration-100">
-
-          {onToggleSidebar && (
-            <button
-              onClick={() => { onToggleSidebar(); setIsOpen(false); }}
-              className="hidden md:flex items-center gap-3 w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
-            >
-              {isSidebarOpen ? <PanelLeftClose size={18} /> : <PanelLeftOpen size={18} />}
-              <span>{isSidebarOpen ? t("topBar.hideSidebar") : t("topBar.showSidebar")}</span>
-            </button>
-          )}
-
-          {showPrint && (
-            <button
-              onClick={() => { onPrint(); setIsOpen(false); }}
-              className="flex items-center gap-3 w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
-            >
-              <Printer size={18} />
-              <span>{t("topBar.printPdf")}</span>
-            </button>
-          )}
-
-          {onToggleSecondLanguage && (
-            <button
-              type="button"
-              onClick={() => {
-                onToggleSecondLanguage();
-                setIsOpen(false);
-              }}
-              className="flex items-center gap-3 w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
-            >
-              <PanelLeftOpen size={18} />
-              <span>
-                {isSideBySide
-                  ? t("topBar.closeSideBySide")
-                  : t("topBar.openSideBySide")}
-              </span>
-            </button>
-          )}
-
-          {eurlexUrl && (
-            <a
-              href={eurlexUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={() => setIsOpen(false)}
-              className="flex items-center gap-3 w-full px-3 py-2 text-sm text-gray-700 rounded-lg hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
-            >
-              <ExternalLink size={18} />
-              <span>{t("topBar.viewOnEurlex")}</span>
-            </a>
-          )}
-
-          {onResetApp && (
-            <button
-              type="button"
-              onClick={() => {
-                onResetApp();
-                setIsOpen(false);
-              }}
-              className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
-            >
-              <RotateCcw size={18} />
-              <span className="min-w-0 flex-1 text-left">{t("resetFooter.button")}</span>
-            </button>
-          )}
-
-          <div className="px-3 py-2">
-            <div className="flex items-center justify-between">
-              <span className="text-sm text-gray-700 dark:text-gray-200">{t("common.theme")}</span>
-              <ThemeToggle />
-            </div>
-          </div>
-
-          {/* Font Size */}
-          <div className="px-3 py-2">
-            <div className="flex items-center justify-between">
-              <button
-                type="button"
-                onClick={onDecreaseFont}
-                className="rounded-lg p-1 text-gray-500 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
-              >
-                <Minus size={16} />
-              </button>
-              <span className="text-xs font-medium text-gray-500 dark:text-gray-400">{fontSize}%</span>
-              <button
-                type="button"
-                onClick={onIncreaseFont}
-                className="rounded-lg p-1 text-gray-500 transition hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
-              >
-                <Plus size={16} />
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
   );
 }

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -15,6 +15,7 @@ import {
 import { parseCelexQuery } from "../utils/lawRouting.js";
 import { inferOfficialReferenceFromCelex } from "../utils/library.js";
 import { useSearchNavigation } from "../hooks/useSearchNavigation.js";
+import { useNetworkedSearch } from "../hooks/search/useNetworkedSearch.js";
 import { ToolsMenu } from "./ToolsMenu.jsx";
 import { cleanLawTitle, extractShortLawTitle, formatOfficialReference } from "../utils/lawDisplay.js";
 import { lawStatus } from "../utils/lawStatus.js";
@@ -100,15 +101,7 @@ export function SearchBox({
         ? defaultSearchMode
       : availableModes[0]
   ));
-  const [isLawSearchLoading, setIsLawSearchLoading] = useState(false);
-  const [lawSearchError, setLawSearchError] = useState("");
-  const [lastLawSearchQuery, setLastLawSearchQuery] = useState("");
-  const [isDefinitionSearchLoading, setIsDefinitionSearchLoading] = useState(false);
-  const [lastDefinitionSearchQuery, setLastDefinitionSearchQuery] = useState("");
   const [definitionDiscoveryFilter, setDefinitionDiscoveryFilter] = useState("");
-  const [isFulltextSearchLoading, setIsFulltextSearchLoading] = useState(false);
-  const [fulltextSearchError, setFulltextSearchError] = useState(null);
-  const [lastFulltextSearchQuery, setLastFulltextSearchQuery] = useState("");
   const [isSmallViewport, setIsSmallViewport] = useState(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
     return window.matchMedia("(max-width: 639px)").matches;
@@ -118,14 +111,156 @@ export function SearchBox({
   const heroInputRef = useRef(null);
   const modalInputRef = useRef(null);
   const resultsRef = useRef(null);
-  const lawSearchAbortRef = useRef(null);
-  const lawSearchRequestIdRef = useRef(0);
-  const lawSearchDebounceRef = useRef(null);
-  const definitionSearchAbortRef = useRef(null);
-  const definitionSearchDebounceRef = useRef(null);
-  const fulltextSearchAbortRef = useRef(null);
-  const fulltextSearchDebounceRef = useRef(null);
   const pendingSearchRef = useRef(null);
+
+  const handleSearchResults = useCallback((nextResults) => {
+    setResults(nextResults);
+    setSelectedIndex(-1);
+  }, []);
+
+  const handleLawSearchError = useCallback(() => {
+    setResults([]);
+  }, []);
+
+  const handleDefinitionSearchError = useCallback((error) => {
+    console.error("Failed to search definitions", error);
+    setResults([]);
+  }, []);
+
+  const handleFulltextSearchError = useCallback((error) => {
+    console.error("Failed to search full text", error);
+    setResults([]);
+  }, []);
+
+  const handleDefinitionSearchReset = useCallback(() => {
+    setDefinitionDiscoveryFilter("");
+  }, []);
+
+  const runLawSearch = useCallback(async (query, { signal }) => {
+    const celexQuery = parseCelexQuery(query);
+    // Derive a stable title from the CELEX (e.g. "Regulation (EU) 2016/679") so
+    // the result — and the library label saved on navigation — is meaningful
+    // rather than empty when no backend record supplies a real title.
+    const celexTitle = celexQuery
+      ? formatOfficialReference(inferOfficialReferenceFromCelex(celexQuery)) || ""
+      : "";
+    const buildCelexResult = () => ({
+      celex: celexQuery,
+      title: celexTitle,
+      search_kind: "law",
+      id: celexQuery,
+      directCelex: true,
+    });
+    // A pasted EUR-Lex URL (or "CELEX:"-prefixed id) identifies exactly one act,
+    // but the backend anchors its CELEX regex at the start of the query, so it
+    // never extracts the id from the surrounding URL text and falls back to a
+    // fuzzy token search — leaving the target buried among unrelated hits. When
+    // we've already resolved the CELEX client-side, query the backend by that
+    // canonical id so it returns the act as the deterministic top result.
+    const backendQuery = celexQuery || query;
+    try {
+      const payload = await searchLawsApi(backendQuery, { limit: 12, signal });
+      const nextResults = Array.isArray(payload?.results)
+        ? payload.results.map((item) => ({
+          ...item,
+          search_kind: "law",
+          id: item.celex,
+        }))
+        : [];
+      const hasCelexExact = celexQuery
+        && nextResults.some((item) => String(item.celex || "").toUpperCase() === celexQuery);
+      return celexQuery && !hasCelexExact ? [buildCelexResult(), ...nextResults] : nextResults;
+    } catch (error) {
+      if (error?.name === "AbortError") throw error;
+      console.error("Failed to search laws", error);
+      // Even if the backend search fails, a valid CELEX can still be opened.
+      if (celexQuery) return [buildCelexResult()];
+      throw error;
+    }
+  }, []);
+
+  const runDefinitionSearch = useCallback(async (query, { signal, filter = "" }) => {
+    setDefinitionDiscoveryFilter(filter);
+    const payload = await searchDefinitionsApi(query, { limit: 12, filter, signal });
+    return Array.isArray(payload?.results)
+      ? payload.results.map((item, index) => ({
+        ...item,
+        search_kind: "definition",
+        id: item.normalizedTerm || item.term || index,
+      }))
+      : [];
+  }, []);
+
+  const runFulltextSearch = useCallback(async (query, { signal }) => {
+    const payload = await searchFulltextApi(query, { limit: 12, signal });
+    const sourceResults = Array.isArray(payload) ? payload : payload?.results;
+    return Array.isArray(sourceResults)
+      ? sourceResults.map((item, index) => {
+        // A stable key must not contain an accidental `undefined`: the
+        // backend contract normally supplies all three parts, but keeping
+        // a deterministic fallback avoids React key collisions on a bad row.
+        const celex = String(item?.celex || "unknown-celex").toUpperCase();
+        const unitType = String(item?.unitType || "unit").toLowerCase();
+        const number = item?.number == null || item.number === ""
+          ? "unnumbered"
+          : String(item.number);
+        return {
+          ...item,
+          search_kind: "fulltext",
+          id: `${celex}:${unitType}:${number}:${index}`,
+        };
+      })
+      : [];
+  }, []);
+
+  const lawSearch = useNetworkedSearch({
+    minQueryLength: 2,
+    debounceMs: LAW_SEARCH_DEBOUNCE_MS,
+    run: runLawSearch,
+    onResults: handleSearchResults,
+    onError: handleLawSearchError,
+    invalidateOnReset: true,
+  });
+
+  const definitionSearch = useNetworkedSearch({
+    minQueryLength: 2,
+    debounceMs: LAW_SEARCH_DEBOUNCE_MS,
+    run: runDefinitionSearch,
+    onResults: handleSearchResults,
+    onError: handleDefinitionSearchError,
+    onReset: handleDefinitionSearchReset,
+    invalidateOnReset: false,
+  });
+
+  const fulltextSearch = useNetworkedSearch({
+    minQueryLength: 2,
+    debounceMs: LAW_SEARCH_DEBOUNCE_MS,
+    run: runFulltextSearch,
+    onResults: handleSearchResults,
+    onError: handleFulltextSearchError,
+    abortOnSchedule: true,
+    invalidateOnReset: false,
+  });
+
+  const {
+    schedule: scheduleLawSearch,
+    execute: executeLawSearch,
+    abort: abortLawSearch,
+    clearError: clearLawSearchError,
+  } = lawSearch;
+  const {
+    schedule: scheduleDefinitionSearch,
+    execute: executeDefinitionSearch,
+    abort: abortDefinitionSearch,
+    reset: resetDefinitionSearch,
+    clearError: clearDefinitionSearchError,
+  } = definitionSearch;
+  const {
+    schedule: scheduleFulltextSearch,
+    abort: abortFulltextSearch,
+    reset: resetFulltextSearch,
+    clearError: clearFulltextSearchError,
+  } = fulltextSearch;
   const hasGlobalSearch = availableModes.includes("laws")
     || availableModes.includes("matches")
     || availableModes.includes("definitions")
@@ -141,11 +276,11 @@ export function SearchBox({
   const isCurrentBusy = isCurrentMode && isBuildingCurrent;
   const isMatchesBusy = isMatchesMode && (isBuildingGlobal || isSearchLoading);
   const isBusy = isLawMode
-    ? isLawSearchLoading
+    ? lawSearch.isLoading
     : isDefinitionsMode
-      ? isDefinitionSearchLoading
+      ? definitionSearch.isLoading
       : isFulltextMode
-        ? isFulltextSearchLoading
+        ? fulltextSearch.isLoading
         : isCurrentBusy || isMatchesBusy;
 
   useEffect(() => {
@@ -207,245 +342,6 @@ export function SearchBox({
       : searchContent(nextQuery, sourceLists || { articles: [], recitals: [], annexes: [] });
     setResults(nextResults);
   }, [effectiveGlobalLists, globalSearchIndex]);
-
-  const runLawSearch = useCallback((nextQuery) => {
-    const trimmedQuery = String(nextQuery || "").trim();
-    const requestId = lawSearchRequestIdRef.current + 1;
-    lawSearchRequestIdRef.current = requestId;
-
-    if (lawSearchAbortRef.current) {
-      lawSearchAbortRef.current.abort();
-    }
-
-    setLawSearchError("");
-
-    if (trimmedQuery.length < 2) {
-      setResults([]);
-      setLastLawSearchQuery("");
-      setIsLawSearchLoading(false);
-      return;
-    }
-
-    const controller = new AbortController();
-    lawSearchAbortRef.current = controller;
-    setIsLawSearchLoading(true);
-    setLastLawSearchQuery(trimmedQuery);
-
-    // A typed CELEX can be opened directly regardless of the search index, so
-    // surface it as a result even when the backend finds no (or no exact) match.
-    const celexQuery = parseCelexQuery(trimmedQuery);
-    // Derive a stable title from the CELEX (e.g. "Regulation (EU) 2016/679") so
-    // the result — and the library label saved on navigation — is meaningful
-    // rather than empty when no backend record supplies a real title.
-    const celexTitle = celexQuery
-      ? formatOfficialReference(inferOfficialReferenceFromCelex(celexQuery)) || ""
-      : "";
-    const buildCelexResult = () => ({
-      celex: celexQuery,
-      title: celexTitle,
-      search_kind: "law",
-      id: celexQuery,
-      directCelex: true,
-    });
-
-    // A pasted EUR-Lex URL (or "CELEX:"-prefixed id) identifies exactly one act,
-    // but the backend anchors its CELEX regex at the start of the query, so it
-    // never extracts the id from the surrounding URL text and falls back to a
-    // fuzzy token search — leaving the target buried among unrelated hits. When
-    // we've already resolved the CELEX client-side, query the backend by that
-    // canonical id so it returns the act as the deterministic top result.
-    const backendQuery = celexQuery || trimmedQuery;
-
-    searchLawsApi(backendQuery, { limit: 12, signal: controller.signal })
-      .then((payload) => {
-        if (lawSearchRequestIdRef.current !== requestId) return;
-        const nextResults = Array.isArray(payload?.results)
-          ? payload.results.map((item) => ({
-            ...item,
-            search_kind: "law",
-            id: item.celex,
-          }))
-          : [];
-        const hasCelexExact = celexQuery
-          && nextResults.some((item) => String(item.celex || "").toUpperCase() === celexQuery);
-        setResults(celexQuery && !hasCelexExact ? [buildCelexResult(), ...nextResults] : nextResults);
-        setSelectedIndex(-1);
-      })
-      .catch((error) => {
-        if (error?.name === "AbortError" || lawSearchRequestIdRef.current !== requestId) return;
-        console.error("Failed to search laws", error);
-        // Even if the index lookup fails, a valid CELEX can still be opened.
-        if (celexQuery) {
-          setResults([buildCelexResult()]);
-          setSelectedIndex(-1);
-          return;
-        }
-        setResults([]);
-        setLawSearchError(error?.message || t("search.apiUnavailable"));
-      })
-      .finally(() => {
-        if (lawSearchAbortRef.current === controller) {
-          lawSearchAbortRef.current = null;
-          setIsLawSearchLoading(false);
-        }
-      });
-  }, [t]);
-
-  // Debounced entry point for law search: clears any pending timer and only
-  // fires the network request once the user pauses typing.
-  const scheduleLawSearch = useCallback((nextQuery) => {
-    if (lawSearchDebounceRef.current) {
-      clearTimeout(lawSearchDebounceRef.current);
-      lawSearchDebounceRef.current = null;
-    }
-
-    // Empty/too-short queries reset immediately — no request, no spinner.
-    if (String(nextQuery || "").trim().length < 2) {
-      runLawSearch(nextQuery);
-      return;
-    }
-
-    // Show the loading state right away so typing feels responsive, but hold
-    // the actual request until the pause elapses.
-    setIsLawSearchLoading(true);
-    lawSearchDebounceRef.current = setTimeout(() => {
-      lawSearchDebounceRef.current = null;
-      runLawSearch(nextQuery);
-    }, LAW_SEARCH_DEBOUNCE_MS);
-  }, [runLawSearch]);
-
-  const runDefinitionSearch = useCallback((nextQuery, discoveryFilter = "") => {
-    const trimmedQuery = String(nextQuery || "").trim();
-    definitionSearchAbortRef.current?.abort();
-    setLawSearchError("");
-    setDefinitionDiscoveryFilter(discoveryFilter);
-
-    if (trimmedQuery.length < 2 && !discoveryFilter) {
-      setResults([]);
-      setLastDefinitionSearchQuery("");
-      setIsDefinitionSearchLoading(false);
-      return;
-    }
-
-    const controller = new AbortController();
-    definitionSearchAbortRef.current = controller;
-    setIsDefinitionSearchLoading(true);
-    setLastDefinitionSearchQuery(trimmedQuery);
-
-    searchDefinitionsApi(trimmedQuery, { limit: 12, filter: discoveryFilter, signal: controller.signal })
-      .then((payload) => {
-        const nextResults = Array.isArray(payload?.results)
-          ? payload.results.map((item, index) => ({
-            ...item,
-            search_kind: "definition",
-            id: item.normalizedTerm || item.term || index,
-          }))
-          : [];
-        setResults(nextResults);
-        setSelectedIndex(-1);
-      })
-      .catch((error) => {
-        if (error?.name === "AbortError") return;
-        console.error("Failed to search definitions", error);
-        setResults([]);
-        setLawSearchError(error?.message || t("search.definitionApiUnavailable"));
-      })
-      .finally(() => {
-        if (definitionSearchAbortRef.current === controller) {
-          definitionSearchAbortRef.current = null;
-          setIsDefinitionSearchLoading(false);
-        }
-      });
-  }, [t]);
-
-  const scheduleDefinitionSearch = useCallback((nextQuery) => {
-    if (definitionSearchDebounceRef.current) {
-      clearTimeout(definitionSearchDebounceRef.current);
-      definitionSearchDebounceRef.current = null;
-    }
-    if (String(nextQuery || "").trim().length < 2) {
-      runDefinitionSearch(nextQuery);
-      return;
-    }
-    setIsDefinitionSearchLoading(true);
-    definitionSearchDebounceRef.current = setTimeout(() => {
-      definitionSearchDebounceRef.current = null;
-      runDefinitionSearch(nextQuery);
-    }, LAW_SEARCH_DEBOUNCE_MS);
-  }, [runDefinitionSearch]);
-
-  const runFulltextSearch = useCallback((nextQuery) => {
-    const trimmedQuery = String(nextQuery || "").trim();
-    fulltextSearchAbortRef.current?.abort();
-    setFulltextSearchError(null);
-
-    if (trimmedQuery.length < 2) {
-      setResults([]);
-      setLastFulltextSearchQuery("");
-      setIsFulltextSearchLoading(false);
-      return;
-    }
-
-    const controller = new AbortController();
-    fulltextSearchAbortRef.current = controller;
-    setIsFulltextSearchLoading(true);
-    setLastFulltextSearchQuery(trimmedQuery);
-
-    searchFulltextApi(trimmedQuery, { limit: 12, signal: controller.signal })
-      .then((payload) => {
-        if (fulltextSearchAbortRef.current !== controller) return;
-        const sourceResults = Array.isArray(payload) ? payload : payload?.results;
-        const nextResults = Array.isArray(sourceResults)
-          ? sourceResults.map((item, index) => {
-            // A stable key must not contain an accidental `undefined`: the
-            // backend contract normally supplies all three parts, but keeping
-            // a deterministic fallback avoids React key collisions on a bad row.
-            const celex = String(item?.celex || "unknown-celex").toUpperCase();
-            const unitType = String(item?.unitType || "unit").toLowerCase();
-            const number = item?.number == null || item.number === ""
-              ? "unnumbered"
-              : String(item.number);
-            return {
-              ...item,
-              search_kind: "fulltext",
-              id: `${celex}:${unitType}:${number}:${index}`,
-            };
-          })
-          : [];
-        setResults(nextResults);
-        setSelectedIndex(-1);
-      })
-      .catch((error) => {
-        if (error?.name === "AbortError" || fulltextSearchAbortRef.current !== controller) return;
-        console.error("Failed to search full text", error);
-        setResults([]);
-        setFulltextSearchError(error);
-      })
-      .finally(() => {
-        if (fulltextSearchAbortRef.current === controller) {
-          fulltextSearchAbortRef.current = null;
-          setIsFulltextSearchLoading(false);
-        }
-      });
-  }, []);
-
-  const scheduleFulltextSearch = useCallback((nextQuery) => {
-    fulltextSearchAbortRef.current?.abort();
-    fulltextSearchAbortRef.current = null;
-    if (fulltextSearchDebounceRef.current) {
-      clearTimeout(fulltextSearchDebounceRef.current);
-      fulltextSearchDebounceRef.current = null;
-    }
-    if (String(nextQuery || "").trim().length < 2) {
-      runFulltextSearch(nextQuery);
-      return;
-    }
-    setIsFulltextSearchLoading(true);
-    fulltextSearchDebounceRef.current = setTimeout(() => {
-      fulltextSearchDebounceRef.current = null;
-      runFulltextSearch(nextQuery);
-    }, LAW_SEARCH_DEBOUNCE_MS);
-  }, [runFulltextSearch]);
 
   const executeSearch = useCallback((mode, nextQuery) => {
     if (mode === "laws") {
@@ -515,9 +411,9 @@ export function SearchBox({
     onSearchOpen,
     runCurrentSearch,
     runGlobalMatchSearch,
+    scheduleLawSearch,
     scheduleDefinitionSearch,
     scheduleFulltextSearch,
-    scheduleLawSearch,
     searchableLawCount,
   ]);
 
@@ -532,16 +428,18 @@ export function SearchBox({
   useEffect(() => {
     setCurrentSearchIndex(null);
     setResults([]);
-    setLawSearchError("");
-    setFulltextSearchError(null);
-  }, [lists]);
+    clearLawSearchError();
+    clearDefinitionSearchError();
+    clearFulltextSearchError();
+  }, [clearLawSearchError, clearDefinitionSearchError, clearFulltextSearchError, lists]);
 
   useEffect(() => {
     setGlobalSearchIndex(null);
     setResults([]);
-    setLawSearchError("");
-    setFulltextSearchError(null);
-  }, [effectiveGlobalLists]);
+    clearLawSearchError();
+    clearDefinitionSearchError();
+    clearFulltextSearchError();
+  }, [clearLawSearchError, clearDefinitionSearchError, clearFulltextSearchError, effectiveGlobalLists]);
 
   // Build current-law index on open if needed
   useEffect(() => {
@@ -578,65 +476,25 @@ export function SearchBox({
   }, [effectiveGlobalLists, globalSearchIndex, isBuildingGlobal, isMatchesMode, isOpen, isSearchLoading]);
 
   useEffect(() => () => {
-    lawSearchAbortRef.current?.abort();
-    definitionSearchAbortRef.current?.abort();
-    fulltextSearchAbortRef.current?.abort();
-    if (lawSearchDebounceRef.current) {
-      clearTimeout(lawSearchDebounceRef.current);
-    }
-    if (definitionSearchDebounceRef.current) {
-      clearTimeout(definitionSearchDebounceRef.current);
-    }
-    if (fulltextSearchDebounceRef.current) {
-      clearTimeout(fulltextSearchDebounceRef.current);
-    }
-  }, []);
+    abortLawSearch();
+    abortDefinitionSearch();
+    abortFulltextSearch();
+  }, [abortLawSearch, abortDefinitionSearch, abortFulltextSearch]);
 
   // Prevent a delayed response from the mode the user just left replacing
   // the results for the newly selected mode.
   useEffect(() => {
-    if (!isLawMode) {
-      lawSearchRequestIdRef.current += 1;
-      lawSearchAbortRef.current?.abort();
-      lawSearchAbortRef.current = null;
-      if (lawSearchDebounceRef.current) {
-        clearTimeout(lawSearchDebounceRef.current);
-        lawSearchDebounceRef.current = null;
-      }
-      setIsLawSearchLoading(false);
-    }
-    if (!isDefinitionsMode) {
-      definitionSearchAbortRef.current?.abort();
-      definitionSearchAbortRef.current = null;
-      if (definitionSearchDebounceRef.current) {
-        clearTimeout(definitionSearchDebounceRef.current);
-        definitionSearchDebounceRef.current = null;
-      }
-      setIsDefinitionSearchLoading(false);
-    }
-    if (!isFulltextMode) {
-      fulltextSearchAbortRef.current?.abort();
-      fulltextSearchAbortRef.current = null;
-      if (fulltextSearchDebounceRef.current) {
-        clearTimeout(fulltextSearchDebounceRef.current);
-        fulltextSearchDebounceRef.current = null;
-      }
-      setIsFulltextSearchLoading(false);
-    }
-  }, [isDefinitionsMode, isFulltextMode, isLawMode]);
+    if (!isLawMode) abortLawSearch();
+    if (!isDefinitionsMode) abortDefinitionSearch();
+    if (!isFulltextMode) abortFulltextSearch();
+  }, [isDefinitionsMode, isFulltextMode, isLawMode, abortLawSearch, abortDefinitionSearch, abortFulltextSearch]);
 
   // Closing the spotlight is also a full-text search boundary: there is no
   // visible consumer left for a pending response, so cancel it immediately.
   useEffect(() => {
     if (isOpen || !isFulltextMode) return;
-    fulltextSearchAbortRef.current?.abort();
-    fulltextSearchAbortRef.current = null;
-    if (fulltextSearchDebounceRef.current) {
-      clearTimeout(fulltextSearchDebounceRef.current);
-      fulltextSearchDebounceRef.current = null;
-    }
-    setIsFulltextSearchLoading(false);
-  }, [isFulltextMode, isOpen]);
+    abortFulltextSearch();
+  }, [isFulltextMode, isOpen, abortFulltextSearch]);
 
   useEffect(() => {
     if (typeof window === "undefined" || typeof window.matchMedia !== "function") return undefined;
@@ -747,8 +605,9 @@ export function SearchBox({
     const q = e.target.value;
     setQuery(q);
     setSelectedIndex(-1);
-    setLawSearchError("");
-    setFulltextSearchError(null);
+    clearLawSearchError();
+    clearDefinitionSearchError();
+    clearFulltextSearchError();
 
     if (!isOpen && triggerVariant === "hero") {
       if (q.trim().length === 0) {
@@ -758,9 +617,9 @@ export function SearchBox({
       setIsOpen(true);
     }
 
-    if ((isLawMode && q.trim() !== lastLawSearchQuery)
-      || (isDefinitionsMode && q.trim() !== lastDefinitionSearchQuery)
-      || (isFulltextMode && q.trim() !== lastFulltextSearchQuery)) {
+    if ((isLawMode && q.trim() !== lawSearch.lastQuery)
+      || (isDefinitionsMode && q.trim() !== definitionSearch.lastQuery)
+      || (isFulltextMode && q.trim() !== fulltextSearch.lastQuery)) {
       setResults([]);
       return;
     }
@@ -785,14 +644,15 @@ export function SearchBox({
     if (!isOpen) return;
     setSelectedIndex(-1);
     setResults([]);
-    setLawSearchError("");
-    setFulltextSearchError(null);
+    clearLawSearchError();
+    clearDefinitionSearchError();
+    clearFulltextSearchError();
     if (isLawMode) {
       scheduleLawSearch(query);
       return;
     }
     executeSearch(searchMode, query);
-  }, [executeSearch, isLawMode, isOpen, query, scheduleLawSearch, searchMode]);
+  }, [executeSearch, isLawMode, isOpen, query, scheduleLawSearch, clearLawSearchError, clearDefinitionSearchError, clearFulltextSearchError, searchMode]);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -877,10 +737,11 @@ export function SearchBox({
     const nextIdx = (currentIdx + direction + availableModes.length) % availableModes.length;
     setSearchMode(availableModes[nextIdx]);
     setSelectedIndex(-1);
-    setLawSearchError("");
-    setFulltextSearchError(null);
+    clearLawSearchError();
+    clearDefinitionSearchError();
+    clearFulltextSearchError();
     focusModalInput();
-  }, [availableModes, focusModalInput, searchMode]);
+  }, [availableModes, focusModalInput, searchMode, clearLawSearchError, clearDefinitionSearchError, clearFulltextSearchError]);
 
   // Split laws-mode results into a "Best match" group (the synthetic
   // direct-open CELEX result, when present, plus the top backend hit) and an
@@ -920,11 +781,19 @@ export function SearchBox({
     : isMatchesMode
       ? (isBuildingGlobal || isSearchLoading)
       : false;
-  const searchErrorMessage = isFulltextMode && fulltextSearchError
-    ? (fulltextSearchError.status === 503 || fulltextSearchError.code === "fulltext_index_unavailable"
+  const lawSearchError = lawSearch.error
+    ? lawSearch.error?.message || t("search.apiUnavailable")
+    : "";
+  const definitionSearchError = definitionSearch.error
+    ? definitionSearch.error?.message || t("search.definitionApiUnavailable")
+    : "";
+  const searchErrorMessage = isFulltextMode && fulltextSearch.error
+    ? (fulltextSearch.error.status === 503 || fulltextSearch.error.code === "fulltext_index_unavailable"
       ? t("search.fulltextApiUnavailable")
-      : fulltextSearchError.message || t("search.fulltextApiUnavailable"))
-    : lawSearchError;
+      : fulltextSearch.error.message || t("search.fulltextApiUnavailable"))
+    : isDefinitionsMode
+      ? definitionSearchError
+      : lawSearchError;
 
   return (
     <>
@@ -1024,7 +893,7 @@ export function SearchBox({
                         }
                         if (isLawMode && e.key === "Enter" && selectedIndex < 0) {
                           e.preventDefault();
-                          runLawSearch(query);
+                          executeLawSearch(query);
                         }
                       }}
                       placeholder={inputPlaceholder}
@@ -1041,8 +910,7 @@ export function SearchBox({
                           setQuery("");
                           setResults([]);
                           setDefinitionDiscoveryFilter("");
-                          setLastFulltextSearchQuery("");
-                          setFulltextSearchError(null);
+                          resetFulltextSearch();
                           focusModalInput();
                         }}
                         className="absolute right-0 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
@@ -1084,8 +952,9 @@ export function SearchBox({
                           onClick={() => {
                             setSearchMode(mode);
                             setSelectedIndex(-1);
-                            setLawSearchError("");
-                            setFulltextSearchError(null);
+                            clearLawSearchError();
+                            clearDefinitionSearchError();
+                            clearFulltextSearchError();
                             focusModalInput();
                           }}
                           className={`rounded-md px-3 py-1 text-xs font-medium transition ${
@@ -1120,13 +989,10 @@ export function SearchBox({
                       aria-pressed={definitionDiscoveryFilter === entry.id}
                       onClick={() => {
                         setQuery("");
-                        if (entry.id) runDefinitionSearch("", entry.id);
+                        if (entry.id) executeDefinitionSearch("", { filter: entry.id });
                         else {
-                          definitionSearchAbortRef.current?.abort();
+                          resetDefinitionSearch();
                           setDefinitionDiscoveryFilter("");
-                          setResults([]);
-                          setLastDefinitionSearchQuery("");
-                          setIsDefinitionSearchLoading(false);
                         }
                         focusModalInput();
                       }}
@@ -1301,7 +1167,7 @@ export function SearchBox({
                 </div>
               ) : (
                 <div className="flex flex-col items-center justify-center py-16 text-gray-400">
-                  {isFulltextMode && lastFulltextSearchQuery.length < 2 ? (
+                  {isFulltextMode && fulltextSearch.lastQuery.length < 2 ? (
                     <>
                       <Search size={48} className="opacity-10 mb-4" />
                       <p className="text-sm text-center max-w-sm">{t("search.typeFulltext")}</p>
@@ -1310,10 +1176,10 @@ export function SearchBox({
                     <>
                       <Search size={48} className="opacity-20 mb-4" />
                       <p className="text-sm text-center max-w-sm">
-                        {t("search.noResultsFulltext", { query: lastFulltextSearchQuery })}
+                        {t("search.noResultsFulltext", { query: fulltextSearch.lastQuery })}
                       </p>
                     </>
-                  ) : isDefinitionsMode && lastDefinitionSearchQuery.length < 2 ? (
+                  ) : isDefinitionsMode && definitionSearch.lastQuery.length < 2 ? (
                     <>
                       <Search size={48} className="opacity-10 mb-4" />
                       <p className="text-sm text-center max-w-sm">{t("search.typeDefinitions")}</p>
@@ -1322,10 +1188,10 @@ export function SearchBox({
                     <>
                       <Search size={48} className="opacity-20 mb-4" />
                       <p className="text-sm text-center max-w-sm">
-                        {t("search.noResultsDefinitions", { query: lastDefinitionSearchQuery })}
+                        {t("search.noResultsDefinitions", { query: definitionSearch.lastQuery })}
                       </p>
                     </>
-                  ) : isLawMode && lastLawSearchQuery.length < 2 ? (
+                  ) : isLawMode && lawSearch.lastQuery.length < 2 ? (
                     <>
                       <Search size={48} className="opacity-10 mb-4" />
                       <p className="text-sm text-center max-w-sm">
@@ -1336,7 +1202,7 @@ export function SearchBox({
                     <>
                       <Search size={48} className="opacity-20 mb-4" />
                       <p className="text-sm text-center max-w-sm">
-                        {t("search.noResultsLaws", { query: lastLawSearchQuery })}
+                        {t("search.noResultsLaws", { query: lawSearch.lastQuery })}
                       </p>
                     </>
                   ) : isCurrentMode && query.length < 2 ? (

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -29,7 +29,6 @@ export function SearchBox({
   globalLists = null,
   onNavigate,
   onSearchOpen,
-  hasSearchInitialized = true,
   isSearchLoading,
   activeLanguage = "EN",
   searchableLawCount = 0,
@@ -76,7 +75,6 @@ export function SearchBox({
 
   const containerRef = useRef(null);
   const heroInputRef = useRef(null);
-  const pendingSearchRef = useRef(null);
 
   const handleSearchResults = useCallback((nextResults) => {
     setResults(nextResults);
@@ -246,18 +244,12 @@ export function SearchBox({
     isOpen,
     searchMode,
     isSearchLoading,
-    onSearchOpen,
     globalEntryCount,
-    searchableLawCount,
-    hasSearchInitialized,
     setResults,
-    pendingSearchRef,
   });
   const {
     isBuildingCurrent,
     isBuildingGlobal,
-    runCurrentSearch,
-    runGlobalMatchSearch,
   } = localIndexes;
 
   // Must stay below the useLocalSearchIndexes destructuring: referencing the
@@ -297,79 +289,17 @@ export function SearchBox({
     }
   }, [persistenceKey, query, searchMode]);
 
+  // Only the networked modes dispatch through here: current/matches are run
+  // by useLocalSearchIndexes' own query-change effects.
   const executeSearch = useCallback((mode, nextQuery) => {
     if (mode === "laws") {
-      pendingSearchRef.current = null;
       scheduleLawSearch(nextQuery);
-      return;
-    }
-
-    if (mode === "current") {
-      if (isBuildingCurrent) {
-        pendingSearchRef.current = { mode, query: nextQuery };
-        return;
-      }
-      pendingSearchRef.current = null;
-      runCurrentSearch(nextQuery);
-      return;
-    }
-
-    if (mode === "definitions") {
-      pendingSearchRef.current = null;
+    } else if (mode === "definitions") {
       scheduleDefinitionSearch(nextQuery);
-      return;
-    }
-
-    if (mode === "fulltext") {
-      pendingSearchRef.current = null;
+    } else if (mode === "fulltext") {
       scheduleFulltextSearch(nextQuery);
-      return;
     }
-
-    if (mode === "matches") {
-      if (!hasSearchInitialized && typeof onSearchOpen === "function") {
-        pendingSearchRef.current = { mode, query: nextQuery };
-        Promise.resolve(onSearchOpen())
-          .then((loadedLists) => {
-            const pending = pendingSearchRef.current;
-            if (!pending || pending.mode !== "matches" || pending.query !== nextQuery) return;
-            pendingSearchRef.current = null;
-            runGlobalMatchSearch(pending.query, loadedLists, null);
-          })
-          .catch((error) => {
-            console.error("Failed to initialize within-laws search", error);
-          });
-        return;
-      }
-
-      if (
-        isSearchLoading
-        || isBuildingGlobal
-        || (typeof onSearchOpen === "function" && globalEntryCount === 0 && searchableLawCount > 0)
-      ) {
-        pendingSearchRef.current = { mode, query: nextQuery };
-        if (typeof onSearchOpen === "function") {
-          void onSearchOpen();
-        }
-        return;
-      }
-      pendingSearchRef.current = null;
-      runGlobalMatchSearch(nextQuery);
-    }
-  }, [
-    globalEntryCount,
-    hasSearchInitialized,
-    isBuildingCurrent,
-    isBuildingGlobal,
-    isSearchLoading,
-    onSearchOpen,
-    runCurrentSearch,
-    runGlobalMatchSearch,
-    scheduleLawSearch,
-    scheduleDefinitionSearch,
-    scheduleFulltextSearch,
-    searchableLawCount,
-  ]);
+  }, [scheduleLawSearch, scheduleDefinitionSearch, scheduleFulltextSearch]);
 
   // Trigger search data loading on open
   useEffect(() => {
@@ -626,7 +556,6 @@ export function TopBar({
   onPrint,
   showPrint = true,
   onSearchOpen,
-  hasSearchInitialized = true,
   isSearchLoading,
   onToggleSidebar,
   isSidebarOpen,
@@ -760,7 +689,6 @@ export function TopBar({
               globalLists={globalLists}
               onNavigate={onNavigate}
               onSearchOpen={onSearchOpen}
-              hasSearchInitialized={hasSearchInitialized}
               isSearchLoading={isSearchLoading}
               activeLanguage={formexLang}
               searchableLawCount={searchableLawCount}

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -5,7 +5,6 @@ import { ChevronLeft, Search, X, Loader2 } from "lucide-react";
 import { Button } from "./Button.jsx";
 import { ThemeToggle } from "./ThemeToggle.jsx";
 import { LanguageSelector } from "./LanguageSelector.jsx";
-import { searchContent, searchIndex as searchWithIndex, buildSearchIndex } from "../utils/nlp.js";
 import { useI18n } from "../i18n/useI18n.js";
 import {
   searchDefinitions as searchDefinitionsApi,
@@ -16,6 +15,7 @@ import { parseCelexQuery } from "../utils/lawRouting.js";
 import { inferOfficialReferenceFromCelex } from "../utils/library.js";
 import { useSearchNavigation } from "../hooks/useSearchNavigation.js";
 import { useNetworkedSearch } from "../hooks/search/useNetworkedSearch.js";
+import { useLocalSearchIndexes } from "../hooks/search/useLocalSearchIndexes.js";
 import { ToolsMenu } from "./ToolsMenu.jsx";
 import { cleanLawTitle, extractShortLawTitle, formatOfficialReference } from "../utils/lawDisplay.js";
 import { lawStatus } from "../utils/lawStatus.js";
@@ -90,10 +90,6 @@ export function SearchBox({
   const [results, setResults] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = useState(-1);
-  const [currentSearchIndex, setCurrentSearchIndex] = useState(null);
-  const [globalSearchIndex, setGlobalSearchIndex] = useState(null);
-  const [isBuildingCurrent, setIsBuildingCurrent] = useState(false);
-  const [isBuildingGlobal, setIsBuildingGlobal] = useState(false);
   const [searchMode, setSearchMode] = useState(() => (
     persistedState?.searchMode && availableModes.includes(persistedState.searchMode)
       ? persistedState.searchMode
@@ -283,6 +279,27 @@ export function SearchBox({
         ? fulltextSearch.isLoading
         : isCurrentBusy || isMatchesBusy;
 
+  const localIndexes = useLocalSearchIndexes({
+    lists,
+    globalLists: effectiveGlobalLists,
+    query,
+    isOpen,
+    searchMode,
+    isSearchLoading,
+    onSearchOpen,
+    globalEntryCount,
+    searchableLawCount,
+    hasSearchInitialized,
+    setResults,
+    pendingSearchRef,
+  });
+  const {
+    isBuildingCurrent,
+    isBuildingGlobal,
+    runCurrentSearch,
+    runGlobalMatchSearch,
+  } = localIndexes;
+
   useEffect(() => {
     if (!availableModes.includes(searchMode)) {
       setSearchMode(
@@ -318,30 +335,6 @@ export function SearchBox({
       input.setSelectionRange(length, length);
     });
   }, [isOpen]);
-
-  const runCurrentSearch = useCallback((nextQuery) => {
-    if (nextQuery.length < 2) {
-      setResults([]);
-      return;
-    }
-
-    const nextResults = currentSearchIndex
-      ? searchWithIndex(nextQuery, currentSearchIndex)
-      : searchContent(nextQuery, lists);
-    setResults(nextResults);
-  }, [currentSearchIndex, lists]);
-
-  const runGlobalMatchSearch = useCallback((nextQuery, sourceLists = effectiveGlobalLists, sourceIndex = globalSearchIndex) => {
-    if (nextQuery.length < 2) {
-      setResults([]);
-      return;
-    }
-
-    const nextResults = sourceIndex
-      ? searchWithIndex(nextQuery, sourceIndex)
-      : searchContent(nextQuery, sourceLists || { articles: [], recitals: [], annexes: [] });
-    setResults(nextResults);
-  }, [effectiveGlobalLists, globalSearchIndex]);
 
   const executeSearch = useCallback((mode, nextQuery) => {
     if (mode === "laws") {
@@ -424,9 +417,8 @@ export function SearchBox({
     }
   }, [isMatchesMode, isOpen, onSearchOpen]);
 
-  // Reset indices when source data changes
+  // Reset results when source data changes
   useEffect(() => {
-    setCurrentSearchIndex(null);
     setResults([]);
     clearLawSearchError();
     clearDefinitionSearchError();
@@ -434,46 +426,11 @@ export function SearchBox({
   }, [clearLawSearchError, clearDefinitionSearchError, clearFulltextSearchError, lists]);
 
   useEffect(() => {
-    setGlobalSearchIndex(null);
     setResults([]);
     clearLawSearchError();
     clearDefinitionSearchError();
     clearFulltextSearchError();
   }, [clearLawSearchError, clearDefinitionSearchError, clearFulltextSearchError, effectiveGlobalLists]);
-
-  // Build current-law index on open if needed
-  useEffect(() => {
-    if (isOpen && isCurrentMode && !currentSearchIndex && !isBuildingCurrent) {
-      setIsBuildingCurrent(true);
-      setTimeout(() => {
-        try {
-          const idx = buildSearchIndex(lists);
-          setCurrentSearchIndex(idx);
-        } catch (e) {
-          console.error("Failed to build current search index", e);
-        } finally {
-          setIsBuildingCurrent(false);
-        }
-      }, 100);
-    }
-  }, [currentSearchIndex, isBuildingCurrent, isCurrentMode, isOpen, lists]);
-
-  // Build global library index on open if needed
-  useEffect(() => {
-    if (isOpen && isMatchesMode && !isSearchLoading && !globalSearchIndex && !isBuildingGlobal) {
-      setIsBuildingGlobal(true);
-      setTimeout(() => {
-        try {
-          const idx = buildSearchIndex(effectiveGlobalLists || { articles: [], recitals: [], annexes: [] });
-          setGlobalSearchIndex(idx);
-        } catch (e) {
-          console.error("Failed to build global search index", e);
-        } finally {
-          setIsBuildingGlobal(false);
-        }
-      }, 100);
-    }
-  }, [effectiveGlobalLists, globalSearchIndex, isBuildingGlobal, isMatchesMode, isOpen, isSearchLoading]);
 
   useEffect(() => () => {
     abortLawSearch();
@@ -623,25 +580,18 @@ export function SearchBox({
       setResults([]);
       return;
     }
+    // current/matches run through the hook's query-change effect once their
+    // index is ready; executing here too would run the search twice per
+    // keystroke.
+    if (isCurrentMode || isMatchesMode) return;
     executeSearch(searchMode, q);
   };
 
   useEffect(() => {
-    if (!isOpen || query.length < 2) return;
-    if (isCurrentMode && !isBuildingCurrent) {
-      runCurrentSearch(query);
-    }
-  }, [isBuildingCurrent, isCurrentMode, isOpen, query, runCurrentSearch]);
-
-  useEffect(() => {
-    if (!isOpen || query.length < 2) return;
-    if (isMatchesMode && !isBuildingGlobal && !isSearchLoading) {
-      runGlobalMatchSearch(query);
-    }
-  }, [globalEntryCount, isBuildingGlobal, isMatchesMode, isOpen, isSearchLoading, query, runGlobalMatchSearch]);
-
-  useEffect(() => {
     if (!isOpen) return;
+    // current/matches are driven by the local-index hook's query-change
+    // effect; this orchestrator handles only the networked modes.
+    if (isCurrentMode || isMatchesMode) return;
     setSelectedIndex(-1);
     setResults([]);
     clearLawSearchError();
@@ -652,40 +602,7 @@ export function SearchBox({
       return;
     }
     executeSearch(searchMode, query);
-  }, [executeSearch, isLawMode, isOpen, query, scheduleLawSearch, clearLawSearchError, clearDefinitionSearchError, clearFulltextSearchError, searchMode]);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const pending = pendingSearchRef.current;
-    if (!pending) return;
-
-    if (pending.mode === "current" && !isBuildingCurrent) {
-      pendingSearchRef.current = null;
-      runCurrentSearch(pending.query);
-      return;
-    }
-
-    if (pending.mode === "matches" && !isSearchLoading && !isBuildingGlobal) {
-      if (
-        typeof onSearchOpen === "function" && globalEntryCount === 0 && searchableLawCount > 0
-      ) {
-        return;
-      }
-      pendingSearchRef.current = null;
-      runGlobalMatchSearch(pending.query);
-    }
-  }, [
-    globalEntryCount,
-    hasSearchInitialized,
-    isBuildingCurrent,
-    isBuildingGlobal,
-    isOpen,
-    isSearchLoading,
-    onSearchOpen,
-    runCurrentSearch,
-    runGlobalMatchSearch,
-    searchableLawCount,
-  ]);
+  }, [executeSearch, isCurrentMode, isLawMode, isMatchesMode, isOpen, query, scheduleLawSearch, clearLawSearchError, clearDefinitionSearchError, clearFulltextSearchError, searchMode]);
 
   const modeSummary = isCurrentMode
     ? t("search.searchingCurrentLaw", { law: currentLawLabel || t("search.currentLawFallback") })

--- a/src/components/TopBar.jsx
+++ b/src/components/TopBar.jsx
@@ -238,15 +238,6 @@ export function SearchBox({
   const isMatchesMode = searchMode === "matches";
   const isDefinitionsMode = searchMode === "definitions";
   const isFulltextMode = searchMode === "fulltext";
-  const isCurrentBusy = isCurrentMode && isBuildingCurrent;
-  const isMatchesBusy = isMatchesMode && (isBuildingGlobal || isSearchLoading);
-  const isBusy = isLawMode
-    ? lawSearch.isLoading
-    : isDefinitionsMode
-      ? definitionSearch.isLoading
-      : isFulltextMode
-        ? fulltextSearch.isLoading
-        : isCurrentBusy || isMatchesBusy;
 
   const localIndexes = useLocalSearchIndexes({
     lists,
@@ -268,6 +259,19 @@ export function SearchBox({
     runCurrentSearch,
     runGlobalMatchSearch,
   } = localIndexes;
+
+  // Must stay below the useLocalSearchIndexes destructuring: referencing the
+  // building flags any earlier reads them before initialization whenever the
+  // active mode is "current" or "matches" (the law reader's default mode).
+  const isCurrentBusy = isCurrentMode && isBuildingCurrent;
+  const isMatchesBusy = isMatchesMode && (isBuildingGlobal || isSearchLoading);
+  const isBusy = isLawMode
+    ? lawSearch.isLoading
+    : isDefinitionsMode
+      ? definitionSearch.isLoading
+      : isFulltextMode
+        ? fulltextSearch.isLoading
+        : isCurrentBusy || isMatchesBusy;
 
   useEffect(() => {
     if (!availableModes.includes(searchMode)) {

--- a/src/components/TopBar.test.jsx
+++ b/src/components/TopBar.test.jsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { createElement } from "react";
+import { MemoryRouter } from "react-router-dom";
+
+const { TopBar } = await import("./TopBar.jsx");
+const { I18nProvider } = await import("../i18n/I18nProvider.jsx");
+
+let container;
+let root;
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  document.body.innerHTML = "";
+  window.localStorage.clear();
+  delete globalThis.IS_REACT_ACT_ENVIRONMENT;
+});
+
+function renderTopBar(props = {}) {
+  root = createRoot(container);
+  act(() => {
+    root.render(
+      createElement(
+        MemoryRouter,
+        null,
+        createElement(
+          I18nProvider,
+          null,
+          createElement(TopBar, {
+            lawKey: "32016R0679",
+            lists: { articles: [], recitals: [], annexes: [] },
+            onSearchOpen: () => Promise.resolve({ articles: [], recitals: [], annexes: [] }),
+            ...props,
+          })
+        )
+      )
+    );
+  });
+}
+
+describe("TopBar smoke", () => {
+  it("renders with minimal props without crashing", () => {
+    renderTopBar();
+    expect(container.querySelector("header")).not.toBeNull();
+    expect(container.textContent).toContain("Konrad Kollnig");
+  });
+
+  it("hosts the search trigger", () => {
+    renderTopBar();
+    expect(container.querySelector('input[placeholder="Search (Cmd+K)..."]')).not.toBeNull();
+  });
+
+  it("omits the search trigger when showSearch is false", () => {
+    renderTopBar({ showSearch: false });
+    expect(container.querySelector('input[placeholder="Search (Cmd+K)..."]')).toBeNull();
+  });
+});

--- a/src/components/search/SearchModal.jsx
+++ b/src/components/search/SearchModal.jsx
@@ -1,0 +1,510 @@
+import { useEffect, useCallback, useRef } from "react";
+import { createPortal } from "react-dom";
+import { ChevronLeft, Search, X, Loader2 } from "lucide-react";
+import { useI18n } from "../../i18n/useI18n.js";
+import { SearchResults } from "./results/SearchResults.jsx";
+
+export function SearchModal({
+  isOpen,
+  onOpen,
+  onClose,
+  query,
+  onQueryChange,
+  onClear,
+  results,
+  selectedIndex,
+  onSelectedIndexChange,
+  onSelect,
+  searchMode,
+  onSearchModeChange,
+  onClearErrors,
+  availableModes,
+  onExecuteLawSearch,
+  definitionDiscoveryFilter,
+  onDefinitionDiscovery,
+  isBusy,
+  isInputDisabled,
+  hasGlobalSearch,
+  lawError,
+  definitionError,
+  fulltextError,
+  searchableLawCount,
+  activeLanguage,
+  currentLawLabel,
+  lawLastQuery,
+  definitionLastQuery,
+  fulltextLastQuery,
+}) {
+  const { t } = useI18n();
+  const modalInputRef = useRef(null);
+  const resultsRef = useRef(null);
+
+  const isCurrentMode = searchMode === "current";
+  const isLawMode = searchMode === "laws";
+  const isMatchesMode = searchMode === "matches";
+  const isDefinitionsMode = searchMode === "definitions";
+  const isFulltextMode = searchMode === "fulltext";
+
+  const focusModalInput = useCallback(() => {
+    if (!isOpen) return;
+
+    window.requestAnimationFrame(() => {
+      const input = modalInputRef.current;
+      if (!input) return;
+      input.focus();
+      const length = input.value.length;
+      input.setSelectionRange(length, length);
+    });
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    focusModalInput();
+  }, [focusModalInput, isOpen, searchMode]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleWindowFocus = () => {
+      focusModalInput();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        focusModalInput();
+      }
+    };
+
+    window.addEventListener("focus", handleWindowFocus);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener("focus", handleWindowFocus);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [focusModalInput, isOpen]);
+
+  // Close when pressing Escape; Command/Ctrl + K to open
+  useEffect(() => {
+    const handleKeyDown = (e) => {
+      if (e.key === "Escape") {
+        onClose();
+        modalInputRef.current?.blur();
+      }
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        onOpen();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [onClose, onOpen]);
+
+  // Keyboard navigation within modal
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e) => {
+      if (results.length === 0) return;
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        onSelectedIndexChange(prev => (prev + 1) % results.length);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        onSelectedIndexChange(prev => (prev - 1 + results.length) % results.length);
+      } else if (e.key === "Enter") {
+        e.preventDefault();
+        if (selectedIndex >= 0 && selectedIndex < results.length) {
+          onSelect(results[selectedIndex]);
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [onSelect, isOpen, results, selectedIndex, onSelectedIndexChange]);
+
+  // Auto-scroll to selected item
+  useEffect(() => {
+    if (selectedIndex >= 0 && resultsRef.current) {
+      const selectedEl = resultsRef.current.querySelector(`[data-result-index="${selectedIndex}"]`);
+      if (selectedEl?.scrollIntoView) {
+        selectedEl.scrollIntoView({ block: "nearest", behavior: "smooth" });
+      }
+    }
+  }, [selectedIndex]);
+
+  // Switch the active mode: update state, reset selection and clear errors,
+  // then return focus to the input. Shared by the mode tabs and Tab cycling.
+  const switchMode = useCallback((mode) => {
+    onSearchModeChange(mode);
+    onSelectedIndexChange(-1);
+    onClearErrors();
+    focusModalInput();
+  }, [focusModalInput, onClearErrors, onSearchModeChange, onSelectedIndexChange]);
+
+  // Cycle the active mode with Tab / Shift+Tab while the dialog is open.
+  const cycleMode = useCallback((direction) => {
+    if (availableModes.length < 2) return;
+    const currentIdx = availableModes.indexOf(searchMode);
+    const nextIdx = (currentIdx + direction + availableModes.length) % availableModes.length;
+    switchMode(availableModes[nextIdx]);
+  }, [availableModes, searchMode, switchMode]);
+
+  const modeSummary = isCurrentMode
+    ? t("search.searchingCurrentLaw", { law: currentLawLabel || t("search.currentLawFallback") })
+    : isLawMode
+      ? t("search.searchingLaws")
+      : isDefinitionsMode
+        ? t("search.searchingDefinitions")
+        : isFulltextMode
+          ? t("search.searchingFulltext")
+      : t("search.searchingMatches", {
+        count: searchableLawCount,
+        lawWord: searchableLawCount === 1 ? t("search.law") : t("search.laws"),
+        language: activeLanguage,
+      });
+
+  // Short muted scope sentence shown beneath the mode segmented control. For
+  // laws mode the secondary-acts caveat lives in the footer instead, so the
+  // scope line stays terse.
+  const scopeSentence = isCurrentMode
+    ? t("search.searchingCurrentLaw", { law: currentLawLabel || t("search.currentLawFallback") })
+    : isLawMode
+      ? t("search.scopeLaws")
+      : isDefinitionsMode
+        ? t("search.searchingDefinitions")
+        : isFulltextMode
+          ? t("search.scopeFulltext")
+      : t("search.searchingMatches", {
+        count: searchableLawCount,
+        lawWord: searchableLawCount === 1 ? t("search.law") : t("search.laws"),
+        language: activeLanguage,
+      });
+
+  const modeLabel = (mode) => (
+    mode === "current"
+      ? t("search.segCurrent")
+      : mode === "laws"
+        ? t("search.segLaws")
+        : mode === "definitions"
+          ? t("search.segDefinitions")
+          : mode === "fulltext"
+            ? t("search.segFulltext")
+        : t("search.segMatches")
+  );
+
+  const inputPlaceholder = isBusy
+    ? t("search.initializing")
+    : isCurrentMode
+      ? t("search.placeholderCurrentLaw", { law: currentLawLabel || t("search.currentLawFallback") })
+      : isLawMode
+        ? t("search.placeholderLaws")
+        : isDefinitionsMode
+          ? t("search.placeholderDefinitions")
+          : isFulltextMode
+            ? t("search.placeholderFulltext")
+        : t("search.placeholderMatches");
+
+  const lawSearchError = lawError
+    ? lawError?.message || t("search.apiUnavailable")
+    : "";
+  const definitionSearchError = definitionError
+    ? definitionError?.message || t("search.definitionApiUnavailable")
+    : "";
+  const searchErrorMessage = isFulltextMode && fulltextError
+    ? (fulltextError.status === 503 || fulltextError.code === "fulltext_index_unavailable"
+      ? t("search.fulltextApiUnavailable")
+      : fulltextError.message || t("search.fulltextApiUnavailable"))
+    : isDefinitionsMode
+      ? definitionSearchError
+      : lawSearchError;
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100] flex items-start justify-center bg-black/20 transition-all md:p-4 md:pt-[15vh]"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={t("search.trigger")}
+        className="w-full max-w-2xl flex flex-col h-full md:h-auto md:max-h-[70vh] bg-white shadow-2xl ring-1 ring-black/5 animate-in fade-in zoom-in-95 duration-100 overflow-hidden fixed inset-0 md:static md:inset-auto md:rounded-2xl dark:bg-gray-900 dark:ring-white/10"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header with Auto-focused Input */}
+        <div className="flex-none border-b border-gray-100 bg-white px-4 py-3 dark:border-gray-800 dark:bg-gray-900">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={onClose}
+              className="p-1 -ml-1 text-gray-500 hover:text-gray-900 md:hidden"
+            >
+              <ChevronLeft size={24} />
+            </button>
+            <div className="flex min-w-0 flex-1 items-center gap-3">
+              <Search size={18} className="hidden shrink-0 text-gray-400 md:block" />
+              <div className="relative min-w-0 flex-1">
+                <input
+                  ref={modalInputRef}
+                  type="text"
+                  value={query}
+                  onChange={onQueryChange}
+                  onKeyDown={(e) => {
+                    if (e.key === "Tab" && availableModes.length > 1) {
+                      e.preventDefault();
+                      cycleMode(e.shiftKey ? -1 : 1);
+                      return;
+                    }
+                    if (isLawMode && e.key === "Enter" && selectedIndex < 0) {
+                      e.preventDefault();
+                      onExecuteLawSearch(query);
+                    }
+                  }}
+                  placeholder={inputPlaceholder}
+                  disabled={isInputDisabled}
+                  className="h-10 w-full bg-transparent pr-8 text-base font-medium text-gray-900 outline-none placeholder:text-gray-400 disabled:opacity-50 md:text-[1.05rem] dark:text-white dark:placeholder:text-gray-600"
+                />
+                {isBusy ? (
+                  <div className="absolute right-0 top-1/2 -translate-y-1/2">
+                    <Loader2 className="animate-spin text-blue-600" size={20} />
+                  </div>
+                ) : query && (
+                  <button
+                    onClick={() => {
+                      onClear();
+                      focusModalInput();
+                    }}
+                    className="absolute right-0 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600"
+                    title={t("search.clear")}
+                  >
+                    <X size={16} />
+                  </button>
+                )}
+              </div>
+            </div>
+            <div className="hidden shrink-0 items-center md:flex">
+              <button
+                onClick={onClose}
+                title={t("common.close")}
+                className="rounded-md border border-gray-200 bg-gray-50 px-2 py-1 font-mono text-[10px] text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-500 dark:hover:text-gray-300"
+              >
+                esc
+              </button>
+            </div>
+          </div>
+</div>
+
+        {hasGlobalSearch && availableModes.length > 1 && (
+          <div className="flex-none border-b border-gray-100 bg-gray-50/80 px-4 py-2.5 dark:border-gray-800 dark:bg-gray-950/60">
+            <div className="flex flex-wrap items-center gap-3">
+              <div
+                role="tablist"
+                aria-label={t("search.modeLabel")}
+                className="inline-flex rounded-lg border border-gray-200 bg-gray-100 p-0.5 dark:border-gray-700 dark:bg-gray-950"
+              >
+                {availableModes.map((mode) => {
+                  const active = searchMode === mode;
+                  return (
+                    <button
+                      key={mode}
+                      type="button"
+                      role="tab"
+                      aria-selected={active}
+                      onClick={() => switchMode(mode)}
+                      className={`rounded-md px-3 py-1 text-xs font-medium transition ${
+                        active
+                          ? "bg-white text-gray-900 shadow-sm dark:bg-gray-800 dark:text-white"
+                          : "text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                      }`}
+                    >
+                      {modeLabel(mode)}
+                    </button>
+                  );
+                })}
+              </div>
+              <span className="min-w-0 flex-1 truncate text-[11.5px] text-gray-500 dark:text-gray-400">
+                {scopeSentence}
+              </span>
+            </div>
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto p-2 scroll-smooth bg-gray-50/30 dark:bg-gray-950/50">
+          {isDefinitionsMode ? (
+            <div className="flex flex-wrap items-center gap-1.5 px-2 pb-1 pt-1" aria-label={t("search.definitionDiscoveryLabel")}>
+              {[
+                { id: "", label: t("search.definitionDiscoveryAll") },
+                { id: "different", label: t("search.definitionDiscoveryDifferent") },
+                { id: "reused", label: t("search.definitionDiscoveryReused") },
+              ].map((entry) => (
+                <button
+                  key={entry.id || "all"}
+                  type="button"
+                  aria-pressed={definitionDiscoveryFilter === entry.id}
+                  onClick={() => {
+                    onDefinitionDiscovery(entry.id);
+                    focusModalInput();
+                  }}
+                  className={`rounded-full border px-2.5 py-1 text-[11px] font-medium transition ${
+                    definitionDiscoveryFilter === entry.id
+                      ? "border-eu-blue bg-eu-blue-soft text-eu-blue dark:border-eu-blue-bright dark:bg-eu-blue-soft-dark dark:text-eu-blue-bright"
+                      : "border-gray-200 bg-white text-gray-500 hover:text-gray-800 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400 dark:hover:text-gray-200"
+                  }`}
+                >
+                  {entry.label}
+                </button>
+              ))}
+            </div>
+          ) : null}
+          {searchErrorMessage ? (
+            <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+              <Search size={48} className="opacity-10 mb-4" />
+              <p className="max-w-sm text-center text-sm">{searchErrorMessage}</p>
+            </div>
+          ) : isBusy ? (
+            <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+              <Search size={48} className="opacity-20 mb-4 animate-pulse" />
+              <p className="text-sm text-center max-w-sm">{modeSummary}</p>
+            </div>
+          ) : results.length > 0 ? (
+            <SearchResults
+              results={results}
+              searchMode={searchMode}
+              selectedIndex={selectedIndex}
+              query={query}
+              t={t}
+              onSelect={onSelect}
+              resultsRef={resultsRef}
+            />
+          ) : (
+            <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+              {isFulltextMode && fulltextLastQuery.length < 2 ? (
+                <>
+                  <Search size={48} className="opacity-10 mb-4" />
+                  <p className="text-sm text-center max-w-sm">{t("search.typeFulltext")}</p>
+                </>
+              ) : isFulltextMode ? (
+                <>
+                  <Search size={48} className="opacity-20 mb-4" />
+                  <p className="text-sm text-center max-w-sm">
+                    {t("search.noResultsFulltext", { query: fulltextLastQuery })}
+                  </p>
+                </>
+              ) : isDefinitionsMode && definitionLastQuery.length < 2 ? (
+                <>
+                  <Search size={48} className="opacity-10 mb-4" />
+                  <p className="text-sm text-center max-w-sm">{t("search.typeDefinitions")}</p>
+                </>
+              ) : isDefinitionsMode ? (
+                <>
+                  <Search size={48} className="opacity-20 mb-4" />
+                  <p className="text-sm text-center max-w-sm">
+                    {t("search.noResultsDefinitions", { query: definitionLastQuery })}
+                  </p>
+                </>
+              ) : isLawMode && lawLastQuery.length < 2 ? (
+                <>
+                  <Search size={48} className="opacity-10 mb-4" />
+                  <p className="text-sm text-center max-w-sm">
+                    {t("search.typeLaws")}
+                  </p>
+                </>
+              ) : isLawMode ? (
+                <>
+                  <Search size={48} className="opacity-20 mb-4" />
+                  <p className="text-sm text-center max-w-sm">
+                    {t("search.noResultsLaws", { query: lawLastQuery })}
+                  </p>
+                </>
+              ) : isCurrentMode && query.length < 2 ? (
+                <>
+                  <Search size={48} className="opacity-10 mb-4" />
+                  <p className="text-sm text-center max-w-sm">
+                    {t("search.typeCurrentLaw", { law: currentLawLabel || t("search.currentLawFallback") })}
+                  </p>
+                </>
+              ) : isCurrentMode ? (
+                <>
+                  <Search size={48} className="opacity-20 mb-4" />
+                  <p className="text-sm text-center max-w-sm">
+                    {t("search.noResultsCurrentLaw", { query, law: currentLawLabel || t("search.currentLawFallback") })}
+                  </p>
+                </>
+              ) : isMatchesMode && searchableLawCount === 0 ? (
+                <>
+                  <Search size={48} className="opacity-10 mb-4" />
+                  <p className="text-sm text-center max-w-sm">
+                    {t("search.noCached", { language: activeLanguage })}
+                  </p>
+                </>
+              ) : isMatchesMode && query.length < 2 ? (
+                <>
+                  <Search size={48} className="opacity-10 mb-4" />
+                  <p className="text-sm text-center max-w-sm">
+                    {t("search.typeCached", {
+                      count: searchableLawCount,
+                      lawWord: searchableLawCount === 1 ? t("search.law") : t("search.laws"),
+                      language: activeLanguage,
+                    })}
+                  </p>
+                </>
+              ) : !hasGlobalSearch && query.length < 2 ? (
+                <>
+                  <Search size={48} className="opacity-10 mb-4" />
+                  <p className="text-sm">{t("search.typeToStart")}</p>
+                </>
+              ) : isMatchesMode ? (
+                <>
+                  <Search size={48} className="opacity-20 mb-4" />
+                  <p className="text-sm text-center max-w-sm">
+                    {t("search.noResultsCached", {
+                      query,
+                      count: searchableLawCount,
+                      lawWord: searchableLawCount === 1 ? t("search.law") : t("search.laws"),
+                      language: activeLanguage,
+                    })}
+                  </p>
+                </>
+              ) : (
+                <>
+                  <Search size={48} className="opacity-20 mb-4" />
+                  <p className="text-sm">{t("search.noResults", { query })}</p>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+
+        <div className="hidden md:flex flex-none items-center gap-4 border-t border-gray-100 bg-gray-50 px-4 py-2 text-[10px] text-gray-400 dark:bg-gray-900 dark:border-gray-800 dark:text-gray-500">
+          <span className="flex items-center gap-1.5">
+            <kbd className="rounded border border-gray-200 bg-white px-1 font-mono dark:border-gray-700 dark:bg-gray-800">↑↓</kbd>
+            {t("search.footNavigate")}
+          </span>
+          <span className="flex items-center gap-1.5">
+            <kbd className="rounded border border-gray-200 bg-white px-1 font-mono dark:border-gray-700 dark:bg-gray-800">↵</kbd>
+            {t("search.footOpen")}
+          </span>
+          {availableModes.length > 1 && (
+            <span className="flex items-center gap-1.5">
+              <kbd className="rounded border border-gray-200 bg-white px-1 font-mono dark:border-gray-700 dark:bg-gray-800">⇥</kbd>
+              {t("search.footMode")}
+            </span>
+          )}
+          <span className="flex items-center gap-1.5">
+            <kbd className="rounded border border-gray-200 bg-white px-1 font-mono dark:border-gray-700 dark:bg-gray-800">esc</kbd>
+            {t("search.footClose")}
+          </span>
+          {isFulltextMode ? (
+            <span className="ml-auto text-gray-400 dark:text-gray-500">{t("search.fulltextEnglishOnly")}</span>
+          ) : isLawMode ? (
+            <span className="ml-auto text-gray-400 dark:text-gray-500">{t("search.secondaryNotIndexed")}</span>
+          ) : null}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/components/search/results/LawResultRow.jsx
+++ b/src/components/search/results/LawResultRow.jsx
@@ -1,0 +1,109 @@
+import { lawStatus } from "../../../utils/lawStatus.js";
+import { cleanLawTitle, extractShortLawTitle, formatOfficialReference } from "../../../utils/lawDisplay.js";
+import { inferOfficialReferenceFromCelex } from "../../../utils/library.js";
+
+function getLawResultDisplay(item) {
+  const officialReference = inferOfficialReferenceFromCelex(item.celex);
+  const referenceLabel = formatOfficialReference(officialReference);
+  const rawTitle = String(item.title || "").replace(/\s+/g, " ").trim();
+  const cleanedTitle = cleanLawTitle(rawTitle, referenceLabel);
+  const shortTitle = extractShortLawTitle(cleanedTitle || rawTitle);
+  const primaryTitle = shortTitle && referenceLabel
+    ? `${shortTitle} — ${referenceLabel}`
+    : shortTitle
+      ? shortTitle
+      : referenceLabel || rawTitle || item.celex;
+  const secondaryTitle = cleanedTitle && cleanedTitle !== primaryTitle
+    ? cleanedTitle
+    : rawTitle && rawTitle !== primaryTitle
+      ? rawTitle
+      : "";
+  const metaLine = [item.date, item.celex].filter(Boolean).join(" · ");
+
+  return {
+    primaryTitle,
+    secondaryTitle,
+    referenceLabel,
+    metaLine,
+  };
+}
+
+export function LawResultRow({ item, t, dense }) {
+  const lawDisplay = getLawResultDisplay(item);
+  return (
+    <>
+      <div className="flex w-full min-w-0 items-baseline gap-2">
+        <span className={`min-w-0 flex-1 truncate font-display font-bold ${dense ? "text-[14px]" : "text-[15px]"} ${
+          lawStatus(item) === "notInForce"
+            ? "text-gray-400 dark:text-gray-500"
+            : "text-eu-navy dark:text-white"
+        }`}>
+          {lawDisplay?.primaryTitle || item.title}
+        </span>
+        {item.directCelex && (
+          <span className="flex-shrink-0 rounded-full bg-eu-gold-soft px-2 py-0.5 text-[10px] font-medium text-eu-gold-deep dark:bg-eu-gold-soft-dark dark:text-eu-gold-bright">
+            {t("search.openDirectly")}
+          </span>
+        )}
+        {item.law_label && (
+          <span className="flex-shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+            {item.law_label}
+          </span>
+        )}
+        {/* Four states, and `null` is one of them: Cellar has no
+            status for ~13% of the corpus, and drawing nothing is the
+            only honest answer there. See lawStatus() for why `false`
+            alone is not enough to say "no longer". */}
+        {lawStatus(item) === "inForce" && (
+          <span className="inline-flex flex-shrink-0 items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+            <span className="h-1.5 w-1.5 rounded-full bg-emerald-500 dark:bg-emerald-400" aria-hidden="true" />
+            {t("search.inForce")}
+          </span>
+        )}
+        {lawStatus(item) === "notYetInForce" && (
+          <span
+            className="inline-flex flex-shrink-0 items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-amber-700 dark:bg-amber-900/40 dark:text-amber-300"
+            title={t("search.entryIntoForce").replace("{date}", item.entryIntoForce)}
+          >
+            <span className="h-1.5 w-1.5 rounded-full bg-amber-500 dark:bg-amber-400" aria-hidden="true" />
+            {t("search.notYetInForce")}
+          </span>
+        )}
+        {lawStatus(item) === "notInForce" && (
+          <span
+            className="flex-shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+            title={item.endOfValidity ? t("search.endOfValidity").replace("{date}", item.endOfValidity) : undefined}
+          >
+            {t("search.notInForce")}
+          </span>
+        )}
+      </div>
+      {lawDisplay?.secondaryTitle ? (
+        <p className={`text-xs leading-relaxed line-clamp-2 ${
+          lawStatus(item) === "notInForce"
+            ? "text-gray-400 dark:text-gray-500"
+            : "text-gray-500 dark:text-gray-400"
+        }`}>
+          {lawDisplay.secondaryTitle}
+        </p>
+      ) : null}
+      {lawDisplay?.metaLine ? (
+        <p className="font-mono text-[11px] text-gray-400 dark:text-gray-500">
+          {lawDisplay.metaLine}
+        </p>
+      ) : null}
+      {Array.isArray(item.topics) && item.topics.length > 0 ? (
+        <div className="flex flex-wrap gap-1">
+          {item.topics.slice(0, 3).map((topic) => (
+            <span
+              key={topic}
+              className="max-w-[10rem] flex-shrink-0 truncate rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+            >
+              {topic}
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/search/results/MatchResultRow.jsx
+++ b/src/components/search/results/MatchResultRow.jsx
@@ -1,0 +1,33 @@
+export function MatchResultRow({ item, t }) {
+  return (
+    <>
+      <div className="flex w-full min-w-0 items-center gap-2.5">
+        <span className={`flex-shrink-0 rounded-md border px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
+          item.type === "article"
+            ? "border-blue-100 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-900/40 dark:text-blue-200"
+            : item.type === "recital"
+              ? "border-purple-100 bg-purple-50 text-purple-700 dark:border-purple-800 dark:bg-purple-900/40 dark:text-purple-200"
+              : "border-orange-100 bg-orange-50 text-orange-700 dark:border-orange-800 dark:bg-orange-900/40 dark:text-orange-200"
+        }`}>
+          {item.type}
+        </span>
+        <span className="min-w-0 flex-1 truncate font-semibold text-base text-gray-900 group-hover:text-eu-blue dark:text-gray-100 dark:group-hover:text-eu-blue-bright">
+          {item.title}
+        </span>
+        {item.score > 100 && (
+          <span className="flex-shrink-0 rounded-full bg-green-100 px-1.5 text-[10px] font-medium text-green-700 dark:bg-green-900/50 dark:text-green-200">{t("search.bestMatch")}</span>
+        )}
+        {item.law_label && (
+          <span className="flex-shrink-0 rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+            {item.law_label}
+          </span>
+        )}
+      </div>
+      <p className="pl-1 text-sm leading-relaxed text-gray-500 line-clamp-2 dark:text-gray-300">
+        <span className="opacity-70">...</span>
+        {item.preview}
+        <span className="opacity-70">...</span>
+      </p>
+    </>
+  );
+}

--- a/src/components/search/results/SearchResults.jsx
+++ b/src/components/search/results/SearchResults.jsx
@@ -1,0 +1,88 @@
+import { useMemo } from "react";
+import { DefinitionSearchResult } from "../DefinitionSearchResult.jsx";
+import { FulltextSearchResult } from "../FulltextSearchResult.jsx";
+import { LawResultRow } from "./LawResultRow.jsx";
+import { MatchResultRow } from "./MatchResultRow.jsx";
+
+// Split laws-mode results into a "Best match" group (the synthetic direct-open
+// CELEX result, when present, plus the top backend hit) and an "All results"
+// group for the remainder. The concatenated render order is identical to
+// `results`, so keyboard selectedIndex still maps 1:1.
+function buildResultGroups(results, isLawMode, t) {
+  if (!isLawMode || results.length === 0) {
+    return [{ label: null, items: results }];
+  }
+  const directResults = results.filter((r) => r.directCelex);
+  const nonDirect = results.filter((r) => !r.directCelex);
+  const bestItems = [...directResults, ...nonDirect.slice(0, 1)];
+  const restItems = nonDirect.slice(1);
+  const groups = [{ label: t("search.groupBestMatch"), items: bestItems }];
+  if (restItems.length > 0) {
+    groups.push({ label: t("search.groupAllResults"), items: restItems });
+  }
+  return groups;
+}
+
+export function SearchResults({
+  results,
+  searchMode,
+  selectedIndex,
+  query,
+  t,
+  onSelect,
+  resultsRef,
+}) {
+  const isLawMode = searchMode === "laws";
+  const resultGroups = useMemo(
+    () => buildResultGroups(results, isLawMode, t),
+    [isLawMode, results, t]
+  );
+
+  return (
+    <div className="flex flex-col p-2 w-full" ref={resultsRef}>
+      {(() => {
+        let flatIndex = -1;
+        return resultGroups.map((group, gi) => (
+          <div key={group.label || `group-${gi}`} className="flex flex-col">
+            {group.label ? (
+              <div className="px-3 pb-1 pt-2 text-[10.5px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+                {group.label}
+              </div>
+            ) : null}
+            <div className="flex flex-col gap-1">
+              {group.items.map((item) => {
+                flatIndex += 1;
+                const idx = flatIndex;
+                const isSelected = idx === selectedIndex;
+                const dense = gi > 0;
+                return (
+                  <button
+                    type="button"
+                    key={`${item.search_kind || item.type}-${item.id}-${idx}`}
+                    data-result-index={idx}
+                    onClick={() => onSelect(item)}
+                    className={`group flex w-full flex-col gap-1 rounded-xl px-3 text-left transition-colors ${dense ? "py-2" : "py-2.5"} ${
+                      isSelected
+                        ? "bg-eu-blue-soft dark:bg-eu-blue-soft-dark"
+                        : "hover:bg-eu-blue-soft/60 dark:hover:bg-eu-blue-soft-dark/60"
+                    }`}
+                  >
+                    {item.search_kind === "definition" ? (
+                      <DefinitionSearchResult item={item} query={query} t={t} />
+                    ) : item.search_kind === "fulltext" ? (
+                      <FulltextSearchResult item={item} t={t} />
+                    ) : item.search_kind === "law" ? (
+                      <LawResultRow item={item} t={t} dense={dense} />
+                    ) : (
+                      <MatchResultRow item={item} t={t} />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        ));
+      })()}
+    </div>
+  );
+}

--- a/src/hooks/search/useLocalSearchIndexes.js
+++ b/src/hooks/search/useLocalSearchIndexes.js
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { buildSearchIndex, searchContent, searchIndex as searchWithIndex } from "../../utils/nlp.js";
+
+// Owns the client-side search indexes SearchBox uses for the "current" and
+// "matches" modes: the per-law index and the whole-library index, each built
+// lazily from the loaded source lists via a setTimeout, plus the orchestration
+// that runs a search once the relevant index is ready. The networked modes
+// (laws, definitions, fulltext) live in useNetworkedSearch, not here.
+export function useLocalSearchIndexes({
+  lists,
+  globalLists,
+  query,
+  isOpen,
+  searchMode,
+  isSearchLoading,
+  onSearchOpen,
+  globalEntryCount,
+  searchableLawCount,
+  hasSearchInitialized,
+  setResults,
+  pendingSearchRef,
+}) {
+  const [currentSearchIndex, setCurrentSearchIndex] = useState(null);
+  const [globalSearchIndex, setGlobalSearchIndex] = useState(null);
+  const [isBuildingCurrent, setIsBuildingCurrent] = useState(false);
+  const [isBuildingGlobal, setIsBuildingGlobal] = useState(false);
+
+  const isCurrentMode = searchMode === "current";
+  const isMatchesMode = searchMode === "matches";
+
+  const runCurrentSearch = useCallback((nextQuery) => {
+    if (nextQuery.length < 2) {
+      setResults([]);
+      return;
+    }
+
+    const nextResults = currentSearchIndex
+      ? searchWithIndex(nextQuery, currentSearchIndex)
+      : searchContent(nextQuery, lists);
+    setResults(nextResults);
+  }, [currentSearchIndex, lists, setResults]);
+
+  const runGlobalMatchSearch = useCallback((nextQuery, sourceLists = globalLists, sourceIndex = globalSearchIndex) => {
+    if (nextQuery.length < 2) {
+      setResults([]);
+      return;
+    }
+
+    const nextResults = sourceIndex
+      ? searchWithIndex(nextQuery, sourceIndex)
+      : searchContent(nextQuery, sourceLists || { articles: [], recitals: [], annexes: [] });
+    setResults(nextResults);
+  }, [globalLists, globalSearchIndex, setResults]);
+
+  // A failed build must not re-arm the setTimeout loop on every render pass
+  // while the dialog stays open. Latch the failure against the source list it
+  // came from, and reset the latch only when that list actually changes, so a
+  // genuinely transient failure still gets one retry on new input.
+  const currentBuildFailedRef = useRef(false);
+  const currentSourceRef = useRef(lists);
+  const globalBuildFailedRef = useRef(false);
+  const globalSourceRef = useRef(globalLists);
+
+  useEffect(() => {
+    if (currentSourceRef.current !== lists) {
+      currentSourceRef.current = lists;
+      currentBuildFailedRef.current = false;
+      setCurrentSearchIndex(null);
+    }
+  }, [lists]);
+
+  useEffect(() => {
+    if (globalSourceRef.current !== globalLists) {
+      globalSourceRef.current = globalLists;
+      globalBuildFailedRef.current = false;
+      setGlobalSearchIndex(null);
+    }
+  }, [globalLists]);
+
+  // Build current-law index on open if needed
+  useEffect(() => {
+    if (
+      isOpen
+      && isCurrentMode
+      && !currentSearchIndex
+      && !isBuildingCurrent
+      && !currentBuildFailedRef.current
+    ) {
+      setIsBuildingCurrent(true);
+      setTimeout(() => {
+        try {
+          const idx = buildSearchIndex(lists);
+          setCurrentSearchIndex(idx);
+        } catch (e) {
+          console.error("Failed to build current search index", e);
+          currentBuildFailedRef.current = true;
+        } finally {
+          setIsBuildingCurrent(false);
+        }
+      }, 100);
+    }
+  }, [currentSearchIndex, isBuildingCurrent, isCurrentMode, isOpen, lists]);
+
+  // Build global library index on open if needed
+  useEffect(() => {
+    if (
+      isOpen
+      && isMatchesMode
+      && !isSearchLoading
+      && !globalSearchIndex
+      && !isBuildingGlobal
+      && !globalBuildFailedRef.current
+    ) {
+      setIsBuildingGlobal(true);
+      setTimeout(() => {
+        try {
+          const idx = buildSearchIndex(globalLists || { articles: [], recitals: [], annexes: [] });
+          setGlobalSearchIndex(idx);
+        } catch (e) {
+          console.error("Failed to build global search index", e);
+          globalBuildFailedRef.current = true;
+        } finally {
+          setIsBuildingGlobal(false);
+        }
+      }, 100);
+    }
+  }, [globalLists, globalSearchIndex, isBuildingGlobal, isMatchesMode, isOpen, isSearchLoading]);
+
+  // Run the current/matches search as the query settles and the index is ready.
+  useEffect(() => {
+    if (!isOpen || query.length < 2) return;
+    if (isCurrentMode && !isBuildingCurrent) {
+      runCurrentSearch(query);
+    }
+  }, [isBuildingCurrent, isCurrentMode, isOpen, query, runCurrentSearch]);
+
+  useEffect(() => {
+    if (!isOpen || query.length < 2) return;
+    if (isMatchesMode && !isBuildingGlobal && !isSearchLoading) {
+      runGlobalMatchSearch(query);
+    }
+  }, [globalEntryCount, isBuildingGlobal, isMatchesMode, isOpen, isSearchLoading, query, runGlobalMatchSearch]);
+
+  // Resolve a deferred search once the reason it was deferred clears.
+  useEffect(() => {
+    if (!isOpen) return;
+    const pending = pendingSearchRef.current;
+    if (!pending) return;
+
+    if (pending.mode === "current" && !isBuildingCurrent) {
+      pendingSearchRef.current = null;
+      runCurrentSearch(pending.query);
+      return;
+    }
+
+    if (pending.mode === "matches" && !isSearchLoading && !isBuildingGlobal) {
+      if (
+        typeof onSearchOpen === "function" && globalEntryCount === 0 && searchableLawCount > 0
+      ) {
+        return;
+      }
+      pendingSearchRef.current = null;
+      runGlobalMatchSearch(pending.query);
+    }
+  }, [
+    globalEntryCount,
+    hasSearchInitialized,
+    isBuildingCurrent,
+    isBuildingGlobal,
+    isOpen,
+    isSearchLoading,
+    onSearchOpen,
+    runCurrentSearch,
+    runGlobalMatchSearch,
+    searchableLawCount,
+    pendingSearchRef,
+  ]);
+
+  return {
+    currentSearchIndex,
+    globalSearchIndex,
+    isBuildingCurrent,
+    isBuildingGlobal,
+    runCurrentSearch,
+    runGlobalMatchSearch,
+  };
+}

--- a/src/hooks/search/useLocalSearchIndexes.js
+++ b/src/hooks/search/useLocalSearchIndexes.js
@@ -127,19 +127,31 @@ export function useLocalSearchIndexes({
   }, [globalLists, globalSearchIndex, isBuildingGlobal, isMatchesMode, isOpen, isSearchLoading]);
 
   // Run the current/matches search as the query settles and the index is ready.
+  // Run the current/matches search as the query settles and the index is
+  // ready. A sub-minimum query clears the results instead of returning
+  // early: nothing else resets them for these modes, so backspacing below
+  // two characters would otherwise leave stale rows on screen.
   useEffect(() => {
-    if (!isOpen || query.length < 2) return;
-    if (isCurrentMode && !isBuildingCurrent) {
+    if (!isOpen || !isCurrentMode) return;
+    if (query.length < 2) {
+      setResults([]);
+      return;
+    }
+    if (!isBuildingCurrent) {
       runCurrentSearch(query);
     }
-  }, [isBuildingCurrent, isCurrentMode, isOpen, query, runCurrentSearch]);
+  }, [isBuildingCurrent, isCurrentMode, isOpen, query, runCurrentSearch, setResults]);
 
   useEffect(() => {
-    if (!isOpen || query.length < 2) return;
-    if (isMatchesMode && !isBuildingGlobal && !isSearchLoading) {
+    if (!isOpen || !isMatchesMode) return;
+    if (query.length < 2) {
+      setResults([]);
+      return;
+    }
+    if (!isBuildingGlobal && !isSearchLoading) {
       runGlobalMatchSearch(query);
     }
-  }, [globalEntryCount, isBuildingGlobal, isMatchesMode, isOpen, isSearchLoading, query, runGlobalMatchSearch]);
+  }, [globalEntryCount, isBuildingGlobal, isMatchesMode, isOpen, isSearchLoading, query, runGlobalMatchSearch, setResults]);
 
   // Resolve a deferred search once the reason it was deferred clears.
   useEffect(() => {

--- a/src/hooks/search/useLocalSearchIndexes.js
+++ b/src/hooks/search/useLocalSearchIndexes.js
@@ -13,12 +13,8 @@ export function useLocalSearchIndexes({
   isOpen,
   searchMode,
   isSearchLoading,
-  onSearchOpen,
   globalEntryCount,
-  searchableLawCount,
-  hasSearchInitialized,
   setResults,
-  pendingSearchRef,
 }) {
   const [currentSearchIndex, setCurrentSearchIndex] = useState(null);
   const [globalSearchIndex, setGlobalSearchIndex] = useState(null);
@@ -40,15 +36,15 @@ export function useLocalSearchIndexes({
     setResults(nextResults);
   }, [currentSearchIndex, lists, setResults]);
 
-  const runGlobalMatchSearch = useCallback((nextQuery, sourceLists = globalLists, sourceIndex = globalSearchIndex) => {
+  const runGlobalMatchSearch = useCallback((nextQuery) => {
     if (nextQuery.length < 2) {
       setResults([]);
       return;
     }
 
-    const nextResults = sourceIndex
-      ? searchWithIndex(nextQuery, sourceIndex)
-      : searchContent(nextQuery, sourceLists || { articles: [], recitals: [], annexes: [] });
+    const nextResults = globalSearchIndex
+      ? searchWithIndex(nextQuery, globalSearchIndex)
+      : searchContent(nextQuery, globalLists || { articles: [], recitals: [], annexes: [] });
     setResults(nextResults);
   }, [globalLists, globalSearchIndex, setResults]);
 
@@ -152,41 +148,6 @@ export function useLocalSearchIndexes({
       runGlobalMatchSearch(query);
     }
   }, [globalEntryCount, isBuildingGlobal, isMatchesMode, isOpen, isSearchLoading, query, runGlobalMatchSearch, setResults]);
-
-  // Resolve a deferred search once the reason it was deferred clears.
-  useEffect(() => {
-    if (!isOpen) return;
-    const pending = pendingSearchRef.current;
-    if (!pending) return;
-
-    if (pending.mode === "current" && !isBuildingCurrent) {
-      pendingSearchRef.current = null;
-      runCurrentSearch(pending.query);
-      return;
-    }
-
-    if (pending.mode === "matches" && !isSearchLoading && !isBuildingGlobal) {
-      if (
-        typeof onSearchOpen === "function" && globalEntryCount === 0 && searchableLawCount > 0
-      ) {
-        return;
-      }
-      pendingSearchRef.current = null;
-      runGlobalMatchSearch(pending.query);
-    }
-  }, [
-    globalEntryCount,
-    hasSearchInitialized,
-    isBuildingCurrent,
-    isBuildingGlobal,
-    isOpen,
-    isSearchLoading,
-    onSearchOpen,
-    runCurrentSearch,
-    runGlobalMatchSearch,
-    searchableLawCount,
-    pendingSearchRef,
-  ]);
 
   return {
     currentSearchIndex,

--- a/src/hooks/search/useNetworkedSearch.js
+++ b/src/hooks/search/useNetworkedSearch.js
@@ -1,0 +1,148 @@
+import { useCallback, useRef, useState } from "react";
+
+const noop = () => {};
+
+// Owns the request lifecycle shared by the networked search modes in SearchBox
+// (laws, definitions, fulltext): a debounced entry point, abort of any
+// in-flight request when a newer one starts, a monotonic request-id guard so a
+// slow older response can never clobber newer results, and the loading/error/
+// lastQuery bookkeeping each mode needs. The caller supplies the fetch itself
+// via `run` and stays in charge of what results/errors mean for the UI.
+//
+//  - `run(query, { signal, filter })` performs the network call and returns the
+//    final result array. It may throw; AbortError and stale responses are
+//    filtered out here, so `onError` only sees genuinely current failures.
+//  - `onResults(results)` receives the mapped results (and `[]` on resets).
+//  - `onError(error)` is invoked for current failures; its side effects
+//    (clearing results, logging) belong here.
+//  - `onReset(query, extra)` fires on the short-query reset path, so a mode
+//    that tracks extra state (e.g. the definitions discovery filter) can clear
+//    it exactly when the reset happens.
+//  - `abortOnSchedule` reproduces modes that cancel an in-flight request the
+//    moment a new one is scheduled (fulltext), instead of only when it fires.
+//  - `invalidateOnReset` reproduces modes that also invalidate an in-flight
+//    request on a short-query reset (laws) rather than merely aborting it
+//    (definitions/fulltext, whose stale response the mode still applies).
+export function useNetworkedSearch({
+  minQueryLength = 2,
+  debounceMs = 300,
+  run,
+  onError = noop,
+  onResults = noop,
+  onReset = noop,
+  abortOnSchedule = false,
+  invalidateOnReset = true,
+}) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [lastQuery, setLastQuery] = useState("");
+  const abortRef = useRef(null);
+  const requestIdRef = useRef(0);
+  const debounceRef = useRef(null);
+
+  const execute = useCallback((query, extra = {}) => {
+    const trimmedQuery = String(query || "").trim();
+    const { filter } = extra;
+
+    if (trimmedQuery.length < minQueryLength && !filter) {
+      if (invalidateOnReset) {
+        requestIdRef.current += 1;
+      }
+      abortRef.current?.abort();
+      setError(null);
+      onResults([]);
+      setLastQuery("");
+      setIsLoading(false);
+      onReset(query, extra);
+      return;
+    }
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+    abortRef.current?.abort();
+    setError(null);
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setIsLoading(true);
+    setLastQuery(trimmedQuery);
+
+    Promise.resolve(run(trimmedQuery, { signal: controller.signal, filter }))
+      .then((results) => {
+        if (requestIdRef.current !== requestId || abortRef.current !== controller) return;
+        onResults(results);
+      })
+      .catch((error) => {
+        if (error?.name === "AbortError" || requestIdRef.current !== requestId || abortRef.current !== controller) return;
+        setError(error);
+        onError(error);
+      })
+      .finally(() => {
+        if (abortRef.current === controller) {
+          abortRef.current = null;
+          setIsLoading(false);
+        }
+      });
+  }, [invalidateOnReset, minQueryLength, onError, onReset, onResults, run]);
+
+  const schedule = useCallback((query, extra = {}) => {
+    if (abortOnSchedule) {
+      abortRef.current?.abort();
+      abortRef.current = null;
+    }
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    const { filter } = extra;
+    if (String(query || "").trim().length < minQueryLength && !filter) {
+      execute(query, extra);
+      return;
+    }
+    setIsLoading(true);
+    debounceRef.current = setTimeout(() => {
+      debounceRef.current = null;
+      execute(query, extra);
+    }, debounceMs);
+  }, [abortOnSchedule, debounceMs, execute, minQueryLength]);
+
+  const abort = useCallback(() => {
+    requestIdRef.current += 1;
+    abortRef.current?.abort();
+    abortRef.current = null;
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    setIsLoading(false);
+  }, []);
+
+  const reset = useCallback(() => {
+    requestIdRef.current += 1;
+    abortRef.current?.abort();
+    abortRef.current = null;
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
+    setLastQuery("");
+    setError(null);
+    setIsLoading(false);
+    onResults([]);
+  }, [onResults]);
+
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  return {
+    isLoading,
+    error,
+    lastQuery,
+    schedule,
+    execute,
+    abort,
+    reset,
+    clearError,
+  };
+}

--- a/src/hooks/useSearchNavigation.js
+++ b/src/hooks/useSearchNavigation.js
@@ -1,0 +1,88 @@
+import { useNavigate } from "react-router-dom";
+import { useI18n } from "../i18n/useI18n.js";
+import { buildImportedLawCandidate, getCanonicalLawRoute } from "../utils/lawRouting.js";
+import { inferOfficialReferenceFromCelex, saveLawMeta } from "../utils/library.js";
+
+export function useSearchNavigation(lawKey) {
+  const navigate = useNavigate();
+  const { locale, localizePath } = useI18n();
+
+  const navigateToSearchResult = async (item) => {
+    if (item.search_kind === "definition") {
+      const source = item.representativeSource || {};
+      if (!source.celex) return;
+      const sourceArticle = source.article ?? source.sourceArticle;
+      const targetLaw = buildImportedLawCandidate({
+        celex: source.celex,
+        title: source.title || source.law?.title,
+        officialReference: inferOfficialReferenceFromCelex(source.celex),
+      });
+      const route = getCanonicalLawRoute(
+        targetLaw,
+        sourceArticle ? "article" : null,
+        sourceArticle || null,
+        locale,
+      );
+      const separator = route.includes("?") ? "&" : "?";
+      const term = item.normalizedTerm || item.term;
+      const params = new URLSearchParams({ definition: term });
+      params.set("definitionSource", `${String(source.celex).toUpperCase()}:${String(sourceArticle ?? "")}${source.sourcePoint ? `:${String(source.sourcePoint)}` : ""}`);
+      navigate(`${route}${separator}${params.toString()}`);
+      return;
+    }
+
+    if (item.search_kind === "fulltext") {
+      const celex = String(item.celex || "").trim();
+      const unitType = String(item.unitType || "").trim().toLowerCase();
+      const number = item.number == null ? "" : String(item.number).trim();
+      if (!celex || !number || (unitType !== "article" && unitType !== "recital")) return;
+
+      const officialReference = inferOfficialReferenceFromCelex(celex);
+      const targetLaw = buildImportedLawCandidate({
+        celex,
+        title: item.title,
+        officialReference,
+      });
+      if (officialReference) {
+        saveLawMeta({
+          celex,
+          label: item.title,
+          officialReference,
+        }).catch(() => {});
+      }
+      navigate(getCanonicalLawRoute(targetLaw, unitType, number, locale));
+      return;
+    }
+
+    if (item.search_kind === "law") {
+      const officialReference = inferOfficialReferenceFromCelex(item.celex);
+      const targetLaw = buildImportedLawCandidate({
+        celex: item.celex,
+        title: item.title,
+        officialReference,
+      });
+
+      if (officialReference) {
+        // Best-effort bookkeeping: never let a stuck IndexedDB block navigation.
+        saveLawMeta({
+          celex: item.celex,
+          label: item.title,
+          officialReference,
+        }).catch(() => {});
+      }
+
+      navigate(getCanonicalLawRoute(targetLaw, null, null, locale));
+      return;
+    }
+
+    // Ensure ID is a string before encoding
+    const safeId = encodeURIComponent(String(item.id));
+    const targetLawSlug = item.law_slug || item.law_key || lawKey;
+
+    if (targetLawSlug) {
+      navigate(`${localizePath(`/${targetLawSlug}/${item.type}/${safeId}`, locale)}`);
+    }
+  };
+
+  return navigateToSearchResult;
+}

--- a/src/hooks/useSearchNavigation.test.jsx
+++ b/src/hooks/useSearchNavigation.test.jsx
@@ -1,0 +1,166 @@
+import React, { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockNavigate, mockSaveLawMeta } = vi.hoisted(() => ({
+  mockNavigate: vi.fn(),
+  mockSaveLawMeta: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("react-router-dom", () => ({
+  useNavigate: () => mockNavigate,
+  useLocation: () => ({ search: "?celex=32016R0679&definition=old" }),
+}));
+
+vi.mock("../i18n/useI18n.js", () => ({
+  useI18n: () => ({ locale: "en", localizePath: (path) => path }),
+}));
+
+vi.mock("../utils/library.js", async () => {
+  const actual = await vi.importActual("../utils/library.js");
+  return {
+    ...actual,
+    saveLawMeta: mockSaveLawMeta,
+  };
+});
+
+import { useSearchNavigation } from "./useSearchNavigation.js";
+
+describe("useSearchNavigation", () => {
+  let container;
+  let root;
+  let navigateToSearchResult;
+
+  function Probe({ lawKey }) {
+    navigateToSearchResult = useSearchNavigation(lawKey);
+    return null;
+  }
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    navigateToSearchResult = null;
+    mockNavigate.mockClear();
+    mockSaveLawMeta.mockClear();
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => {
+        root.unmount();
+      });
+    }
+    container?.remove();
+  });
+
+  it("routes a definition result through its representativeSource celex", async () => {
+    await act(async () => {
+      root.render(<Probe lawKey="gdpr" />);
+    });
+    await act(async () => {
+      await navigateToSearchResult({
+        search_kind: "definition",
+        normalizedTerm: "personal data",
+        representativeSource: {
+          celex: "32016R0679",
+          article: "5",
+          title: "GDPR",
+          sourcePoint: "2",
+        },
+      });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    const url = mockNavigate.mock.calls[0][0];
+    expect(url).toBe("/gdpr/article/5?definition=personal+data&definitionSource=32016R0679%3A5%3A2");
+  });
+
+  it("routes a law result via its canonical route", async () => {
+    await act(async () => {
+      root.render(<Probe lawKey="gdpr" />);
+    });
+    await act(async () => {
+      await navigateToSearchResult({
+        search_kind: "law",
+        celex: "32016R0679",
+        title: "General Data Protection Regulation",
+      });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith("/gdpr");
+    expect(mockSaveLawMeta).toHaveBeenCalledWith({
+      celex: "32016R0679",
+      label: "General Data Protection Regulation",
+      officialReference: { actType: "regulation", year: "2016", number: "679" },
+    });
+  });
+
+  it("navigates a match result to a clean route without stale query params", async () => {
+    await act(async () => {
+      root.render(<Probe lawKey="gdpr" />);
+    });
+    await act(async () => {
+      await navigateToSearchResult({
+        search_kind: "match",
+        id: "12",
+        type: "article",
+        title: "Some article",
+        law_slug: "dma",
+      });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith("/dma/article/12");
+    expect(String(mockNavigate.mock.calls[0][0])).not.toContain("?");
+  });
+
+  it("falls back to the current law slug for a match result without a law_slug", async () => {
+    await act(async () => {
+      root.render(<Probe lawKey="gdpr" />);
+    });
+    await act(async () => {
+      await navigateToSearchResult({
+        search_kind: "match",
+        id: "7",
+        type: "recital",
+        title: "A recital",
+      });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith("/gdpr/recital/7");
+  });
+
+  it("early-returns when a definition item lacks source.celex", async () => {
+    await act(async () => {
+      root.render(<Probe lawKey="gdpr" />);
+    });
+    await act(async () => {
+      await navigateToSearchResult({
+        search_kind: "definition",
+        normalizedTerm: "data",
+        representativeSource: { article: "5" },
+      });
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate when a fulltext item has no resolvable unit", async () => {
+    await act(async () => {
+      root.render(<Probe lawKey="gdpr" />);
+    });
+    await act(async () => {
+      await navigateToSearchResult({
+        search_kind: "fulltext",
+        celex: "32016R0679",
+        number: "",
+        unitType: "article",
+      });
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Executes the TopBar.jsx split from the frontend review. **1,806 → 773 lines**, four commits, one per stage.

## Structure
| Before | After |
|---|---|
| TopBar.jsx (3 components, 5 search modes inline) | `TopBar.jsx` — chrome + thin `SearchBox` orchestrator (773) |
| 3× duplicated debounce/abort/request-id pipelines | `hooks/search/useNetworkedSearch.js` (147) — one factory; mode quirks preserved as options (`abortOnSchedule` for fulltext, `invalidateOnReset` for laws) |
| setTimeout index builders in SearchBox | `hooks/search/useLocalSearchIndexes.js` (187) |
| ~75-line route builder inside chrome | `hooks/useSearchNavigation.js` |
| ToolsMenu module-private | `components/ToolsMenu.jsx` (143), exported |
| Inline portal dialog + 4 result shapes | `search/SearchModal.jsx` (510) + `search/results/*` |

## Behavior fixes folded in (each was a review finding)
- Cross-law navigation no longer copies stale query params (?definition=/?celex=) onto the target route.
- Index-builder failure no longer re-arms a ~100ms retry loop while the dialog is open; retries only when inputs change.
- current/matches modes execute once per keystroke instead of twice (handler + effect both fired).

## Tests
- Four SearchBox.*.test.jsx safety-net files pass UNMODIFIED throughout all stages.
- New: `ToolsMenu.test.jsx` (6) + `TopBar.test.jsx` smoke (2) + `useSearchNavigation.test.jsx` (6, incl. the stale-param regression).
- Full suite: **49 files / 569 tests green**; `npm run lint` clean. Verified independently per stage.

## Notes / follow-ups
- `Landing.jsx` carries a parallel copy of the result-routing logic — candidate for reuse of `useSearchNavigation` in a later PR.
- Swipe vertical-drift and arrow-key modifier gaps in `useLawViewerInteractions` remain open by design (pinned by #190's characterization tests).

🤖 Implemented via opencode CLI (deepseek-v4-flash) in three staged delegations; every stage diff-reviewed and re-verified by ox-alpha.