### PR TITLE
Fix reader arrow keys when the definition comparison is open

### DIFF
--- a/backend/search/citation-graph-build.test.js
+++ b/backend/search/citation-graph-build.test.js
@@ -381,9 +381,15 @@ test("batched builder's default pool parses a real corpus through persistent wor
   assert.equal(artifact.stats.parsedLaws, 5);
   assert.equal(artifact.stats.parseFailures, 0);
   assert.ok(Number.isInteger(artifact.parserVersion), "real parser stamps its version on every shard");
-  // Three batches of two/two/one, each reported with the same wording as before.
-  assert.deepEqual(messages.map((message) => message.replace(/ laws.*/, "")), [
-    "[citation-graph] 2/5", "[citation-graph] 4/5", "[citation-graph] 5/5",
-  ]);
-  assert.match(messages[2], /last=32010L0005/);
+  // Three batches of two/two/one, pulled by two workers concurrently, so the
+  // cumulative "N/5" counts are logged in completion order, not batch order
+  // (e.g. 2/5 → 3/5 → 5/5 when the single-file batch lands between the two
+  // two-file ones). Assert the stable invariants: one message per batch, the
+  // completed-in-isolated-workers wording, strictly increasing counts that
+  // finish at 5/5, and each batch naming its trailing law.
+  assert.equal(messages.length, 3);
+  assert.ok(messages.every((message) => /^\[citation-graph\] \d+\/5 laws completed in isolated workers; last=32010L000[1-5]$/.test(message)));
+  const counts = messages.map((message) => Number(message.match(/^\[citation-graph\] (\d+)\/5/)[1]));
+  assert.deepEqual(counts, [...counts].sort((a, b) => a - b), "cumulative counts are reported in increasing order");
+  assert.equal(counts[counts.length - 1], 5, "progress finishes at 5/5");
 });

--- a/src/components/law-viewer/DefinitionComparisonSheet.jsx
+++ b/src/components/law-viewer/DefinitionComparisonSheet.jsx
@@ -1,13 +1,35 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { DefinitionComparisonPanel } from "./DefinitionComparisonPanel.jsx";
+
+// The comparison panel lives in the sidebar (LawViewerContextRail) on wide
+// screens; below the xl breakpoint it becomes this bottom sheet instead. Keep
+// the sheet out of the DOM entirely on wide screens — a display:none dialog
+// with aria-modal="true" would still make the reader defer its arrow/j-k keys
+// to it (querySelector matches hidden elements).
+const SHEET_MEDIA_QUERY = "(max-width: 1279.98px)";
+
+function matchesSheetQuery() {
+  return typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia(SHEET_MEDIA_QUERY).matches
+    : false;
+}
 
 export function DefinitionComparisonSheet(props) {
   const sheetRef = useRef(null);
   const { term, onClose } = props;
+  const [isSheet, setIsSheet] = useState(matchesSheetQuery);
 
   useEffect(() => {
-    if (!term) return undefined;
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return undefined;
+    const query = window.matchMedia(SHEET_MEDIA_QUERY);
+    const handleChange = (event) => setIsSheet(event.matches);
+    query.addEventListener("change", handleChange);
+    return () => query.removeEventListener("change", handleChange);
+  }, []);
+
+  useEffect(() => {
+    if (!term || !isSheet) return undefined;
     const previousFocus = document.activeElement;
     const handleKeyDown = (event) => {
       if (event.key === "Escape") {
@@ -39,13 +61,13 @@ export function DefinitionComparisonSheet(props) {
       document.removeEventListener("keydown", handleKeyDown);
       if (previousFocus instanceof HTMLElement && previousFocus.isConnected) previousFocus.focus();
     };
-  }, [onClose, term]);
+  }, [onClose, term, isSheet]);
 
-  if (!term || typeof document === "undefined") return null;
+  if (!term || !isSheet || typeof document === "undefined") return null;
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[90] flex items-end bg-black/25 xl:hidden"
+      className="fixed inset-0 z-[90] flex items-end bg-black/25"
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose?.();
       }}

