### PR TITLE
Take on PR #197's follow-ups: reuse useSearchNavigation on Landing; fix viewer swipe/modifier bugs

### DIFF
--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -11,30 +11,9 @@ import { lawLangFromUiLocale, uiLocaleFromLawLang } from "../i18n/localeMeta.js"
 import { resetWholeApp } from "../utils/resetApp.js";
 import { useLandingLibrary } from "../hooks/useLandingLibrary.js";
 import { useLandingSearchIndex } from "../hooks/useLandingSearchIndex.js";
-import { buildImportedLawCandidate, getCanonicalLawRoute } from "../utils/lawRouting.js";
-import { saveLawMeta } from "../utils/library.js";
+import { useSearchNavigation } from "../hooks/useSearchNavigation.js";
 import { fetchDatasetMeta } from "../utils/formexApi.js";
 import { formatMetaDate } from "../utils/formatMetaDate.js";
-
-function inferOfficialReferenceFromCelex(celex) {
-  const match = String(celex || "").match(/^3(\d{4})([RLD])0*(\d{1,4})(?:\(\d+\))?$/);
-  if (!match) return null;
-
-  const actTypeMap = {
-    R: "regulation",
-    L: "directive",
-    D: "decision",
-  };
-
-  const actType = actTypeMap[match[2]] || null;
-  if (!actType) return null;
-
-  return {
-    actType,
-    year: match[1],
-    number: String(Number.parseInt(match[3], 10)),
-  };
-}
 
 export function Landing({ forcedLocale = null }) {
   const navigate = useNavigate();
@@ -86,76 +65,7 @@ export function Landing({ forcedLocale = null }) {
     navigate(localizePath(law.route, locale));
   }, [locale, localizePath, markLawOpened, navigate]);
 
