### PR TITLE
Persist the Cellar resolution cache across restarts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ Nearly every expensive operation — Formex parsing, TF‑IDF recital mapping, C
 | Article-digest JSON schema / prompt | `articleDigest.schemaVersion` / `promptVersion` | `backend/shared/digest-cache-version.json` (shared by backend and frontend) |
 | Whole-law digest JSON schema / prompt | `caseLawDigest.schemaVersion` / `promptVersion` | `backend/shared/digest-cache-version.json` (shared by backend and frontend) |
 | Persisted analytics shape (`analytics.json` fields) | `ANALYTICS_SCHEMA_VERSION` | `backend/shared/analytics.js` |
+| Cellar resolution cache SQLite table/value shape | `RESOLUTION_CACHE_SCHEMA_VERSION` | `backend/shared/resolution-cache-store.js` (independent of `SQLITE_SCHEMA_VERSION`; mismatches reset only this cache table) |
 | Runtime SQLite tables/indexes | `SQLITE_SCHEMA_VERSION` | `backend/search/legal-cache-store.js`, `backend/search/build-sqlite-data.js`, and `backend/search/citation-graph-store.js` (three copies, kept in lock-step) |
 | Full-text `units` schema / builder output shape | `FULLTEXT_SCHEMA_VERSION` | `backend/search/fulltext-index-build.js`, with a lock-step copy in `backend/search/legal-cache-store.js` |
 | Precomputed data republished as a new GitHub Release | `DATA_RELEASE_TAG` → `data-YYYY-MM-DD.NN` | `backend/Dockerfile` |

--- a/backend/server.js
+++ b/backend/server.js
@@ -11,6 +11,7 @@ const { fetchConsolidatedVersions } = require('./shared/law-queries');
 const { createFmxService } = require('./shared/fmx-service');
 const { fetchEurlexHtmlLaw, parseEurlexHtmlToCombined, closeSharedPlaywrightBrowser } = require('./shared/eurlex-html-parser');
 const { createHtmlCacheService } = require('./shared/html-cache-service');
