### PR TITLE
Share one consolidated-version lookup between /parsed and /consolidated

### DIFF
--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -115,6 +115,7 @@ function registerApiRoutes(app, deps) {
     citationGraphStore,
     findDownloadUrls,
     findFmx4Uri,
+    fetchConsolidatedVersionsMemo: injectedConsolidatedVersionsMemo,
     parseReferenceText,
     parseStructuredReference,
     prepareLawPayload,
@@ -137,6 +138,20 @@ function registerApiRoutes(app, deps) {
     validateCelex,
     validateLang
   } = deps;
+
+  // Consolidated-version lookups are shared with parsed-law resolution — the
+  // parsed route needs the same list to decide whether to serve the "as
+  // amended" text — so the memo is created once in server.js and injected into
+  // both. This fallback keeps the route self-sufficient when it isn't (unit
+  // tests wire their own deps), with the same key and TTL.
+  const fetchConsolidatedVersionsMemo = injectedConsolidatedVersionsMemo || (async (celex) => {
+    const cacheKey = `consolidated:${celex}`;
+    const cached = cacheGet(resolutionCache, cacheKey);
+    if (cached) return cached;
+    const payload = await fetchConsolidatedVersions(celex, runSparqlQuery);
+    cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+    return payload;
+  });
 
   app.get('/health', (req, res) => {
     res.json({ status: 'ok', timestamp: new Date().toISOString() });
@@ -438,15 +453,7 @@ function registerApiRoutes(app, deps) {
         return res.status(400).json({ error: 'Invalid CELEX format' });
       }
 
-      const cacheKey = `consolidated:${celex}`;
-      const cached = cacheGet(resolutionCache, cacheKey);
-      if (cached) {
-        return res.json(cached);
-      }
-
-      const payload = await fetchConsolidatedVersions(celex, runSparqlQuery);
-      cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
-      res.json(payload);
+      res.json(await fetchConsolidatedVersionsMemo(celex));
     } catch (err) {
       safeErrorResponse(res, err, 'Failed to fetch consolidated versions');
     }

--- a/backend/routes/api-routes.test.js
+++ b/backend/routes/api-routes.test.js
@@ -152,6 +152,9 @@ function registerTestRoutes(overrides = {}) {
       prepareLawPayload: deps.prepareLawPayload,
       fetchAndParseHtmlLaw: deps.fetchAndParseHtmlLaw,
       CELEX_NAMES: deps.CELEX_NAMES,
+      fetchConsolidatedVersions: deps.fetchConsolidatedVersions,
+      fetchConsolidatedVersionsMemo: deps.fetchConsolidatedVersionsMemo,
+      runSparqlQuery: deps.runSparqlQuery,
     });
   }
 
@@ -492,6 +495,48 @@ test("GET /api/laws/:celex/parsed accepts ?version=current and forwards it to re
   assert.equal(res.statusCode, 200);
   assert.equal(res.payload.version, "current");
   assert.deepEqual(calls, [{ celex: "32013R0575", lang: "ENG", options: { skipFmxProbe: false, version: "current" } }]);
+});
+
+test("parsed and consolidated routes share the consolidated-version memo", async () => {
+  const celex = "32013R0575";
+  const resolutionCache = new Map();
+  let upstreamCalls = 0;
+  const fetchConsolidatedVersions = async (requestedCelex) => {
+    upstreamCalls += 1;
+    return {
+      celex: requestedCelex,
+      base: "02013R0575",
+      versions: [{ celex: "02013R0575-20260626", date: "2026-06-26" }],
+    };
+  };
+  const fetchConsolidatedVersionsMemo = async (requestedCelex) => {
+    const cacheKey = `consolidated:${requestedCelex}`;
+    const cached = cacheGet(resolutionCache, cacheKey);
+    if (cached) return cached;
+    const payload = await fetchConsolidatedVersions(requestedCelex);
+    cacheSet(resolutionCache, cacheKey, payload, 60_000);
+    return payload;
+  };
+
+  const { app } = registerTestRoutes({
+    resolutionCache,
+    fetchConsolidatedVersionsMemo,
+    prepareLawPayload: async () => ({ servePath: gdprFmxPath }),
+  });
+
+  const consolidatedHandler = app.routes.get("/api/laws/:celex/consolidated");
+  const consolidatedResponse = createResponseRecorder();
+  await consolidatedHandler({ params: { celex }, query: {} }, consolidatedResponse);
+
+  const parsedHandler = app.routes.get("/api/laws/:celex/parsed");
+  const parsedResponse = createResponseRecorder();
+  await parsedHandler({ params: { celex }, query: { lang: "ENG", version: "current" } }, parsedResponse);
+
+  assert.equal(consolidatedResponse.statusCode, 200);
+  assert.equal(parsedResponse.statusCode, 200);
+  assert.equal(parsedResponse.payload.source, "fmx-consolidated");
+  assert.equal(upstreamCalls, 1, "the parsed route should reuse the consolidated route's cached lookup");
+  assert.ok(resolutionCache.has(`consolidated:${celex}`));
 });
 
 test("GET /api/laws/:celex/case-law uses a short cache ttl", async () => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -112,6 +112,19 @@ const { resolveEurlexUrl, resolveReference, resolveReferenceViaCellar, runSparql
   toSearchLang,
 });
 
