### PR TITLE
Fix first-load page refresh after the migration reset

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,6 @@ import { createBrowserRouter, RouterProvider, Outlet, ScrollRestoration, isRoute
 import { Landing } from "./components/Landing.jsx";
 import { LawViewer } from "./components/LawViewer.jsx";
 import { ThemeProvider } from "./components/ThemeProvider.jsx";
-import { runOneTimeMigrationReset } from "./utils/resetApp.js";
 import { runOneTimeTopicsBackfill } from "./utils/topicsBackfill.js";
 import { I18nProvider } from "./i18n/I18nProvider.jsx";
 import { useI18n } from "./i18n/useI18n.js";
@@ -11,15 +10,9 @@ import { getLocaleHomePath, isSupportedUiLocale, normalizeUiLocale, SUPPORTED_UI
 
 function Layout() {
   useEffect(() => {
-    runOneTimeMigrationReset().then((didReset) => {
-      if (didReset) {
-        window.location.replace(`${window.location.pathname}${window.location.search}${window.location.hash}`);
-        return;
-      }
-      // No reset (which would reload anyway) — backfill EuroVoc topics onto
-      // library laws opened before topics were persisted. Best-effort.
-      runOneTimeTopicsBackfill().catch(() => {});
-    });
+    // The one-time migration reset now runs in main.jsx before the tree
+    // mounts, so it finishes before first paint and no reload is needed.
+    runOneTimeTopicsBackfill().catch(() => {});
   }, []);
 
   return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,9 +3,15 @@ import { createRoot } from 'react-dom/client'
 import './fonts.css'
 import './index.css'
 import App from './App.jsx'
+import { runOneTimeMigrationReset } from './utils/resetApp.js'
 
-createRoot(document.getElementById('root')).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-)
+async function bootstrap() {
+  await runOneTimeMigrationReset();
+  createRoot(document.getElementById('root')).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}
+
+bootstrap();


### PR DESCRIPTION
## What

The app hard-reloaded ~1s after the first hard load of any page (landing, law pages like `/gdpr`), which looked like a routing bug.

## Root cause

Not routing. The one-time migration reset ran inside `Layout`'s `useEffect` (wraps every route). On a fresh hard load in a browser without the `legalviz-migration-version` marker, `runOneTimeMigrationReset()` wiped local storage / IndexedDB / caches / service workers (~1s), then did a full `window.location.replace(...)` reload.

## Fix

Run the reset in `main.jsx` before the React tree mounts (`bootstrap()` awaits `runOneTimeMigrationReset()`), so it completes before first paint and no reload is needed.

- `src/main.jsx` — await migration reset before `createRoot(...).render(...)`
- `src/App.jsx` — `Layout` no longer runs the reset or reloads; keeps the non-destructive topics backfill

## Notes

- Normal loads are unaffected: when the marker is present the reset is an immediate no-op.
- On a reset-needed load the user now gets a brief blank instead of a flash + reload.
- The migration marker constant is unchanged, so returning users don't re-trigger it.
- `resetWholeApp()` (manual full reset) still reloads by design.

## Tests

- `eslint` clean on changed files
- `vitest` `resetApp` + `topicsBackfill` suites pass (6 tests)