### PR TITLE
Refine law overview status

### DIFF
--- a/src/components/ConsolidationNotice.jsx
+++ b/src/components/ConsolidationNotice.jsx
@@ -170,6 +170,26 @@ export function ConsolidationNotice({
       </button>
     ) : null;
 
+    if (variant === "compact") {
+      return (
+        <div className="mb-6 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-slate-700 dark:text-slate-300">
+          <History size={15} aria-hidden="true" />
+          <strong className="font-semibold text-slate-900 dark:text-slate-100">
+            {t("consolidation.currentText")}
+          </strong>
+          <span>
+            {t("consolidation.notAmended")}
+            {corrigenda > 0 ? (
+              <> · {corrigenda === 1
+                ? t("consolidation.corrigendumOnceShort")
+                : t("consolidation.corrigendaShort", { count: corrigenda })}</>
+            ) : null}
+          </span>
+          {correctionAction ? <span>{correctionAction}</span> : null}
+        </div>
+      );
+    }
+
     return (
       <div className="mb-6 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-700 dark:border-slate-800 dark:bg-slate-900/40 dark:text-slate-300">
         <div className="flex items-center gap-2 font-medium text-slate-900 dark:text-slate-100">

--- a/src/components/ConsolidationNotice.test.jsx
+++ b/src/components/ConsolidationNotice.test.jsx
@@ -168,6 +168,91 @@ describe("ConsolidationNotice", () => {
     expect(container.querySelector("button")).toBe(null);
   });
 
+  it("renders the compact current state without a corrigendum action", async () => {
+    fetchAmendments.mockResolvedValue({ amendments: [] });
+    fetchConsolidatedVersions.mockResolvedValue({ versions: [] });
+
+    await render({ variant: "compact", onToggleVersion: vi.fn() });
+
+    expect(container.textContent).toContain("Current text");
+    expect(container.textContent).toContain("Not amended");
+    expect(container.textContent).not.toContain("corrigendum");
+    expect(container.querySelector("button")).toBe(null);
+    expect(container.querySelector(".rounded-xl")).toBe(null);
+  });
+
+  it.each([
+    [1, "1 corrigendum"],
+    [2, "2 corrigenda"],
+  ])("renders the compact corrigendum count (%s)", async (count, label) => {
+    fetchAmendments.mockResolvedValue({
+      amendments: Array.from({ length: count }, (_, index) => ({
+        celex: `32016R0679R(0${index + 1})`,
+        date: "2018-05-23",
+        type: "corrigendum",
+      })),
+    });
+    fetchConsolidatedVersions.mockResolvedValue({
+      versions: [{ celex: "02016R0679-20160504", date: "2016-05-04" }],
+    });
+
+    await render({ variant: "compact", onToggleVersion: vi.fn() });
+
+    expect(container.textContent).toContain("Current text");
+    expect(container.textContent).toContain("Not amended");
+    expect(container.textContent).toContain(label);
+  });
+
+  it("keeps the compact correction action pending while EUR-Lex is checked", async () => {
+    fetchAmendments.mockResolvedValue({
+      amendments: [{ celex: "32016R0679R(01)", date: "2018-05-23", type: "corrigendum" }],
+    });
+    fetchConsolidatedVersions.mockReturnValue(new Promise(() => {}));
+
+    await render({ variant: "compact", onToggleVersion: vi.fn() });
+
+    expect(container.textContent).toContain("Current text");
+    expect(container.textContent).toContain("Not amended");
+    expect(container.textContent).toContain("Checking EUR-Lex for the current version");
+    expect(container.textContent).not.toContain("corrections applied");
+  });
+
+  it("toggles the compact correction action when a current version exists", async () => {
+    fetchAmendments.mockResolvedValue({
+      amendments: [{ celex: "32016R0679R(01)", date: "2018-05-23", type: "corrigendum" }],
+    });
+    fetchConsolidatedVersions.mockResolvedValue({
+      versions: [{ celex: "02016R0679-20160504", date: "2016-05-04" }],
+    });
+    const onToggleVersion = vi.fn();
+
+    await render({ variant: "compact", onToggleVersion });
+
+    const toggle = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent.includes("corrections applied")
+    );
+    expect(toggle).toBeTruthy();
+
+    await act(async () => { toggle.click(); });
+    expect(onToggleVersion).toHaveBeenCalledWith("current");
+  });
+
+  it("keeps an amended law as the existing full warning in compact mode", async () => {
+    fetchAmendments.mockResolvedValue({
+      amendments: [{ celex: "32020R0001", date: "2020-01-01", type: "amendment" }],
+    });
+    fetchConsolidatedVersions.mockResolvedValue({
+      versions: [{ celex: "02020R0001-20200101", date: "2020-01-01" }],
+    });
+
+    await render({ variant: "compact", onToggleVersion: vi.fn() });
+
+    expect(container.textContent).toContain("You are reading this law as adopted");
+    expect(container.textContent).toContain("Read this law as amended");
+    expect(container.textContent).not.toContain("Current text");
+    expect(container.querySelector(".rounded-xl")).toBeTruthy();
+  });
+
   it("claims nothing about a never-amended law when the history could not be fetched", async () => {
     // `[]` on failure keeps the warning off, but it must not be read as
     // evidence for the opposite claim.

--- a/src/components/LawViewer.jsx
+++ b/src/components/LawViewer.jsx
@@ -409,7 +409,6 @@ export function LawViewer() {
                     else if (primaryDocument.data.recitals?.[0]) selection.selectRecitalIdx(0);
                     else if (primaryDocument.data.annexes?.[0]) selection.selectAnnexIdx(0);
                   }}
-                  onPrint={() => printState.setPrintModalOpen(true)}
                   externalLawOverview={derived.externalLawOverview}
                   onOpenExternalLaw={interactions.handleOpenExternalLaw}
                   onOpenCitedLaw={interactions.handleOpenLawByCelex}

--- a/src/components/law-viewer/LawOverviewPage.jsx
+++ b/src/components/law-viewer/LawOverviewPage.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { ExternalLink, Loader2, Printer, Scale } from "lucide-react";
+import { ExternalLink, Loader2, Scale } from "lucide-react";
 import { LawSummary } from "../LawSummary.jsx";
 import { MetadataPanel } from "../MetadataPanel.jsx";
 import { CaseLawModal } from "../CaseLawModal.jsx";
@@ -89,7 +89,6 @@ export function LawOverviewPage({
   formexLang,
   onArticleClick,
   onStartReading,
-  onPrint,
   externalLawOverview = [],
   onOpenExternalLaw,
   onOpenCitedLaw,
@@ -193,6 +192,7 @@ export function LawOverviewPage({
         celex={effectiveCelex}
         currentLang={formexLang}
         locale={locale}
+        variant="compact"
         source={data?.source}
         version={version}
         versionUnavailable={versionUnavailable}
@@ -228,16 +228,6 @@ export function LawOverviewPage({
             <ExternalLink size={16} />
             {procedureLabel}
           </a>
-        ) : null}
-        {onPrint ? (
-          <button
-            type="button"
-            onClick={onPrint}
-            className="inline-flex items-center gap-2 rounded-xl px-4 py-2 text-sm font-medium text-gray-500 transition hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800"
-          >
-            <Printer size={16} />
-            {t("lawOverview.print")}
-          </button>
         ) : null}
       </div>
 

--- a/src/components/law-viewer/LawOverviewPage.test.jsx
+++ b/src/components/law-viewer/LawOverviewPage.test.jsx
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+
+vi.mock("../LawSummary.jsx", () => ({ LawSummary: () => null }));
+vi.mock("../MetadataPanel.jsx", () => ({ MetadataPanel: () => null }));
+vi.mock("../ConsolidationNotice.jsx", () => ({
+  ConsolidationNotice: ({ variant }) => createElement("div", { "data-variant": variant }),
+}));
+vi.mock("./ConsolidatedFallbackNotice.jsx", () => ({ ConsolidatedFallbackNotice: () => null }));
+vi.mock("../../hooks/useLawMetadata.js", () => ({
+  useLawMetadata: () => ({
+    metadata: {},
+    status: null,
+    procedure: { procedureUrl: "https://eur-lex.europa.eu/procedure" },
+    amendments: [],
+    implementing: [],
+    citedBy: [],
+  }),
+}));
+vi.mock("../../hooks/law-viewer/useCaseLaw.js", () => ({
+  useCaseLaw: () => ({ cases: null, loading: false, loaded: false, trigger: vi.fn() }),
+}));
+
+const { LawOverviewPage } = await import("./LawOverviewPage.jsx");
+
+let container;
+let root;
+
+const t = (key, values = {}) => ({
+  "lawOverview.actTypeRegulation": "Regulation",
+  "lawOverview.celexLabel": `CELEX ${values.celex}`,
+  "lawOverview.procedureView": "Legislative history on EUR-Lex",
+  "metadata.caseLaw": "CJEU Case Law",
+  "metadata.inForce": "In force",
+  "lawViewer.startReading": "Start reading",
+}[key] || key);
+
+beforeEach(() => {
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  container.remove();
+  document.body.innerHTML = "";
+});
+
+describe("LawOverviewPage", () => {
+  it("uses the compact notice and keeps the overview action labels without Print", async () => {
+    await act(async () => {
+      root = createRoot(container);
+      root.render(
+        createElement(
+          MemoryRouter,
+          null,
+          createElement(LawOverviewPage, {
+            currentLaw: {
+              label: "Example regulation",
+              officialReference: { actType: "regulation", raw: "Regulation (EU) 2020/1" },
+            },
+            data: { title: "Example regulation", articles: [], recitals: [], annexes: [] },
+            effectiveCelex: "32020R0001",
+            formexLang: "EN",
+            onArticleClick: vi.fn(),
+            onStartReading: vi.fn(),
+            externalLawOverview: [],
+            onOpenExternalLaw: vi.fn(),
+            onOpenCitedLaw: vi.fn(),
+            isExternalReferencePending: false,
+            t,
+          })
+        )
+      );
+    });
+
+    expect(container.querySelector("[data-variant=compact]")).toBeTruthy();
+    expect(container.textContent).toContain("Start reading");
+    expect(container.textContent).toContain("CJEU Case Law");
+    expect(container.textContent).toContain("Legislative history on EUR-Lex");
+    expect(container.textContent).not.toContain("Print");
+  });
+});

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -492,6 +492,10 @@
     "correctedOnce": "One corrigendum has been published since. Corrigenda are applied to the consolidated text, not to the act as published here.",
     "corrected": "{count} corrigenda have been published since. Corrigenda are applied to the consolidated text, not to the act as published here.",
     "toggleReadCorrected": "Read this law with the corrections applied",
-    "checkingVersion": "Checking EUR-Lex for the current version…"
+    "checkingVersion": "Checking EUR-Lex for the current version…",
+    "currentText": "Current text",
+    "notAmended": "Not amended",
+    "corrigendumOnceShort": "1 corrigendum",
+    "corrigendaShort": "{count} corrigenda"
   }
 }


### PR DESCRIPTION
## Summary
- compact the verified current-text notice on law overview pages
- preserve full amended, unavailable, and consolidated-version warnings
- remove the duplicated overview Print / PDF action while keeping print in More tools
- add focused consolidation and overview action coverage

## Testing
- node_modules/.bin/vitest run src/components/ConsolidationNotice.test.jsx src/components/ToolsMenu.test.jsx src/components/law-viewer/LawOverviewPage.test.jsx
- node_modules/.bin/vitest run src/components/MetadataPanel.tabs.test.jsx
- node_modules/.bin/eslint src/components/ConsolidationNotice.jsx src/components/ConsolidationNotice.test.jsx src/components/LawViewer.jsx src/components/law-viewer/LawOverviewPage.jsx src/components/law-viewer/LawOverviewPage.test.jsx
- node_modules/.bin/vite build
- git diff --check