+// Share the consolidated-version lookup between the consolidated route and
+// parsed-law resolution. Cache only fulfilled lookups so Cellar failures stay
+// non-fatal and retryable.
+async function fetchConsolidatedVersionsMemo(celex) {
+  const cacheKey = `consolidated:${celex}`;
+  const cached = cacheGet(resolutionCache, cacheKey);
+  if (cached) return cached;
+
+  const payload = await fetchConsolidatedVersions(celex, runSparqlQuery);
+  cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+  return payload;
+}
+
 // CELEX to friendly name mapping
 const CELEX_NAMES = {
   '32016R0679': 'GDPR',
@@ -270,6 +283,7 @@ const resolveParsedLaw = createParsedLawResolver({
   fetchAndParseHtmlLaw: fetchAndParseHtmlLawCached,
   CELEX_NAMES,
   fetchConsolidatedVersions,
+  fetchConsolidatedVersionsMemo,
   runSparqlQuery,
 });
 
@@ -284,6 +298,7 @@ registerApiRoutes(app, {
   cacheSet,
   findDownloadUrls,
   findFmx4Uri,
+  fetchConsolidatedVersionsMemo,
   citationGraphStore,
   legalCacheStore,
   parseReferenceText,

--- a/backend/shared/parsed-law-service.js
+++ b/backend/shared/parsed-law-service.js
@@ -27,9 +27,20 @@ function createParsedLawResolver({
   fetchAndParseHtmlLaw,
   CELEX_NAMES = {},
   fetchConsolidatedVersions,
+  fetchConsolidatedVersionsMemo,
   runSparqlQuery,
 }) {
   const parsedCache = new Map(); // `${celex}:${lang}:${skipFmxProbe}:${version}` -> parsed law
+
+  // Prefer the memo the server shares with the /consolidated route: both paths
+  // want the same SPARQL answer for the same CELEX, and without it a cold law
+  // view ran the query twice. Falling back to the raw query keeps the resolver
+  // usable on its own (the CLI and unit tests inject it without a memo), and
+  // leaving both out disables consolidation rather than erroring.
+  const loadConsolidatedVersions = fetchConsolidatedVersionsMemo
+    || (typeof fetchConsolidatedVersions === 'function' && typeof runSparqlQuery === 'function'
+      ? (celex) => fetchConsolidatedVersions(celex, runSparqlQuery)
+      : null);
 
   /**
    * Fetches and parses the current consolidated ("as amended") EUR-Lex
@@ -45,10 +56,8 @@ function createParsedLawResolver({
    * document exists, not what to do when it can't tell.
    */
   async function loadConsolidatedLaw(celex, lang) {
-    if (typeof fetchConsolidatedVersions !== 'function' || typeof runSparqlQuery !== 'function') {
-      return null;
-    }
-    const { versions } = await fetchConsolidatedVersions(celex, runSparqlQuery);
+    if (!loadConsolidatedVersions) return null;
+    const { versions } = await loadConsolidatedVersions(celex);
     const { current } = selectConsolidatedVersions(versions);
     if (!current) return null;
 


### PR DESCRIPTION
## What

`/api/laws/:celex/consolidated` memoizes `fetchConsolidatedVersions` into `resolutionCache` (24h TTL). `loadConsolidatedLaw` in `backend/shared/parsed-law-service.js` called `fetchConsolidatedVersions(celex, runSparqlQuery)` directly and bypassed that memo — so on every parsed-cache miss, `/api/laws/:celex/parsed` re-ran against Cellar the exact SPARQL query `/consolidated` had just cached. Two identical upstream round trips per cold law view, since the overview panel and the reader both load on mount.

The memo now lives in `backend/server.js` beside `resolutionCache` and is injected into both `createParsedLawResolver` and `registerApiRoutes`, following the `fetchCaseLawMemo` pattern already used for case law and added there for the same reason.

## Behaviour

- Only fulfilled lookups are cached, so a Cellar failure stays retryable instead of being pinned for the TTL.
- `loadConsolidatedLaw` still throws on SPARQL/network failure and callers still swallow it into their own fallback — unchanged.
- Both call sites work without the memo injected: the resolver falls back to the raw query (how the CLI wires it) and disables consolidation when neither is available; the route falls back to the same cache key and TTL it used before.
- No response shape changes, so no cache-version constant is bumped.

## Test

`backend/routes/api-routes.test.js` — exercising `/consolidated` and then `/parsed?version=current` for the same CELEX now asserts the upstream lookup ran **once**. Reverting the resolver to the direct call makes it 2 and fails.

## Verification

- `npm run lint` — clean
- `npm test` — 608 frontend, 566 backend passing (2 skipped)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3wd6oBm3ooRTEGG3ZYH7t)_