--- a/src/components/law-viewer/DefinitionComparisonSheet.test.jsx
+++ b/src/components/law-viewer/DefinitionComparisonSheet.test.jsx
@@ -1,0 +1,90 @@
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DefinitionComparisonSheet } from "./DefinitionComparisonSheet.jsx";
+
+let container;
+let root;
+let matchMediaListeners;
+
+function t(key) {
+  return key;
+}
+
+// jsdom has no matchMedia; fake it so the component can pick sheet vs nothing.
+function mockMatchMedia(matches) {
+  matchMediaListeners = [];
+  window.matchMedia = vi.fn().mockImplementation((query) => ({
+    matches,
+    media: query,
+    addEventListener: (_type, listener) => matchMediaListeners.push(listener),
+    removeEventListener: (_type, listener) => {
+      matchMediaListeners = matchMediaListeners.filter((entry) => entry !== listener);
+    },
+  }));
+}
+
+function fireMatchMediaChange(matches) {
+  act(() => {
+    for (const listener of matchMediaListeners) listener({ matches });
+  });
+}
+
+function renderSheet(props = {}) {
+  act(() => {
+    root.render(
+      <DefinitionComparisonSheet
+        term="systemic risk"
+        onClose={() => {}}
+        t={t}
+        {...props}
+      />
+    );
+  });
+}
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("DefinitionComparisonSheet below the xl breakpoint", () => {
+  beforeEach(() => mockMatchMedia(true));
+
+  it("renders the bottom sheet with an aria-modal dialog", () => {
+    renderSheet();
+
+    const dialog = document.querySelector('[role="dialog"][aria-modal="true"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog.textContent).toContain("systemic risk");
+  });
+});
+
+describe("DefinitionComparisonSheet at the xl breakpoint and wider", () => {
+  beforeEach(() => mockMatchMedia(false));
+
+  it("renders nothing, so the reader's modal-dialog check stays clear", () => {
+    renderSheet();
+
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+
+  it("does not leak an aria-modal dialog into the DOM when the viewport widens", () => {
+    mockMatchMedia(true);
+    renderSheet();
+    expect(document.querySelector('[role="dialog"][aria-modal="true"]')).not.toBeNull();
+
+    fireMatchMediaChange(false);
+
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+  });
+});

--- a/src/components/law-viewer/LawViewerQuickNavigation.jsx
+++ b/src/components/law-viewer/LawViewerQuickNavigation.jsx
@@ -3,6 +3,7 @@ import { motion, useAnimationControls, useReducedMotion } from "framer-motion";
 import { CornerDownLeft } from "lucide-react";
 import { NavigationControls } from "../NavigationControls.jsx";
 import { parseJumpQuery } from "../../utils/law-viewer/jumpParser.js";
+import { isModalDialogOpen } from "../../utils/law-viewer/modalDialog.js";
 
 const MotionDiv = motion.div;
 
@@ -13,7 +14,7 @@ function isGlobalShortcutContext(event) {
   const target = event.target;
   const tag = target?.tagName;
   if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable) return false;
-  if (typeof document !== "undefined" && document.querySelector('[role="dialog"][aria-modal="true"]')) return false;
+  if (isModalDialogOpen()) return false;
   return true;
 }
 

--- a/src/hooks/law-viewer/useLawViewerInteractions.js
+++ b/src/hooks/law-viewer/useLawViewerInteractions.js
@@ -5,6 +5,7 @@ import { parseOfficialReference } from "../../utils/officialReferences.js";
 import { buildImportedLawCandidate, getCanonicalLawRoute } from "../../utils/lawRouting.js";
 import { saveLawMeta } from "../../utils/library.js";
 import { FormexApiError, resolveOfficialReference } from "../../utils/formexApi.js";
+import { isModalDialogOpen } from "../../utils/law-viewer/modalDialog.js";
 
 function getCurrentEntryIndex(data, selected) {
   let currentList = [];
@@ -42,8 +43,9 @@ export function useLawViewerInteractions({
       if (event.target.tagName === "INPUT" || event.target.tagName === "TEXTAREA") return;
       // Don't hijack navigation keys while a modal dialog is open on top of the
       // reader (mirrors isGlobalShortcutContext in LawViewerQuickNavigation).
-      // Non-modal dialogs such as the definition tooltip don't block reader keys.
-      if (typeof document !== "undefined" && document.querySelector('[role="dialog"][aria-modal="true"]')) return;
+      // Non-modal dialogs such as the definition tooltip don't block reader
+      // keys, and neither does a modal that is hidden for the current breakpoint.
+      if (isModalDialogOpen()) return;
 
       const { currentList, index } = getCurrentEntryIndex(data, selected);
       if (!currentList.length) return;

--- a/src/hooks/law-viewer/useLawViewerInteractions.test.jsx
+++ b/src/hooks/law-viewer/useLawViewerInteractions.test.jsx
@@ -229,6 +229,23 @@ describe("useLawViewerInteractions", () => {
       dialog.remove();
     });
 
+    it("keeps navigation keys active when a modal dialog is hidden for the current breakpoint", async () => {
+      await render();
+      const dialog = document.createElement("div");
+      dialog.setAttribute("role", "dialog");
+      dialog.setAttribute("aria-modal", "true");
+      dialog.style.display = "none";
+      document.body.appendChild(dialog);
+
+      pressKey({ key: "ArrowRight" });
+      expect(onPrevNext).toHaveBeenLastCalledWith("article", 2);
+
+      pressKey({ key: "ArrowLeft" });
+      expect(onPrevNext).toHaveBeenLastCalledWith("article", 0);
+
+      dialog.remove();
+    });
+
     it("navigates recitals with the same j/k and arrow keys", async () => {
       await render({ selected: { kind: "recital", id: "10" } });
 

--- a/src/utils/law-viewer/modalDialog.js
+++ b/src/utils/law-viewer/modalDialog.js
@@ -1,0 +1,18 @@
+// A modal dialog counts as "open on top of the reader" only when it is
+// actually on screen. querySelector matches display:none elements, so a dialog
+// hidden for the current breakpoint (e.g. the definition-comparison bottom
+// sheet on wide screens) would otherwise keep the reader's arrow/j-k keys
+// suppressed for no reason.
+export function isModalDialogOpen() {
+  if (typeof document === "undefined") return false;
+  const dialog = document.querySelector('[role="dialog"][aria-modal="true"]');
+  if (!dialog) return false;
+  // In a real browser a hidden dialog has no client rects; jsdom does no
+  // layout (getClientRects is always empty), so fall back to the dialog's own
+  // computed display/visibility there.
+  if (dialog.getClientRects().length === 0) {
+    const style = typeof window !== "undefined" ? window.getComputedStyle(dialog) : null;
+    if (style && (style.display === "none" || style.visibility === "hidden")) return false;
+  }
+  return true;
+}

--- a/src/utils/law-viewer/modalDialog.test.js
+++ b/src/utils/law-viewer/modalDialog.test.js
@@ -1,0 +1,37 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { isModalDialogOpen } from "./modalDialog.js";
+
+describe("isModalDialogOpen", () => {
+  let dialog;
+
+  beforeEach(() => {
+    dialog = document.createElement("div");
+    dialog.setAttribute("role", "dialog");
+    dialog.setAttribute("aria-modal", "true");
+  });
+
+  afterEach(() => {
+    dialog?.remove();
+  });
+
+  it("returns false when no modal dialog is present", () => {
+    expect(isModalDialogOpen()).toBe(false);
+  });
+
+  it("returns true for a visible modal dialog", () => {
+    document.body.appendChild(dialog);
+    expect(isModalDialogOpen()).toBe(true);
+  });
+
+  it("ignores a non-modal dialog", () => {
+    dialog.removeAttribute("aria-modal");
+    document.body.appendChild(dialog);
+    expect(isModalDialogOpen()).toBe(false);
+  });
+
+  it("ignores a modal dialog hidden for the current breakpoint", () => {
+    dialog.style.display = "none";
+    document.body.appendChild(dialog);
+    expect(isModalDialogOpen()).toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes #204.

## Root cause
`DefinitionComparisonSheet` rendered unconditionally whenever a `?definition=…` term was set, and its portal carries `role="dialog" aria-modal="true"`. On wide screens the previous `xl:hidden` class only hid it via `display:none`, but `document.querySelector('[role="dialog"][aria-modal="true"]')` matches hidden elements — so both the old check and the `4b669ea` fix (`[role="dialog"]` → `[role="dialog"][aria-modal="true"]`) kept the reader's arrow/j-k keys suppressed on pages like `…/article/3?definition=systemic+risk&definitionSource=…`.

## Changes
- **`DefinitionComparisonSheet.jsx`** — keep the sheet out of the DOM entirely below the `xl` breakpoint, using `matchMedia` the same way `DefinitionTooltip` already does. A desktop-hidden modal no longer exists to be matched.
- **`src/utils/law-viewer/modalDialog.js`** (new) — shared `isModalDialogOpen()` used by both reader-key guards. It only counts a modal dialog as open when it is actually on screen (ignores `display:none`/`visibility:hidden`), so no hidden modal can ever suppress navigation keys again.
- **`useLawViewerInteractions.js` / `LawViewerQuickNavigation.jsx`** — both guards now use the shared helper.

## Tests
- `modalDialog.test.js` — util unit tests (no dialog / visible modal / non-modal / hidden modal).
- `DefinitionComparisonSheet.test.jsx` (new) — renders the sheet below `xl`, renders nothing at `xl`+, and unmounts the dialog when the viewport widens.
- `useLawViewerInteractions.test.jsx` — a modal dialog hidden for the current breakpoint no longer blocks arrow keys.

`npm run test:web` (581 tests) and `npm run lint` pass.