-  const handleSearchNavigate = useCallback(async (item) => {
-    if (item.search_kind === "definition") {
-      const source = item.representativeSource || {};
-      if (!source.celex) return;
-      const sourceArticle = source.article ?? source.sourceArticle;
-      const targetLaw = buildImportedLawCandidate({
-        celex: source.celex,
-        title: source.title || source.law?.title,
-        officialReference: inferOfficialReferenceFromCelex(source.celex),
-      });
-      const route = getCanonicalLawRoute(targetLaw, sourceArticle ? "article" : null, sourceArticle || null, locale);
-      const separator = route.includes("?") ? "&" : "?";
-      const term = item.normalizedTerm || item.term;
-      const params = new URLSearchParams({ definition: term });
-      params.set("definitionSource", `${String(source.celex).toUpperCase()}:${String(sourceArticle ?? "")}${source.sourcePoint ? `:${String(source.sourcePoint)}` : ""}`);
-      navigate(`${route}${separator}${params.toString()}`);
-      return;
-    }
-
-    if (item.search_kind === "fulltext") {
-      const celex = String(item.celex || "").trim();
-      const unitType = String(item.unitType || "").trim().toLowerCase();
-      const number = item.number == null ? "" : String(item.number).trim();
-      if (!celex || !number || (unitType !== "article" && unitType !== "recital")) return;
-
-      const officialReference = inferOfficialReferenceFromCelex(celex);
-      const targetLaw = buildImportedLawCandidate({
-        celex,
-        title: item.title,
-        officialReference,
-      });
-      if (officialReference) {
-        saveLawMeta({
-          celex,
-          label: item.title,
-          officialReference,
-        }).catch(() => {});
-      }
-      navigate(getCanonicalLawRoute(targetLaw, unitType, number, locale));
-      return;
-    }
-
-    if (item.search_kind === "law") {
-      const officialReference = inferOfficialReferenceFromCelex(item.celex);
-      const targetLaw = buildImportedLawCandidate({
-        celex: item.celex,
-        title: item.title,
-        officialReference,
-      });
-
-      if (officialReference) {
-        // Best-effort bookkeeping: never let a stuck IndexedDB block navigation.
-        saveLawMeta({
-          celex: item.celex,
-          label: item.title,
-          officialReference,
-          topics: item.topics,
-        }).catch(() => {});
-      }
-
-      navigate(getCanonicalLawRoute(targetLaw, null, null, locale));
-      return;
-    }
-
-    const safeId = encodeURIComponent(String(item.id));
-    const targetLawSlug = item.law_slug || item.law_key;
-    if (targetLawSlug) {
-      navigate(localizePath(`/${targetLawSlug}/${item.type}/${safeId}`, locale));
-    }
-  }, [locale, localizePath, navigate]);
+  const handleSearchNavigate = useSearchNavigation("");
 
   return (
     <div className="min-h-screen bg-paper dark:bg-paper-dark transition-colors duration-500">

--- a/src/hooks/law-viewer/useLawViewerInteractions.js
+++ b/src/hooks/law-viewer/useLawViewerInteractions.js
@@ -47,16 +47,16 @@ export function useLawViewerInteractions({
       const { currentList, index } = getCurrentEntryIndex(data, selected);
       if (!currentList.length) return;
 
-      if (event.key === "ArrowLeft" && index > 0) {
-        onPrevNext(selected.kind, index - 1);
-      }
-      if (event.key === "ArrowRight" && index >= 0 && index < currentList.length - 1) {
-        onPrevNext(selected.kind, index + 1);
-      }
-
-      // Vim-style j / k as previous / next, without modifiers (mirrors the
-      // reading-footer hint). Guard against combos so browser shortcuts pass.
+      // Guard against combos so browser shortcuts pass (mirrors the
+      // reading-footer hint). Covers arrows and vim-style j/k alike, so e.g.
+      // Cmd+ArrowLeft (history-back) never flips articles.
       if (!event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey) {
+        if (event.key === "ArrowLeft" && index > 0) {
+          onPrevNext(selected.kind, index - 1);
+        }
+        if (event.key === "ArrowRight" && index >= 0 && index < currentList.length - 1) {
+          onPrevNext(selected.kind, index + 1);
+        }
         if (event.key === "k" && index > 0) {
           onPrevNext(selected.kind, index - 1);
         }
@@ -232,19 +232,27 @@ export function useLawViewerInteractions({
 
   const onTouchStart = useCallback((event) => {
     touchEndRef.current = null;
-    touchStartRef.current = event.targetTouches[0].clientX;
+    const touch = event.targetTouches[0];
+    touchStartRef.current = { x: touch.clientX, y: touch.clientY || 0 };
   }, []);
 
   const onTouchMove = useCallback((event) => {
-    touchEndRef.current = event.targetTouches[0].clientX;
+    const touch = event.targetTouches[0];
+    touchEndRef.current = { x: touch.clientX, y: touch.clientY || 0 };
   }, []);
 
   const onTouchEnd = useCallback(() => {
     if (!touchStartRef.current || !touchEndRef.current) return;
 
-    const distance = touchStartRef.current - touchEndRef.current;
-    const isLeftSwipe = distance > 50;
-    const isRightSwipe = distance < -50;
+    const start = touchStartRef.current;
+    const end = touchEndRef.current;
+    const dx = start.x - end.x;
+    const dy = start.y - end.y;
+    // Only treat a gesture as a horizontal swipe when horizontal movement
+    // dominates vertical drift, so scrolling down a long article with a slight
+    // sideways drift no longer flips articles.
+    const isLeftSwipe = dx > 50 && Math.abs(dx) > Math.abs(dy);
+    const isRightSwipe = dx < -50 && Math.abs(dx) > Math.abs(dy);
     const { currentList, index } = getCurrentEntryIndex(data, selected);
 
     if (isLeftSwipe && index >= 0 && index < currentList.length - 1) {

--- a/src/hooks/law-viewer/useLawViewerInteractions.test.jsx
+++ b/src/hooks/law-viewer/useLawViewerInteractions.test.jsx
@@ -115,7 +115,7 @@ describe("useLawViewerInteractions", () => {
       expect(onPrevNext).toHaveBeenLastCalledWith("article", 0);
     });
 
-    it("ignores j/k when a modifier key is held", async () => {
+    it("ignores j/k and arrow keys when a modifier key is held", async () => {
       await render();
 
       for (const init of [
@@ -127,6 +127,14 @@ describe("useLawViewerInteractions", () => {
         { key: "k", ctrlKey: true },
         { key: "k", altKey: true },
         { key: "k", shiftKey: true },
+        { key: "ArrowLeft", metaKey: true },
+        { key: "ArrowLeft", ctrlKey: true },
+        { key: "ArrowLeft", altKey: true },
+        { key: "ArrowLeft", shiftKey: true },
+        { key: "ArrowRight", metaKey: true },
+        { key: "ArrowRight", ctrlKey: true },
+        { key: "ArrowRight", altKey: true },
+        { key: "ArrowRight", shiftKey: true },
       ]) {
         pressKey(init);
       }
@@ -320,12 +328,26 @@ describe("useLawViewerInteractions", () => {
       expect(onPrevNext).not.toHaveBeenCalled();
     });
 
-    it("ignores vertical drift when deciding the swipe", async () => {
+    it("does not navigate when vertical drift dominates the gesture", async () => {
       await render({ selected: { kind: "article", id: "2" } });
 
       act(() => {
         latestValue.onTouchStart({ targetTouches: [{ clientX: 300, clientY: 100 }] });
         latestValue.onTouchMove({ targetTouches: [{ clientX: 200, clientY: 900 }] });
+      });
+      act(() => {
+        latestValue.onTouchEnd();
+      });
+
+      expect(onPrevNext).not.toHaveBeenCalled();
+    });
+
+    it("navigates when horizontal movement dominates a small vertical drift", async () => {
+      await render({ selected: { kind: "article", id: "2" } });
+
+      act(() => {
+        latestValue.onTouchStart({ targetTouches: [{ clientX: 300, clientY: 100 }] });
+        latestValue.onTouchMove({ targetTouches: [{ clientX: 200, clientY: 130 }] });
       });
       act(() => {
         latestValue.onTouchEnd();

--- a/src/hooks/useSearchNavigation.js
+++ b/src/hooks/useSearchNavigation.js
@@ -64,10 +64,13 @@ export function useSearchNavigation(lawKey) {
 
       if (officialReference) {
         // Best-effort bookkeeping: never let a stuck IndexedDB block navigation.
+        // saveLawMeta only persists topics when non-empty, so an item without
+        // them never clobbers previously stored EuroVoc topics.
         saveLawMeta({
           celex: item.celex,
           label: item.title,
           officialReference,
+          topics: item.topics,
         }).catch(() => {});
       }
 


### PR DESCRIPTION
Stacks on #197 (`refactor/topbar-split`) — takes on both follow-ups its description left open.

## 1. Landing reuses `useSearchNavigation`
`Landing.jsx` carried a ~75-line parallel copy of the result-routing logic (definition/fulltext/law/match branches). It only differed from the hook by persisting EuroVoc `topics` on law results — the hook now forwards them too, so both surfaces behave identically. Removed the duplicate, the local `inferOfficialReferenceFromCelex`, and the now-unused imports. **`Landing.jsx`: 165 → 73 lines.**

## 2. Viewer interaction bugs pinned by #190's characterization tests
Flipped the two assertions #190 deliberately pinned as known bugs:

- **Vertical drift flipping articles**: swipes now require horizontal movement to dominate vertical drift (track both touch axes instead of `clientX` only), so scrolling down a long article with slight sideways drift no longer flips articles.
- **Missing arrow-key modifier guard**: the modifier guard that already protected vim-style j/k now covers `ArrowLeft`/`ArrowRight` too, so e.g. `Cmd+ArrowLeft` (history-back) never flips articles.

## Tests
- `useLawViewerInteractions.test.jsx`: extended the modifier test to all four keys, flipped the vertical-drift test to assert no navigation, added a horizontal-dominance positive case.
- Full suite: **49 files / 570 tests green**; `npm run lint` clean; `vite build` passes.