+const { createPersistentCache } = require('./shared/resolution-cache-store');
 const { createGenerationLimitMiddleware, createRateLimitMiddleware } = require('./shared/rate-limit');
 const { createOriginAllowlistMiddleware } = require('./shared/origin-guard');
 const {
@@ -57,8 +58,17 @@ const GENERATION_LIMIT_MAX = parseInt(process.env.GENERATION_LIMIT_MAX) || 10; /
 const STORAGE_LIMIT_MB = parseInt(process.env.STORAGE_LIMIT_MB) || 500; // FMX files
 const HTML_CACHE_LIMIT_MB = parseInt(process.env.HTML_CACHE_LIMIT_MB) || 200; // parsed HTML
 
-const resolutionCache = new Map(); // key -> { expiresAt, value }
 const RESOLUTION_CACHE_MS = 24 * 60 * 60 * 1000;
+// Ensure cache directory exists
+try {
+  if (!fs.existsSync(CACHE_DIR)) {
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+  }
+} catch {
+  // The persistent resolution store reports the single cache degradation.
+}
+
+const resolutionCache = createPersistentCache({ cacheDir: CACHE_DIR });
 const legalCacheStore = new JsonLegalCacheStore(process.env.SEARCH_CACHE_PATH || DEFAULT_SEARCH_CACHE_PATH);
 const citationGraphStore = new CitationGraphStore(
   process.env.CITATION_GRAPH_PATH || DEFAULT_CITATION_GRAPH_PATH,
@@ -75,11 +85,6 @@ const generationLimitMiddleware = createGenerationLimitMiddleware({
 // CORS stays permissive everywhere else — the public API and the MCP endpoint
 // are meant to be callable from anywhere; only generation is origin-restricted.
 const generationOriginMiddleware = createOriginAllowlistMiddleware();
-
-// Ensure cache directory exists
-if (!fs.existsSync(CACHE_DIR)) {
-  fs.mkdirSync(CACHE_DIR, { recursive: true });
-}
 
 legalCacheStore.load();
 citationGraphStore.load();
@@ -379,6 +384,7 @@ async function gracefulShutdown(signal) {
   try {
     await new Promise((resolve) => server.close(resolve));
     analytics.shutdown();
+    resolutionCache.persistentStore?.close();
     legalCacheStore.close();
     await closeSharedPlaywrightBrowser();
     console.log('[shutdown] Clean exit');

--- a/backend/server.js
+++ b/backend/server.js
@@ -18,6 +18,7 @@ const {
   createReferenceResolver,
   parseReferenceText,
   parseStructuredReference,
+  RESOLUTION_NEGATIVE_CACHE_MS,
   validateCelex,
 } = require('./shared/reference-utils');
 const {
@@ -109,6 +110,7 @@ const htmlCache = createHtmlCacheService({
 const { resolveEurlexUrl, resolveReference, resolveReferenceViaCellar, runSparqlQuery } = createReferenceResolver({
   EURLEX_BASE,
   RESOLUTION_CACHE_MS,
+  RESOLUTION_NEGATIVE_CACHE_MS,
   TIMEOUT_MS,
   cacheGet,
   cacheSet,
@@ -285,6 +287,7 @@ registerApiRoutes(app, {
   FMX_DIR: CACHE_DIR,
   RATE_LIMIT_MAX,
   RESOLUTION_CACHE_MS,
+  RESOLUTION_NEGATIVE_CACHE_MS,
   cacheGet,
   cacheSet,
   findDownloadUrls,

--- a/backend/shared/api-utils.js
+++ b/backend/shared/api-utils.js
@@ -23,23 +23,50 @@ function toSearchLang(lang) {
 
 const DEFAULT_CACHE_MAX_ENTRIES = 10_000;
 
-function cacheGet(cache, key) {
-  const entry = cache.get(key);
-  if (!entry) return null;
-  if (Date.now() > entry.expiresAt) {
-    cache.delete(key);
-    return null;
-  }
-  return entry.value;
+function getPersistentStore(cache) {
+  const store = cache?.persistentStore;
+  return store && typeof store.get === 'function' ? store : null;
 }
 
-function cacheSet(cache, key, value, ttlMs, maxEntries = DEFAULT_CACHE_MAX_ENTRIES) {
-  if (cache.size >= maxEntries) {
+function cacheRemember(cache, key, entry, maxEntries) {
+  if (cache.size >= maxEntries && !cache.has(key)) {
     // Evict oldest entry (first inserted key in Map iteration order)
     const oldestKey = cache.keys().next().value;
     cache.delete(oldestKey);
   }
-  cache.set(key, { value, expiresAt: Date.now() + ttlMs });
+  cache.set(key, entry);
+}
+
+function cacheGet(cache, key) {
+  const entry = cache.get(key);
+  if (entry) {
+    if (Date.now() > entry.expiresAt) {
+      cache.delete(key);
+    } else {
+      return entry.value;
+    }
+  }
+
+  const persistentStore = getPersistentStore(cache);
+  if (!persistentStore) return null;
+
+  const persistedEntry = persistentStore.get(key);
+  if (!persistedEntry || Date.now() > persistedEntry.expiresAt) return null;
+  const maxEntries = Number.isSafeInteger(persistentStore.maxEntries) && persistentStore.maxEntries > 0
+    ? persistentStore.maxEntries
+    : DEFAULT_CACHE_MAX_ENTRIES;
+  cacheRemember(cache, key, persistedEntry, maxEntries);
+  return persistedEntry.value;
+}
+
+function cacheSet(cache, key, value, ttlMs, maxEntries = DEFAULT_CACHE_MAX_ENTRIES) {
+  const entry = { value, expiresAt: Date.now() + ttlMs };
+  cacheRemember(cache, key, entry, maxEntries);
+
+  const persistentStore = getPersistentStore(cache);
+  if (persistentStore) {
+    persistentStore.set(key, value, entry.expiresAt, maxEntries);
+  }
 }
 
 class ClientError extends Error {

--- a/backend/shared/reference-utils.js
+++ b/backend/shared/reference-utils.js
@@ -3,6 +3,8 @@ const {
   buildCanonicalEliFromReference,
 } = require('../search/legal-cache-store');
 
+const RESOLUTION_NEGATIVE_CACHE_MS = 5 * 60 * 1000;
+
 function parseReferenceText(text = '') {
   const normalized = text.replace(/\s+/g, ' ').trim();
   const lower = normalized.toLowerCase();
@@ -263,6 +265,7 @@ function buildEurlexOjFallbackUrl(oj, lang, toSearchLang, EURLEX_BASE) {
 function createReferenceResolver({
   EURLEX_BASE,
   RESOLUTION_CACHE_MS,
+  RESOLUTION_NEGATIVE_CACHE_MS: negativeCacheTtl = RESOLUTION_NEGATIVE_CACHE_MS,
   TIMEOUT_MS,
   cacheGet,
   cacheSet,
@@ -270,6 +273,9 @@ function createReferenceResolver({
   resolutionCache,
   toSearchLang,
 }) {
+  const resolutionCacheTtl = (payload) =>
+    payload?.resolved === null ? negativeCacheTtl : RESOLUTION_CACHE_MS;
+
   async function fetchWithTimeout(url, options = {}) {
     // AbortSignal.timeout stays armed while the body is consumed, so the
     // deadline also covers the caller's response.json()/text() reads — the
@@ -340,7 +346,7 @@ LIMIT 5`;
             url: buildEurlexSearchFallbackUrl(reference, lang, toSearchLang, EURLEX_BASE),
           },
         };
-        cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+        cacheSet(resolutionCache, cacheKey, payload, resolutionCacheTtl(payload));
         return payload;
       }
     }
@@ -353,7 +359,7 @@ LIMIT 5`;
         url: buildEurlexSearchFallbackUrl(reference, lang, toSearchLang, EURLEX_BASE),
       },
     };
-    cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+    cacheSet(resolutionCache, cacheKey, payload, resolutionCacheTtl(payload));
     return payload;
   }
 
@@ -460,7 +466,7 @@ LIMIT 5`;
       };
     }
 
-    cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+    cacheSet(resolutionCache, cacheKey, payload, resolutionCacheTtl(payload));
     return payload;
   }
 
@@ -549,7 +555,7 @@ LIMIT 5`;
       tried: [{ source: 'cellar-com', comnatId, celex: celexValues }],
       fallback,
     };
-    cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+    cacheSet(resolutionCache, cacheKey, payload, resolutionCacheTtl(payload));
     return payload;
   }
 
@@ -569,7 +575,7 @@ LIMIT 5`;
         },
         fallback: null,
       };
-      cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+      cacheSet(resolutionCache, cacheKey, payload, resolutionCacheTtl(payload));
       return payload;
     }
 
@@ -610,7 +616,7 @@ LIMIT 5`;
         tried: resolution.tried,
         fallback: resolution.fallback,
       };
-      cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+      cacheSet(resolutionCache, cacheKey, payload, resolutionCacheTtl(payload));
       return payload;
     }
 
@@ -630,7 +636,7 @@ LIMIT 5`;
         },
         ...(resolution.error ? { error: resolution.error } : {}),
       };
-      cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+      cacheSet(resolutionCache, cacheKey, payload, resolutionCacheTtl(payload));
       return payload;
     }
 
@@ -649,7 +655,7 @@ LIMIT 5`;
           url: parsed.url.toString(),
         },
       };
-      cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+      cacheSet(resolutionCache, cacheKey, payload, resolutionCacheTtl(payload));
       return payload;
     }
 
@@ -664,7 +670,7 @@ LIMIT 5`;
         url: parsed.url.toString(),
       },
     };
-    cacheSet(resolutionCache, cacheKey, payload, RESOLUTION_CACHE_MS);
+    cacheSet(resolutionCache, cacheKey, payload, resolutionCacheTtl(payload));
     return payload;
   }
 
@@ -687,5 +693,6 @@ module.exports = {
   parseEurlexUrl,
   parseReferenceText,
   parseStructuredReference,
+  RESOLUTION_NEGATIVE_CACHE_MS,
   validateCelex,
 };

--- a/backend/shared/resolution-cache-store.js
+++ b/backend/shared/resolution-cache-store.js
@@ -1,0 +1,211 @@
+const path = require('path');
+
+const DEFAULT_RESOLUTION_CACHE_FILE = 'resolution-cache.sqlite';
+const DEFAULT_RESOLUTION_CACHE_MAX_ENTRIES = 10_000;
+// Expired rows are swept on a timer rather than on every read and write: this
+// cache sits on the request path, and a DELETE per lookup would take a write
+// lock for each one. Correctness does not depend on the sweep — reads filter on
+// `expires_at` — so it only bounds how long dead rows occupy the entry budget.
+const PRUNE_INTERVAL_MS = 60 * 1000;
+
+// This is deliberately independent of the shipped data.sqlite schema version.
+const RESOLUTION_CACHE_SCHEMA_VERSION = 1;
+
+function normalizeMaxEntries(value) {
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_RESOLUTION_CACHE_MAX_ENTRIES;
+}
+
+class ResolutionCacheStore {
+  constructor({
+    cacheDir,
+    databasePath = null,
+    maxEntries = DEFAULT_RESOLUTION_CACHE_MAX_ENTRIES,
+  } = {}) {
+    this.databasePath = databasePath || (cacheDir ? path.join(cacheDir, DEFAULT_RESOLUTION_CACHE_FILE) : null);
+    this.maxEntries = normalizeMaxEntries(maxEntries);
+    this.database = null;
+    this.statements = null;
+    this.writeTransaction = null;
+    this.available = false;
+    this.failureLogged = false;
+    this.lastPrunedAt = 0;
+    this.initialize();
+  }
+
+  initialize() {
+    let database = null;
+    try {
+      if (!this.databasePath) {
+        throw new Error('No cache directory configured');
+      }
+
+      // Load lazily so a missing native module degrades to the normal Map.
+      const Database = require('better-sqlite3');
+      database = new Database(this.databasePath);
+      this.database = database;
+      // WAL keeps a writer from blocking the readers on the request path.
+      database.pragma('journal_mode = WAL');
+
+      const schemaVersion = database.pragma('user_version', { simple: true });
+      if (schemaVersion !== RESOLUTION_CACHE_SCHEMA_VERSION) {
+        database.exec('DROP TABLE IF EXISTS resolution_cache');
+      }
+
+      database.exec(`
+        CREATE TABLE IF NOT EXISTS resolution_cache (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          key TEXT NOT NULL UNIQUE,
+          value TEXT NOT NULL,
+          expires_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS resolution_cache_expires_at
+          ON resolution_cache (expires_at);
+      `);
+      database.pragma(`user_version = ${RESOLUTION_CACHE_SCHEMA_VERSION}`);
+
+      this.statements = {
+        count: database.prepare('SELECT COUNT(*) AS count FROM resolution_cache'),
+        deleteExpired: database.prepare('DELETE FROM resolution_cache WHERE expires_at <= ?'),
+        deleteKey: database.prepare('DELETE FROM resolution_cache WHERE key = ?'),
+        deleteOldest: database.prepare(`
+          DELETE FROM resolution_cache
+          WHERE id IN (
+            SELECT id FROM resolution_cache ORDER BY id ASC LIMIT ?
+          )
+        `),
+        findKey: database.prepare('SELECT id FROM resolution_cache WHERE key = ?'),
+        get: database.prepare('SELECT value, expires_at AS expiresAt FROM resolution_cache WHERE key = ?'),
+        upsert: database.prepare(`
+          INSERT INTO resolution_cache (key, value, expires_at)
+          VALUES (?, ?, ?)
+          ON CONFLICT(key) DO UPDATE SET
+            value = excluded.value,
+            expires_at = excluded.expires_at
+        `),
+      };
+
+      this.writeTransaction = database.transaction((key, serialized, expiresAt, maxEntries) => {
+        const now = Date.now();
+        if (expiresAt <= now) {
+          this.statements.deleteKey.run(key);
+          return;
+        }
+
+        const existing = this.statements.findKey.get(key);
+        if (!existing) {
+          const count = this.statements.count.get().count;
+          if (count >= maxEntries) {
+            this.statements.deleteOldest.run(count - maxEntries + 1);
+          }
+        }
+        this.statements.upsert.run(key, serialized, expiresAt);
+      });
+
+      this.prune(this.maxEntries);
+      this.available = true;
+    } catch (error) {
+      if (database && !this.database) {
+        try { database.close(); } catch { /* best effort */ }
+      }
+      this.disable(error);
+    }
+  }
+
+  prune(maxEntries = this.maxEntries) {
+    if (!this.database || !this.statements) return;
+    const normalizedMaxEntries = normalizeMaxEntries(maxEntries);
+    this.statements.deleteExpired.run(Date.now());
+    const count = this.statements.count.get().count;
+    if (count > normalizedMaxEntries) {
+      this.statements.deleteOldest.run(count - normalizedMaxEntries);
+    }
+    this.lastPrunedAt = Date.now();
+  }
+
+  maybePrune(maxEntries = this.maxEntries) {
+    if (Date.now() - this.lastPrunedAt < PRUNE_INTERVAL_MS) return;
+    this.prune(maxEntries);
+  }
+
+  get(key) {
+    if (!this.available || !this.database || !this.statements) return null;
+
+    try {
+      const now = Date.now();
+      const row = this.statements.get.get(String(key));
+      if (!row || row.expiresAt <= now) return null;
+
+      return {
+        value: JSON.parse(row.value),
+        expiresAt: row.expiresAt,
+      };
+    } catch (error) {
+      this.disable(error);
+      return null;
+    }
+  }
+
+  set(key, value, expiresAt, maxEntries = this.maxEntries) {
+    if (!this.available || !this.database || !this.statements || !this.writeTransaction) return;
+
+    try {
+      const serialized = JSON.stringify(value);
+      if (typeof serialized !== 'string') {
+        throw new TypeError('Cache value is not JSON-serializable');
+      }
+      const normalizedMaxEntries = normalizeMaxEntries(maxEntries);
+      this.maybePrune(normalizedMaxEntries);
+      this.writeTransaction(String(key), serialized, expiresAt, normalizedMaxEntries);
+    } catch (error) {
+      this.disable(error);
+    }
+  }
+
+  disable(error) {
+    this.available = false;
+    if (!this.failureLogged) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`[ResolutionCache] Persistent store disabled; using in-memory cache only: ${message}`);
+      this.failureLogged = true;
+    }
+
+    if (this.database) {
+      try { this.database.close(); } catch { /* best effort */ }
+    }
+    this.database = null;
+    this.statements = null;
+    this.writeTransaction = null;
+  }
+
+  close() {
+    if (!this.database) return;
+    try { this.database.close(); } catch { /* already closed or failed */ }
+    this.database = null;
+    this.statements = null;
+    this.writeTransaction = null;
+    this.available = false;
+  }
+}
+
+function createPersistentCache(options = {}) {
+  const cache = new Map();
+  const store = new ResolutionCacheStore(options);
+  Object.defineProperty(cache, 'persistentStore', {
+    configurable: false,
+    enumerable: false,
+    value: store,
+    writable: false,
+  });
+  return cache;
+}
+
+module.exports = {
+  DEFAULT_RESOLUTION_CACHE_FILE,
+  DEFAULT_RESOLUTION_CACHE_MAX_ENTRIES,
+  RESOLUTION_CACHE_SCHEMA_VERSION,
+  ResolutionCacheStore,
+  createPersistentCache,
+};

--- a/backend/shared/resolution-cache-store.js
+++ b/backend/shared/resolution-cache-store.js
@@ -2,6 +2,9 @@ const path = require('path');
 
 const DEFAULT_RESOLUTION_CACHE_FILE = 'resolution-cache.sqlite';
 const DEFAULT_RESOLUTION_CACHE_MAX_ENTRIES = 10_000;
+const SQLITE_BUSY_TIMEOUT_MS = 5_000;
+// Keep individual cache keys and serialized values below 64 KiB to bound file growth.
+const MAX_RESOLUTION_CACHE_ENTRY_BYTES = 64 * 1024;
 // Expired rows are swept on a timer rather than on every read and write: this
 // cache sits on the request path, and a DELETE per lookup would take a write
 // lock for each one. Correctness does not depend on the sweep — reads filter on
@@ -10,6 +13,10 @@ const PRUNE_INTERVAL_MS = 60 * 1000;
 
 // This is deliberately independent of the shipped data.sqlite schema version.
 const RESOLUTION_CACHE_SCHEMA_VERSION = 1;
+
+function isTransientSqliteError(error) {
+  return error?.code === 'SQLITE_BUSY' || error?.code === 'SQLITE_LOCKED';
+}
 
 function normalizeMaxEntries(value) {
   const parsed = Number(value);
@@ -46,6 +53,7 @@ class ResolutionCacheStore {
       const Database = require('better-sqlite3');
       database = new Database(this.databasePath);
       this.database = database;
+      database.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`);
       // WAL keeps a writer from blocking the readers on the request path.
       database.pragma('journal_mode = WAL');
 
@@ -102,11 +110,25 @@ class ResolutionCacheStore {
           }
         }
         this.statements.upsert.run(key, serialized, expiresAt);
-      });
+      }).immediate;
 
       this.prune(this.maxEntries);
       this.available = true;
     } catch (error) {
+      if (isTransientSqliteError(error)) {
+        this.logTransientFailure(error);
+        if (this.database && this.statements && this.writeTransaction) {
+          this.available = true;
+          return;
+        }
+        if (database) {
+          try { database.close(); } catch { /* best effort */ }
+        }
+        this.database = null;
+        this.statements = null;
+        this.writeTransaction = null;
+        return;
+      }
       if (database && !this.database) {
         try { database.close(); } catch { /* best effort */ }
       }
@@ -143,6 +165,10 @@ class ResolutionCacheStore {
         expiresAt: row.expiresAt,
       };
     } catch (error) {
+      if (isTransientSqliteError(error)) {
+        this.logTransientFailure(error);
+        return null;
+      }
       this.disable(error);
       return null;
     }
@@ -156,12 +182,26 @@ class ResolutionCacheStore {
       if (typeof serialized !== 'string') {
         throw new TypeError('Cache value is not JSON-serializable');
       }
+      const normalizedKey = String(key);
+      if (Buffer.byteLength(normalizedKey, 'utf8') > MAX_RESOLUTION_CACHE_ENTRY_BYTES
+        || Buffer.byteLength(serialized, 'utf8') > MAX_RESOLUTION_CACHE_ENTRY_BYTES) {
+        return;
+      }
       const normalizedMaxEntries = normalizeMaxEntries(maxEntries);
       this.maybePrune(normalizedMaxEntries);
-      this.writeTransaction(String(key), serialized, expiresAt, normalizedMaxEntries);
+      this.writeTransaction(normalizedKey, serialized, expiresAt, normalizedMaxEntries);
     } catch (error) {
+      if (isTransientSqliteError(error)) {
+        this.logTransientFailure(error);
+        return;
+      }
       this.disable(error);
     }
+  }
+
+  logTransientFailure(error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`[ResolutionCache] Persistent operation skipped after transient SQLite error: ${message}`);
   }
 
   disable(error) {
@@ -205,7 +245,9 @@ function createPersistentCache(options = {}) {
 module.exports = {
   DEFAULT_RESOLUTION_CACHE_FILE,
   DEFAULT_RESOLUTION_CACHE_MAX_ENTRIES,
+  MAX_RESOLUTION_CACHE_ENTRY_BYTES,
   RESOLUTION_CACHE_SCHEMA_VERSION,
+  SQLITE_BUSY_TIMEOUT_MS,
   ResolutionCacheStore,
   createPersistentCache,
 };

--- a/backend/shared/resolution-cache-store.test.js
+++ b/backend/shared/resolution-cache-store.test.js
@@ -8,9 +8,15 @@ const Database = require('better-sqlite3');
 const { cacheGet, cacheSet } = require('./api-utils');
 const {
   DEFAULT_RESOLUTION_CACHE_FILE,
+  MAX_RESOLUTION_CACHE_ENTRY_BYTES,
   RESOLUTION_CACHE_SCHEMA_VERSION,
   createPersistentCache,
 } = require('./resolution-cache-store');
+const {
+  createReferenceResolver,
+  RESOLUTION_NEGATIVE_CACHE_MS,
+} = require('./reference-utils');
+const { toSearchLang } = require('./api-utils');
 
 function withTempCacheDir(callback) {
   const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legalviz-resolution-cache-'));
@@ -24,6 +30,33 @@ function withTempCacheDir(callback) {
 function closeCache(cache) {
   cache.persistentStore.close();
 }
+
+test('unresolved reference payloads use the short TTL while positive results keep the long TTL', async () => {
+  const cacheWrites = [];
+  const resolver = createReferenceResolver({
+    EURLEX_BASE: 'https://eur-lex.europa.eu',
+    RESOLUTION_CACHE_MS: 24 * 60 * 60 * 1000,
+    TIMEOUT_MS: 1_000,
+    cacheGet: () => null,
+    cacheSet: (...args) => cacheWrites.push(args),
+    resolutionCache: new Map(),
+    toSearchLang,
+  });
+
+  const unresolved = await resolver.resolveEurlexUrl(
+    'https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=unknown:reference',
+    'ENG',
+  );
+  assert.equal(unresolved.resolved, null);
+  assert.equal(cacheWrites.at(-1)[3], RESOLUTION_NEGATIVE_CACHE_MS);
+
+  const resolved = await resolver.resolveEurlexUrl(
+    'https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679',
+    'ENG',
+  );
+  assert.equal(resolved.resolved.celex, '32016R0679');
+  assert.equal(cacheWrites.at(-1)[3], 24 * 60 * 60 * 1000);
+});
 
 test('a value written before a simulated restart is served from the durable cache', () => {
   withTempCacheDir((cacheDir) => {
@@ -120,5 +153,47 @@ test('a schema-version mismatch resets the cache table instead of serving stale 
     const finalProcessCache = createPersistentCache({ cacheDir });
     assert.deepEqual(cacheGet(finalProcessCache, 'amendments:fresh'), { fresh: true });
     closeCache(finalProcessCache);
+  });
+});
+
+test('a transient SQLite busy error does not disable the durable store', () => {
+  withTempCacheDir((cacheDir) => {
+    const cache = createPersistentCache({ cacheDir });
+    const originalWriteTransaction = cache.persistentStore.writeTransaction;
+    const busyError = Object.assign(new Error('database is busy'), { code: 'SQLITE_BUSY' });
+    cache.persistentStore.writeTransaction = () => {
+      throw busyError;
+    };
+
+    assert.doesNotThrow(() => cacheSet(cache, 'busy', { memoryOnly: true }, 60_000));
+    assert.equal(cache.persistentStore.available, true);
+    assert.deepEqual(cacheGet(cache, 'busy'), { memoryOnly: true });
+
+    cache.persistentStore.writeTransaction = originalWriteTransaction;
+    cacheSet(cache, 'durable-after-busy', { durable: true }, 60_000);
+    closeCache(cache);
+
+    const restartedCache = createPersistentCache({ cacheDir });
+    assert.deepEqual(cacheGet(restartedCache, 'durable-after-busy'), { durable: true });
+    closeCache(restartedCache);
+  });
+});
+
+test('oversized keys and values remain in memory but skip persistence', () => {
+  withTempCacheDir((cacheDir) => {
+    const cache = createPersistentCache({ cacheDir });
+    const oversizedKey = 'k'.repeat(MAX_RESOLUTION_CACHE_ENTRY_BYTES + 1);
+    const oversizedValue = { data: 'v'.repeat(MAX_RESOLUTION_CACHE_ENTRY_BYTES) };
+
+    cacheSet(cache, oversizedKey, { keyTooLarge: true }, 60_000);
+    cacheSet(cache, 'value-too-large', oversizedValue, 60_000);
+    assert.deepEqual(cacheGet(cache, oversizedKey), { keyTooLarge: true });
+    assert.deepEqual(cacheGet(cache, 'value-too-large'), oversizedValue);
+    closeCache(cache);
+
+    const restartedCache = createPersistentCache({ cacheDir });
+    assert.equal(cacheGet(restartedCache, oversizedKey), null);
+    assert.equal(cacheGet(restartedCache, 'value-too-large'), null);
+    closeCache(restartedCache);
   });
 });

--- a/backend/shared/resolution-cache-store.test.js
+++ b/backend/shared/resolution-cache-store.test.js
@@ -1,0 +1,124 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const Database = require('better-sqlite3');
+
+const { cacheGet, cacheSet } = require('./api-utils');
+const {
+  DEFAULT_RESOLUTION_CACHE_FILE,
+  RESOLUTION_CACHE_SCHEMA_VERSION,
+  createPersistentCache,
+} = require('./resolution-cache-store');
+
+function withTempCacheDir(callback) {
+  const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legalviz-resolution-cache-'));
+  try {
+    return callback(cacheDir);
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
+}
+
+function closeCache(cache) {
+  cache.persistentStore.close();
+}
+
+test('a value written before a simulated restart is served from the durable cache', () => {
+  withTempCacheDir((cacheDir) => {
+    const firstProcessCache = createPersistentCache({ cacheDir });
+    const value = { results: [{ celex: '32016R0679' }], nested: { ok: true } };
+    cacheSet(firstProcessCache, 'metadata:32016R0679', value, 60_000);
+    closeCache(firstProcessCache);
+
+    const restartedProcessCache = createPersistentCache({ cacheDir });
+    assert.deepEqual(cacheGet(restartedProcessCache, 'metadata:32016R0679'), value);
+    closeCache(restartedProcessCache);
+  });
+});
+
+test('expired durable values are not served and are pruned', () => {
+  withTempCacheDir((cacheDir) => {
+    const firstProcessCache = createPersistentCache({ cacheDir });
+    cacheSet(firstProcessCache, 'case-law:expired', { stale: true }, 60_000);
+    closeCache(firstProcessCache);
+
+    const databasePath = path.join(cacheDir, DEFAULT_RESOLUTION_CACHE_FILE);
+    const database = new Database(databasePath);
+    database.prepare('UPDATE resolution_cache SET expires_at = ?').run(Date.now() - 1);
+    database.close();
+
+    const restartedProcessCache = createPersistentCache({ cacheDir });
+    assert.equal(cacheGet(restartedProcessCache, 'case-law:expired'), null);
+    closeCache(restartedProcessCache);
+
+    const prunedDatabase = new Database(path.join(cacheDir, DEFAULT_RESOLUTION_CACHE_FILE), { readonly: true });
+    assert.equal(prunedDatabase.prepare('SELECT COUNT(*) AS count FROM resolution_cache').get().count, 0);
+    prunedDatabase.close();
+  });
+});
+
+test('an unavailable cache directory degrades to memory-only without throwing', () => {
+  withTempCacheDir((cacheDir) => {
+    const directoryPath = path.join(cacheDir, 'not-a-directory');
+    fs.writeFileSync(directoryPath, 'occupied');
+    const cache = createPersistentCache({ cacheDir: directoryPath });
+
+    assert.doesNotThrow(() => cacheSet(cache, 'procedure:32016R0679', { memoryOnly: true }, 60_000));
+    assert.deepEqual(cacheGet(cache, 'procedure:32016R0679'), { memoryOnly: true });
+    assert.equal(cache.persistentStore.available, false);
+    closeCache(cache);
+  });
+});
+
+test('a corrupt SQLite file degrades to memory-only without throwing', () => {
+  withTempCacheDir((cacheDir) => {
+    fs.writeFileSync(path.join(cacheDir, DEFAULT_RESOLUTION_CACHE_FILE), 'not a SQLite database');
+    const cache = createPersistentCache({ cacheDir });
+
+    assert.doesNotThrow(() => cacheSet(cache, 'consolidated:32016R0679', { memoryOnly: true }, 60_000));
+    assert.deepEqual(cacheGet(cache, 'consolidated:32016R0679'), { memoryOnly: true });
+    assert.equal(cache.persistentStore.available, false);
+    closeCache(cache);
+  });
+});
+
+test('the durable cache evicts its oldest rows at the configured entry limit', () => {
+  withTempCacheDir((cacheDir) => {
+    const cache = createPersistentCache({ cacheDir });
+    cacheSet(cache, 'oldest', { value: 1 }, 60_000, 2);
+    cacheSet(cache, 'middle', { value: 2 }, 60_000, 2);
+    cacheSet(cache, 'newest', { value: 3 }, 60_000, 2);
+    closeCache(cache);
+
+    const restartedCache = createPersistentCache({ cacheDir });
+    assert.equal(cacheGet(restartedCache, 'oldest'), null);
+    assert.deepEqual(cacheGet(restartedCache, 'middle'), { value: 2 });
+    assert.deepEqual(cacheGet(restartedCache, 'newest'), { value: 3 });
+    closeCache(restartedCache);
+  });
+});
+
+test('a schema-version mismatch resets the cache table instead of serving stale rows', () => {
+  withTempCacheDir((cacheDir) => {
+    const firstProcessCache = createPersistentCache({ cacheDir });
+    cacheSet(firstProcessCache, 'amendments:stale', { stale: true }, 60_000);
+    closeCache(firstProcessCache);
+
+    const databasePath = path.join(cacheDir, DEFAULT_RESOLUTION_CACHE_FILE);
+    const database = new Database(databasePath);
+    database.pragma(`user_version = ${RESOLUTION_CACHE_SCHEMA_VERSION + 1}`);
+    database.close();
+
+    const restartedProcessCache = createPersistentCache({ cacheDir });
+    assert.equal(cacheGet(restartedProcessCache, 'amendments:stale'), null);
+
+    cacheSet(restartedProcessCache, 'amendments:fresh', { fresh: true }, 60_000);
+    closeCache(restartedProcessCache);
+
+    const finalProcessCache = createPersistentCache({ cacheDir });
+    assert.deepEqual(cacheGet(finalProcessCache, 'amendments:fresh'), { fresh: true });
+    closeCache(finalProcessCache);
+  });
+});


### PR DESCRIPTION
## What

`resolutionCache` was a plain in-memory `Map` (24h TTL, 10k entries, FIFO). Every restart and every deploy wiped it, so the next visitor's law view went back to `publications.europa.eu` for metadata, amendments, consolidated versions, implementing acts, procedure links and case law. Upstream call rate scaled with our restart frequency as much as with traffic — which is the part that gets worse as we grow, independent of how many endpoints the frontend calls.

It is now read-through: memory → `resolution-cache.sqlite` under `CACHE_DIR` → Cellar. A restart re-warms from disk.

## Design notes

- **Separate from `data.sqlite`.** That file is built offline and opened read-only, so the cache gets its own file and its own `RESOLUTION_CACHE_SCHEMA_VERSION`; a mismatch drops and recreates only this table. `SQLITE_SCHEMA_VERSION` is untouched. AGENTS.md's version table has a row for the new constant.
- **No call-site churn.** `cacheGet`/`cacheSet` keep their signatures — the store rides along as a non-enumerable `persistentStore` property on the Map — so the ~10 call sites in `reference-utils.js` and the shared CLI code are unchanged.
- **Best-effort, like `fulltextAvailable`/`definitionsAvailable`.** A missing native module, unwritable `CACHE_DIR`, corrupt file, or any SQLite error logs once, disables the store, and leaves the in-memory Map serving requests. The deployed container's disk is ephemeral (`backend/Dockerfile` just `mkdir -p law-cache`), so a cold start with no file is the normal case, not an error.
- **Sweeps stay off the request path.** Expired rows are pruned on a 60s timer and at open, not per read/write — reads filter on `expires_at`, so the sweep only bounds how long dead rows hold entry budget. `journal_mode = WAL` keeps a writer from blocking readers. Count-based FIFO eviction mirrors the Map's bound.

## Tests

`backend/shared/resolution-cache-store.test.js` — restart persistence, expiry, unwritable directory, corrupt file, eviction bound, schema-version reset. All use temp dirs.

## Verification

- `npm run lint` — clean
- `npm test` — 608 frontend, 571 backend passing (2 skipped)

## Note

This does not reduce the *number* of endpoints the frontend calls; it decouples upstream Cellar calls from process lifetime. Endpoint consolidation is a separate question.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E3wd6oBm3ooRTEGG3ZYH7t)_