### PR TITLE
Route Landing search results through useSearchNavigation

### DIFF
--- a/src/components/Landing.jsx
+++ b/src/components/Landing.jsx
@@ -11,30 +11,9 @@ import { lawLangFromUiLocale, uiLocaleFromLawLang } from "../i18n/localeMeta.js"
 import { resetWholeApp } from "../utils/resetApp.js";
 import { useLandingLibrary } from "../hooks/useLandingLibrary.js";
 import { useLandingSearchIndex } from "../hooks/useLandingSearchIndex.js";
-import { buildImportedLawCandidate, getCanonicalLawRoute } from "../utils/lawRouting.js";
-import { saveLawMeta } from "../utils/library.js";
+import { useSearchNavigation } from "../hooks/useSearchNavigation.js";
 import { fetchDatasetMeta } from "../utils/formexApi.js";
 import { formatMetaDate } from "../utils/formatMetaDate.js";
-
-function inferOfficialReferenceFromCelex(celex) {
-  const match = String(celex || "").match(/^3(\d{4})([RLD])0*(\d{1,4})(?:\(\d+\))?$/);
-  if (!match) return null;
-
-  const actTypeMap = {
-    R: "regulation",
-    L: "directive",
-    D: "decision",
-  };
-
-  const actType = actTypeMap[match[2]] || null;
-  if (!actType) return null;
-
-  return {
-    actType,
-    year: match[1],
-    number: String(Number.parseInt(match[3], 10)),
-  };
-}
 
 export function Landing({ forcedLocale = null }) {
   const navigate = useNavigate();
@@ -86,76 +65,7 @@ export function Landing({ forcedLocale = null }) {
     navigate(localizePath(law.route, locale));
   }, [locale, localizePath, markLawOpened, navigate]);
 
-  const handleSearchNavigate = useCallback(async (item) => {
-    if (item.search_kind === "definition") {
-      const source = item.representativeSource || {};
-      if (!source.celex) return;
-      const sourceArticle = source.article ?? source.sourceArticle;
-      const targetLaw = buildImportedLawCandidate({
-        celex: source.celex,
-        title: source.title || source.law?.title,
-        officialReference: inferOfficialReferenceFromCelex(source.celex),
-      });
-      const route = getCanonicalLawRoute(targetLaw, sourceArticle ? "article" : null, sourceArticle || null, locale);
-      const separator = route.includes("?") ? "&" : "?";
-      const term = item.normalizedTerm || item.term;
-      const params = new URLSearchParams({ definition: term });
-      params.set("definitionSource", `${String(source.celex).toUpperCase()}:${String(sourceArticle ?? "")}${source.sourcePoint ? `:${String(source.sourcePoint)}` : ""}`);
-      navigate(`${route}${separator}${params.toString()}`);
-      return;
-    }
-
-    if (item.search_kind === "fulltext") {
-      const celex = String(item.celex || "").trim();
-      const unitType = String(item.unitType || "").trim().toLowerCase();
-      const number = item.number == null ? "" : String(item.number).trim();
-      if (!celex || !number || (unitType !== "article" && unitType !== "recital")) return;
-
-      const officialReference = inferOfficialReferenceFromCelex(celex);
-      const targetLaw = buildImportedLawCandidate({
-        celex,
-        title: item.title,
-        officialReference,
-      });
-      if (officialReference) {
-        saveLawMeta({
-          celex,
-          label: item.title,
-          officialReference,
-        }).catch(() => {});
-      }
-      navigate(getCanonicalLawRoute(targetLaw, unitType, number, locale));
-      return;
-    }
-
-    if (item.search_kind === "law") {
-      const officialReference = inferOfficialReferenceFromCelex(item.celex);
-      const targetLaw = buildImportedLawCandidate({
-        celex: item.celex,
-        title: item.title,
-        officialReference,
-      });
-
-      if (officialReference) {
-        // Best-effort bookkeeping: never let a stuck IndexedDB block navigation.
-        saveLawMeta({
-          celex: item.celex,
-          label: item.title,
-          officialReference,
-          topics: item.topics,
-        }).catch(() => {});
-      }
-
-      navigate(getCanonicalLawRoute(targetLaw, null, null, locale));
-      return;
-    }
-
-    const safeId = encodeURIComponent(String(item.id));
-    const targetLawSlug = item.law_slug || item.law_key;
-    if (targetLawSlug) {
-      navigate(localizePath(`/${targetLawSlug}/${item.type}/${safeId}`, locale));
-    }
-  }, [locale, localizePath, navigate]);
+  const handleSearchNavigate = useSearchNavigation(null);
 
   return (
     <div className="min-h-screen bg-paper dark:bg-paper-dark transition-colors duration-500">

--- a/src/hooks/useSearchNavigation.js
+++ b/src/hooks/useSearchNavigation.js
@@ -68,6 +68,7 @@ export function useSearchNavigation(lawKey) {
           celex: item.celex,
           label: item.title,
           officialReference,
+          topics: item.topics,
         }).catch(() => {});
       }
 

--- a/src/hooks/useSearchNavigation.test.jsx
+++ b/src/hooks/useSearchNavigation.test.jsx
@@ -98,6 +98,40 @@ describe("useSearchNavigation", () => {
     });
   });
 
+  it("persists EuroVoc topics when a law result carries them", async () => {
+    await act(async () => {
+      root.render(<Probe lawKey="gdpr" />);
+    });
+    await act(async () => {
+      await navigateToSearchResult({
+        search_kind: "law",
+        celex: "32016R0679",
+        title: "General Data Protection Regulation",
+        topics: ["Data protection", "Privacy"],
+      });
+    });
+
+    expect(mockSaveLawMeta).toHaveBeenCalledWith(
+      expect.objectContaining({ topics: ["Data protection", "Privacy"] }),
+    );
+  });
+
+  it("does not navigate a match result when neither the item nor the current law resolves a slug", async () => {
+    await act(async () => {
+      root.render(<Probe lawKey={null} />);
+    });
+    await act(async () => {
+      await navigateToSearchResult({
+        search_kind: "match",
+        id: "7",
+        type: "recital",
+        title: "A recital",
+      });
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
   it("navigates a match result to a clean route without stale query params", async () => {
     await act(async () => {
       root.render(<Probe lawKey="gdpr" />);


### PR DESCRIPTION
Stacked on #197 (base: `refactor/topbar-split` — merge that first).

## What

`Landing.jsx` still carried its own pre-refactor copy of the TopBar search-result handler (~70 lines), and the copies had diverged:

- **Landing saved EuroVoc topics** on law-result navigation (`topics: item.topics` → `saveLawMeta`); TopBar/the shared hook didn't.
- Landing's copy predated the canonical-route handling in `useSearchNavigation`.

## Change

- Delete Landing's private handler and its local `inferOfficialReferenceFromCelex` duplicate; call `useSearchNavigation(null)` instead — same hook TopBar uses, with no current-law fallback for match results.
- The shared hook now forwards `item.topics` to `saveLawMeta` on law results. This is additive bookkeeping only: `library.js` persists topics when present and never wipes stored ones, so opening a law from reader-side search now enriches its library card exactly like opening it from the landing page.

## Tests

- New: topics are persisted when a law result carries them.
- New: a match result with neither an item slug nor a current law (Landing's case) does not navigate.
- Existing suite unchanged and green; lint clean.
