### PR TITLE
Make the FMX cache trustworthy and skip Cellar re-probes on a disk hit

### DIFF
--- a/backend/search/reenrich-cache.js
+++ b/backend/search/reenrich-cache.js
@@ -42,7 +42,18 @@ function readCache(cachePath) {
 }
 
 function writeCache(cachePath, payload) {
-  fs.writeFileSync(cachePath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+  const tempPath = `${cachePath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    fs.writeFileSync(tempPath, `${JSON.stringify(payload, null, 2)}\n`, "utf8");
+    fs.renameSync(tempPath, cachePath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(tempPath);
+    } catch {
+      // The write may have failed before creating the temporary file.
+    }
+    throw error;
+  }
 }
 
 function isEligible(record, options) {

--- a/backend/shared/fmx-service.js
+++ b/backend/shared/fmx-service.js
@@ -6,6 +6,23 @@ const { ClientError } = require('./api-utils');
 
 /** Trailing `.<LANG>.fmx4` on a Cellar manifestation URI, any 3-letter language. */
 const FMX4_ANY_LANG = /\.[A-Z]{3}\.fmx4$/;
+const FMX_PATH_MEMO_FILE = 'fmx-paths-v1.json';
+const CACHE_PROBE_BYTES = 64 * 1024;
+
+function writeFileAtomically(filePath, data, encoding) {
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    fs.writeFileSync(tempPath, data, encoding);
+    fs.renameSync(tempPath, filePath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(tempPath);
+    } catch {
+      // The write may have failed before creating the temporary file.
+    }
+    throw error;
+  }
+}
 
 /** True when the system `unzip` binary is available. */
 const HAS_SYSTEM_UNZIP = (() => {
@@ -23,6 +40,171 @@ function createFmxService({
   STORAGE_LIMIT_MB,
   TIMEOUT_MS,
 }) {
+  const cacheRoot = path.resolve(FMX_DIR);
+  const servePathMemoPath = path.join(FMX_DIR, FMX_PATH_MEMO_FILE);
+
+  function isFmxTempFile(filename) {
+    return /(?:\.xml|\.zip)\.\d+(?:\.\d+)?\.tmp$/.test(filename)
+      || (filename.startsWith(`${FMX_PATH_MEMO_FILE}.`)
+        && /^\d+(?:\.\d+)?\.tmp$/.test(filename.slice(FMX_PATH_MEMO_FILE.length + 1)));
+  }
+
+  function cleanupTempFiles() {
+    try {
+      for (const filename of fs.readdirSync(FMX_DIR).filter(isFmxTempFile)) {
+        try {
+          fs.unlinkSync(path.join(FMX_DIR, filename));
+        } catch {
+          // A concurrent writer may have already renamed or removed it.
+        }
+      }
+    } catch {
+      // The cache directory may not exist until the first download.
+    }
+  }
+
+  function readFileEdges(filePath) {
+    let fd;
+    try {
+      const stat = fs.statSync(filePath);
+      if (!stat.isFile() || stat.size === 0) return null;
+
+      fd = fs.openSync(filePath, 'r');
+      const length = Math.min(CACHE_PROBE_BYTES, stat.size);
+      const head = Buffer.alloc(length);
+      const tail = Buffer.alloc(length);
+      fs.readSync(fd, head, 0, length, 0);
+      fs.readSync(fd, tail, 0, length, Math.max(0, stat.size - length));
+      return { stat, head, tail };
+    } catch {
+      return null;
+    } finally {
+      if (fd !== undefined) {
+        try {
+          fs.closeSync(fd);
+        } catch {
+          // Nothing useful can be done if a best-effort integrity probe cannot close.
+        }
+      }
+    }
+  }
+
+  /**
+   * Validate the cheap structural markers that an interrupted write cannot
+   * leave behind. This deliberately probes only both ends of the file: the
+   * full XML is parsed by the caller after prepareLawPayload returns, while a
+   * zero-byte or cut-off cache must never be mistaken for a hit here.
+   */
+  function isValidCachedFile(filePath, existingEdges = null) {
+    const edges = existingEdges || readFileEdges(filePath);
+    if (!edges) return false;
+
+    if (filePath.endsWith('.zip')) {
+      return [
+        Buffer.from([0x50, 0x4b, 0x05, 0x06]), // end of central directory
+        Buffer.from([0x50, 0x4b, 0x06, 0x06]), // ZIP64 end of central directory
+      ].some((signature) => edges.tail.includes(signature));
+    }
+
+    const head = edges.head.toString('utf8').replace(/^\uFEFF/, '').trimStart();
+    const tail = edges.tail.toString('utf8').trimEnd();
+    if (!head.startsWith('<') || !tail.endsWith('>')) return false;
+
+    if (filePath.endsWith('.combined.xml')) {
+      return /<COMBINED\.FMX(?:\s[^>]*)?>/.test(head)
+        && /<\/COMBINED\.FMX>\s*$/.test(tail);
+    }
+
+    const rootMatch = head.match(/<(?![!?/])([A-Za-z_][\w:.-]*)(?:\s[^<>]*)?>/);
+    if (!rootMatch) return false;
+    if (/\/\s*>$/.test(rootMatch[0])) return true;
+    const rootName = rootMatch[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`</${rootName}\\s*>\\s*$`).test(tail);
+  }
+
+  function loadServePathMemo() {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(servePathMemoPath, 'utf8'));
+      if (!parsed || parsed.version !== 1 || !parsed.entries || typeof parsed.entries !== 'object') {
+        return {};
+      }
+      return parsed.entries;
+    } catch {
+      return {};
+    }
+  }
+
+  let servePathMemo;
+
+  function persistServePathMemo() {
+    try {
+      fs.mkdirSync(FMX_DIR, { recursive: true });
+      writeFileAtomically(
+        servePathMemoPath,
+        JSON.stringify({ version: 1, entries: servePathMemo }, null, 2),
+        'utf8'
+      );
+    } catch {
+      // The on-disk memo is an optimization; a failed persistence must not
+      // make an otherwise valid download fail.
+    }
+  }
+
+  function memoKey(celex, lang) {
+    return `${celex}\u0000${lang}`;
+  }
+
+  function resolveMemoPath(relativePath) {
+    if (typeof relativePath !== 'string' || relativePath.length === 0) return null;
+    const candidate = path.resolve(FMX_DIR, relativePath);
+    const relative = path.relative(cacheRoot, candidate);
+    if (!relative || relative.startsWith('..') || path.isAbsolute(relative)) return null;
+    return candidate;
+  }
+
+  function getMemoizedPayload(celex, lang) {
+    const key = memoKey(celex, lang);
+    const entry = servePathMemo[key];
+    const relativePath = typeof entry === 'string' ? entry : entry?.path;
+    const servePath = resolveMemoPath(relativePath);
+    const hasWrongIdentity = entry && typeof entry === 'object'
+      && (entry.celex !== celex || entry.lang !== lang);
+    const edges = servePath && readFileEdges(servePath);
+    if (hasWrongIdentity
+      || !servePath
+      || !edges
+      || !isValidCachedFile(servePath, edges)
+      || (entry && typeof entry === 'object' && entry.size !== undefined && entry.size !== edges.stat.size)) {
+      if (Object.prototype.hasOwnProperty.call(servePathMemo, key)) {
+        delete servePathMemo[key];
+        persistServePathMemo();
+      }
+      return null;
+    }
+
+    return {
+      type: entry?.type === 'zip' ? 'zip' : 'xml',
+      files: [{ filename: path.basename(servePath), path: servePath, cached: true, size: edges.stat.size }],
+      servePath,
+    };
+  }
+
+  function rememberServePath(celex, lang, type, servePath) {
+    const relativePath = path.relative(cacheRoot, path.resolve(servePath));
+    if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) return;
+    servePathMemo[memoKey(celex, lang)] = {
+      celex,
+      lang,
+      path: relativePath,
+      type,
+      size: fs.statSync(servePath).size,
+    };
+    persistServePathMemo();
+  }
+
+  cleanupTempFiles();
+  servePathMemo = loadServePathMemo();
+
   function getCacheSizeMB() {
     try {
       const files = fs.readdirSync(FMX_DIR).filter((filename) => filename.endsWith('.xml') || filename.endsWith('.zip'));
@@ -51,6 +233,7 @@ function createFmxService({
   }
 
   function evictOldestIfNeeded(requiredMB) {
+    cleanupTempFiles();
     const currentMB = getCacheSizeMB();
     if (currentMB + requiredMB <= STORAGE_LIMIT_MB) {
       return { evicted: 0 };
@@ -162,7 +345,7 @@ function createFmxService({
 
   function combineZipToXml(zipPath) {
     const combinedPath = zipPath.replace(/\.zip$/, '.combined.xml');
-    if (fs.existsSync(combinedPath)) return combinedPath;
+    if (isValidCachedFile(combinedPath)) return combinedPath;
 
     if (HAS_SYSTEM_UNZIP) {
       return combineZipWithUnzip(zipPath, combinedPath);
@@ -198,7 +381,10 @@ function createFmxService({
     }
     parts.push('</COMBINED.FMX>');
 
-    fs.writeFileSync(combinedPath, parts.join('\n'), 'utf8');
+    writeFileAtomically(combinedPath, parts.join('\n'), 'utf8');
+    if (!isValidCachedFile(combinedPath)) {
+      throw new Error(`Combined ZIP output failed integrity check: ${combinedPath}`);
+    }
     console.log(`[ZIP] Combined ${physRefs.length} files from ${path.basename(zipPath)} -> ${path.basename(combinedPath)}`);
     return combinedPath;
   }
@@ -222,7 +408,10 @@ function createFmxService({
     }
     parts.push('</COMBINED.FMX>');
 
-    fs.writeFileSync(combinedPath, parts.join('\n'), 'utf8');
+    writeFileAtomically(combinedPath, parts.join('\n'), 'utf8');
+    if (!isValidCachedFile(combinedPath)) {
+      throw new Error(`Combined ZIP output failed integrity check: ${combinedPath}`);
+    }
     console.log(`[ZIP] Combined ${physRefs.length} files from ${path.basename(zipPath)} -> ${path.basename(combinedPath)}`);
     return combinedPath;
   }
@@ -283,7 +472,7 @@ function createFmxService({
         const filename = url.split('/').pop();
         const destPath = path.join(FMX_DIR, filename);
 
-        if (fs.existsSync(destPath)) {
+        if (isValidCachedFile(destPath)) {
           const stat = fs.statSync(destPath);
           downloaded.push({ filename, path: destPath, cached: true, size: stat.size });
         } else {
@@ -309,7 +498,10 @@ function createFmxService({
         if (!response.ok) throw new Error(`HTTP ${response.status} downloading ${file.url}`);
 
         const buffer = Buffer.from(await response.arrayBuffer());
-        fs.writeFileSync(file.path, buffer);
+        writeFileAtomically(file.path, buffer);
+        if (!isValidCachedFile(file.path)) {
+          throw new Error(`Downloaded Formex file failed integrity check: ${file.filename}`);
+        }
         file.size = buffer.length;
       }
 
@@ -336,11 +528,15 @@ function createFmxService({
   }
 
   async function prepareLawPayload(celex, lang) {
-    console.log(`[API] Fetching ${celex} (lang: ${lang})...`);
-    const { type, files } = await downloadFmx(celex, lang);
+    const requestedLang = lang || 'ENG';
+    const memoized = getMemoizedPayload(celex, requestedLang);
+    if (memoized) return memoized;
+
+    console.log(`[API] Fetching ${celex} (lang: ${requestedLang})...`);
+    const { type, files } = await downloadFmx(celex, requestedLang);
 
     if (files.length === 0) {
-      throw new ClientError(`No FMX files found for ${celex}`, 404, 'fmx_not_found', { celex, lang });
+      throw new ClientError(`No FMX files found for ${celex}`, 404, 'fmx_not_found', { celex, lang: requestedLang });
     }
 
     let servePath;
@@ -348,7 +544,7 @@ function createFmxService({
       servePath = combineZipToXml(files[0].path);
     } else if (files.length > 1) {
       const combinedPath = files[0].path.replace(/\.xml$/, '.combined.xml');
-      if (!fs.existsSync(combinedPath)) {
+      if (!isValidCachedFile(combinedPath)) {
         const parts = ['<?xml version="1.0" encoding="UTF-8"?>', '<COMBINED.FMX>'];
         for (const file of files) {
           let xml = fs.readFileSync(file.path, 'utf8');
@@ -356,7 +552,10 @@ function createFmxService({
           parts.push(xml);
         }
         parts.push('</COMBINED.FMX>');
-        fs.writeFileSync(combinedPath, parts.join('\n'), 'utf8');
+        writeFileAtomically(combinedPath, parts.join('\n'), 'utf8');
+        if (!isValidCachedFile(combinedPath)) {
+          throw new Error(`Combined XML output failed integrity check: ${combinedPath}`);
+        }
         console.log(`[API] Combined ${files.length} XML files -> ${path.basename(combinedPath)}`);
       }
       servePath = combinedPath;
@@ -364,11 +563,13 @@ function createFmxService({
       servePath = files[0].path;
     }
 
-    if (!fs.existsSync(servePath)) {
-      throw new ClientError('Cached file missing', 404, 'cached_file_missing', { celex, lang });
+    if (!isValidCachedFile(servePath)) {
+      throw new ClientError('Cached file missing or corrupt', 404, 'cached_file_invalid', { celex, lang: requestedLang });
     }
 
-    return { type, files, servePath };
+    const result = { type, files, servePath };
+    rememberServePath(celex, requestedLang, type, servePath);
+    return result;
   }
 
   function sendLawResponse(res, servePath) {

--- a/backend/shared/fmx-service.js
+++ b/backend/shared/fmx-service.js
@@ -8,6 +8,13 @@ const { ClientError } = require('./api-utils');
 const FMX4_ANY_LANG = /\.[A-Z]{3}\.fmx4$/;
 const FMX_PATH_MEMO_FILE = 'fmx-paths-v1.json';
 const CACHE_PROBE_BYTES = 64 * 1024;
+// Re-probe twice a day: normal traffic stays off Cellar for hours, while a
+// newly published corrigendum is picked up without leaving stale legal text
+// pinned for the life of the cache directory.
+const FMX_PATH_MEMO_TTL_MS = 6 * 60 * 60 * 1000;
+// Writers normally finish in seconds; an hour leaves ample room for a slow
+// download while still cleaning up temp files left by crashed processes.
+const FMX_TEMP_FILE_MAX_AGE_MS = 60 * 60 * 1000;
 
 function writeFileAtomically(filePath, data, encoding) {
   const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
@@ -51,11 +58,14 @@ function createFmxService({
 
   function cleanupTempFiles() {
     try {
+      const cutoff = Date.now() - FMX_TEMP_FILE_MAX_AGE_MS;
       for (const filename of fs.readdirSync(FMX_DIR).filter(isFmxTempFile)) {
         try {
-          fs.unlinkSync(path.join(FMX_DIR, filename));
+          const tempPath = path.join(FMX_DIR, filename);
+          if (fs.statSync(tempPath).mtimeMs >= cutoff) continue;
+          fs.unlinkSync(tempPath);
         } catch {
-          // A concurrent writer may have already renamed or removed it.
+          // A concurrent writer may have already renamed, removed, or replaced it.
         }
       }
     } catch {
@@ -165,16 +175,25 @@ function createFmxService({
   function getMemoizedPayload(celex, lang) {
     const key = memoKey(celex, lang);
     const entry = servePathMemo[key];
+    const now = Date.now();
+    const isMemoEntry = Boolean(entry) && typeof entry === 'object' && !Array.isArray(entry);
+    const hasFreshMetadata = isMemoEntry
+      && typeof entry.fmx4Uri === 'string'
+      && entry.fmx4Uri.length > 0
+      && Number.isFinite(entry.writtenAt)
+      && entry.writtenAt <= now
+      && now - entry.writtenAt <= FMX_PATH_MEMO_TTL_MS;
     const relativePath = typeof entry === 'string' ? entry : entry?.path;
     const servePath = resolveMemoPath(relativePath);
-    const hasWrongIdentity = entry && typeof entry === 'object'
+    const hasWrongIdentity = isMemoEntry
       && (entry.celex !== celex || entry.lang !== lang);
     const edges = servePath && readFileEdges(servePath);
-    if (hasWrongIdentity
+    if (!hasFreshMetadata
+      || hasWrongIdentity
       || !servePath
       || !edges
       || !isValidCachedFile(servePath, edges)
-      || (entry && typeof entry === 'object' && entry.size !== undefined && entry.size !== edges.stat.size)) {
+      || (isMemoEntry && entry.size !== edges.stat.size)) {
       if (Object.prototype.hasOwnProperty.call(servePathMemo, key)) {
         delete servePathMemo[key];
         persistServePathMemo();
@@ -189,7 +208,7 @@ function createFmxService({
     };
   }
 
-  function rememberServePath(celex, lang, type, servePath) {
+  function rememberServePath(celex, lang, type, servePath, fmx4Uri) {
     const relativePath = path.relative(cacheRoot, path.resolve(servePath));
     if (!relativePath || relativePath.startsWith('..') || path.isAbsolute(relativePath)) return;
     servePathMemo[memoKey(celex, lang)] = {
@@ -198,6 +217,8 @@ function createFmxService({
       path: relativePath,
       type,
       size: fs.statSync(servePath).size,
+      fmx4Uri,
+      writtenAt: Date.now(),
     };
     persistServePathMemo();
   }
@@ -518,7 +539,7 @@ function createFmxService({
         console.log(`[Cache] Post-download eviction removed ${postWriteEvicted} file(s), freed ${postWriteFreedMB} MB`);
       }
 
-      return { type, files: downloaded };
+      return { fmx4Uri, type, files: downloaded };
     })().finally(() => {
       inFlightDownloads.delete(lockKey);
     });
@@ -533,7 +554,7 @@ function createFmxService({
     if (memoized) return memoized;
 
     console.log(`[API] Fetching ${celex} (lang: ${requestedLang})...`);
-    const { type, files } = await downloadFmx(celex, requestedLang);
+    const { fmx4Uri, type, files } = await downloadFmx(celex, requestedLang);
 
     if (files.length === 0) {
       throw new ClientError(`No FMX files found for ${celex}`, 404, 'fmx_not_found', { celex, lang: requestedLang });
@@ -568,7 +589,7 @@ function createFmxService({
     }
 
     const result = { type, files, servePath };
-    rememberServePath(celex, requestedLang, type, servePath);
+    rememberServePath(celex, requestedLang, type, servePath, fmx4Uri);
     return result;
   }
 

--- a/backend/shared/fmx-service.test.js
+++ b/backend/shared/fmx-service.test.js
@@ -19,6 +19,11 @@ function makeCacheDir() {
   return dir;
 }
 
+function ageFile(filePath, ageMs = 2 * 60 * 60 * 1000) {
+  const old = new Date(Date.now() - ageMs);
+  fs.utimesSync(filePath, old, old);
+}
+
 function makeService(dir = makeCacheDir(), storageLimitMB = 100) {
   return createFmxService({
     CELLAR_BASE,
@@ -207,6 +212,7 @@ test('orphaned temporary cache files are cleaned when the service starts', () =>
   const dir = makeCacheDir();
   const tempPath = path.join(dir, 'L_202401689.ENG.fmx4.1.xml.12345.tmp');
   fs.writeFileSync(tempPath, 'partial write');
+  ageFile(tempPath);
 
   makeService(dir);
 
@@ -218,6 +224,7 @@ test('orphaned temporary cache files are cleaned before an eviction pass', async
   const service = makeService(dir);
   const tempPath = path.join(dir, 'L_202401689.ENG.fmx4.1.xml.12345.tmp');
   fs.writeFileSync(tempPath, 'partial write');
+  ageFile(tempPath);
 
   const fmx4Uri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4`;
   const downloadUri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4.1.xml`;
@@ -232,6 +239,20 @@ test('orphaned temporary cache files are cleaned before an eviction pass', async
   await withMockFetch(fetchImpl, () => service.prepareLawPayload('32024R1689', 'ENG'));
 
   assert.equal(fs.existsSync(tempPath), false);
+});
+
+test('fresh temporary cache files survive cleanup while old ones are removed', () => {
+  const dir = makeCacheDir();
+  const freshPath = path.join(dir, 'fresh.fmx4.1.xml.12345.tmp');
+  const oldPath = path.join(dir, 'old.fmx4.1.xml.12345.tmp');
+  fs.writeFileSync(freshPath, 'live write');
+  fs.writeFileSync(oldPath, 'leaked write');
+  ageFile(oldPath);
+
+  makeService(dir);
+
+  assert.equal(fs.existsSync(freshPath), true);
+  assert.equal(fs.existsSync(oldPath), false);
 });
 
 test('a persisted serve-path memo avoids Cellar probes after restart', async () => {
@@ -257,6 +278,79 @@ test('a persisted serve-path memo avoids Cellar probes after restart', async () 
     const second = await secondService.prepareLawPayload('32024R1689', 'ENG');
     assert.equal(second.servePath, first.servePath);
   });
+});
+
+test('an expired serve-path memo re-probes Cellar and refreshes a changed manifestation', async () => {
+  const dir = makeCacheDir();
+  const firstFmx4Uri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4`;
+  const firstDownloadUri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4.1.xml`;
+  const firstFetch = prepareFetch({
+    fmx4Uri: firstFmx4Uri,
+    downloadUrls: [firstDownloadUri],
+    xml: '<?xml version="1.0"?><FMX><ARTICLE>old</ARTICLE></FMX>',
+  });
+  const firstService = makeService(dir);
+  await withMockFetch(firstFetch.fetchImpl, () => (
+    firstService.prepareLawPayload('32024R1689', 'ENG')
+  ));
+
+  const memoPath = path.join(dir, 'fmx-paths-v1.json');
+  const memo = JSON.parse(fs.readFileSync(memoPath, 'utf8'));
+  memo.entries['32024R1689\u0000ENG'].writtenAt = Date.now() - (7 * 60 * 60 * 1000);
+  fs.writeFileSync(memoPath, JSON.stringify(memo));
+
+  const refreshedFmx4Uri = `${CELLAR_BASE}/oj/L_202608260.ENG.fmx4`;
+  const refreshedDownloadUri = `${CELLAR_BASE}/oj/L_202608260.ENG.fmx4.1.xml`;
+  const secondFetch = prepareFetch({
+    fmx4Uri: refreshedFmx4Uri,
+    downloadUrls: [refreshedDownloadUri],
+    xml: '<?xml version="1.0"?><FMX><ARTICLE>current</ARTICLE></FMX>',
+  });
+  const secondService = makeService(dir);
+  const result = await withMockFetch(secondFetch.fetchImpl, () => (
+    secondService.prepareLawPayload('32024R1689', 'ENG')
+  ));
+
+  assert.deepEqual(secondFetch.calls.map((call) => call.method), ['GET', 'GET', 'HEAD', 'GET']);
+  assert.match(fs.readFileSync(result.servePath, 'utf8'), /current/);
+  assert.equal(fs.existsSync(path.join(dir, path.basename(firstDownloadUri))), true);
+
+  const refreshedMemo = JSON.parse(fs.readFileSync(memoPath, 'utf8'));
+  assert.equal(refreshedMemo.entries['32024R1689\u0000ENG'].fmx4Uri, refreshedFmx4Uri);
+  assert.equal(Number.isFinite(refreshedMemo.entries['32024R1689\u0000ENG'].writtenAt), true);
+});
+
+test('a legacy serve-path memo without manifestation URI or timestamp is not accepted', async () => {
+  const dir = makeCacheDir();
+  const fmx4Uri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4`;
+  const downloadUri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4.1.xml`;
+  const firstFetch = prepareFetch({
+    fmx4Uri,
+    downloadUrls: [downloadUri],
+    xml: '<?xml version="1.0"?><FMX><ARTICLE>1</ARTICLE></FMX>',
+  });
+  const firstService = makeService(dir);
+  await withMockFetch(firstFetch.fetchImpl, () => (
+    firstService.prepareLawPayload('32024R1689', 'ENG')
+  ));
+
+  const memoPath = path.join(dir, 'fmx-paths-v1.json');
+  const memo = JSON.parse(fs.readFileSync(memoPath, 'utf8'));
+  delete memo.entries['32024R1689\u0000ENG'].fmx4Uri;
+  delete memo.entries['32024R1689\u0000ENG'].writtenAt;
+  fs.writeFileSync(memoPath, JSON.stringify(memo));
+
+  const secondFetch = prepareFetch({
+    fmx4Uri,
+    downloadUrls: [downloadUri],
+    xml: '<?xml version="1.0"?><FMX><ARTICLE>2</ARTICLE></FMX>',
+  });
+  const secondService = makeService(dir);
+  await withMockFetch(secondFetch.fetchImpl, () => (
+    secondService.prepareLawPayload('32024R1689', 'ENG')
+  ));
+
+  assert.deepEqual(secondFetch.calls.map((call) => call.method), ['GET', 'GET']);
 });
 
 test('the serve-path memo keeps languages separate', async () => {

--- a/backend/shared/fmx-service.test.js
+++ b/backend/shared/fmx-service.test.js
@@ -13,13 +13,17 @@ const CELLAR_BASE = 'http://publications.europa.eu/resource';
 // test into the OS temp directory on every run.
 const createdDirs = [];
 
-function makeService() {
+function makeCacheDir() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fmx-service-'));
   createdDirs.push(dir);
+  return dir;
+}
+
+function makeService(dir = makeCacheDir(), storageLimitMB = 100) {
   return createFmxService({
     CELLAR_BASE,
     FMX_DIR: dir,
-    STORAGE_LIMIT_MB: 100,
+    STORAGE_LIMIT_MB: storageLimitMB,
     TIMEOUT_MS: 5000,
   });
 }
@@ -49,6 +53,51 @@ function withCannedRdf(uris, run) {
       global.fetch = originalFetch;
     }
   })();
+}
+
+function responseWithBody(body, headers = {}) {
+  const buffer = Buffer.from(body);
+  return {
+    ok: true,
+    status: 200,
+    text: async () => body,
+    arrayBuffer: async () => buffer.buffer.slice(buffer.byteOffset, buffer.byteOffset + buffer.byteLength),
+    headers: {
+      get: (name) => headers[name.toLowerCase()] || null,
+    },
+  };
+}
+
+function rdfResponse(uris) {
+  const body = uris.map((uri) => `<rdf:resource="${uri}" />`).join('');
+  return responseWithBody(`<rdf:RDF>${body}</rdf:RDF>`);
+}
+
+function withMockFetch(fetchImpl, run) {
+  const originalFetch = global.fetch;
+  global.fetch = fetchImpl;
+  return (async () => {
+    try {
+      return await run();
+    } finally {
+      global.fetch = originalFetch;
+    }
+  })();
+}
+
+function prepareFetch({ fmx4Uri, downloadUrls, xml }) {
+  const calls = [];
+  const fetchImpl = async (url, options = {}) => {
+    const method = options.method || 'GET';
+    calls.push({ method, url });
+    if (calls.length === 1) return rdfResponse([fmx4Uri]);
+    if (calls.length === 2) return rdfResponse(downloadUrls);
+    if (method === 'HEAD') {
+      return responseWithBody('', { 'content-length': String(Buffer.byteLength(xml)) });
+    }
+    return responseWithBody(xml);
+  };
+  return { calls, fetchImpl };
 }
 
 // Every manifestation id format observed in Cellar for real acts. The previous
@@ -106,3 +155,164 @@ test('findFmx4Uri still reports 404 for an act that genuinely has no Formex', as
     (error) => error.statusCode === 404
   );
 });
+
+test('a truncated downloaded part is treated as a miss and replaced', async () => {
+  const dir = makeCacheDir();
+  const fmx4Uri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4`;
+  const downloadUri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4.1.xml`;
+  const filename = path.basename(downloadUri);
+  fs.writeFileSync(path.join(dir, filename), '<?xml version="1.0"?><FMX><ARTICLE>1</ARTICLE>');
+
+  const { calls, fetchImpl } = prepareFetch({
+    fmx4Uri,
+    downloadUrls: [downloadUri],
+    xml: '<?xml version="1.0"?><FMX><ARTICLE>1</ARTICLE></FMX>',
+  });
+  const service = makeService(dir);
+  await withMockFetch(fetchImpl, () => service.prepareLawPayload('32024R1689', 'ENG'));
+
+  assert.deepEqual(calls.map((call) => call.method), ['GET', 'GET', 'HEAD', 'GET']);
+  assert.equal(fs.readFileSync(path.join(dir, filename), 'utf8'), '<?xml version="1.0"?><FMX><ARTICLE>1</ARTICLE></FMX>');
+});
+
+test('a truncated combined XML is rebuilt instead of served', async () => {
+  const dir = makeCacheDir();
+  const fmx4Uri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4`;
+  const downloadUrls = [
+    `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4.1.xml`,
+    `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4.2.xml`,
+  ];
+  const firstPart = path.join(dir, path.basename(downloadUrls[0]));
+  const secondPart = path.join(dir, path.basename(downloadUrls[1]));
+  fs.writeFileSync(firstPart, '<PART>one</PART>');
+  fs.writeFileSync(secondPart, '<PART>two</PART>');
+  fs.writeFileSync(firstPart.replace(/\.xml$/, '.combined.xml'), '<COMBINED.FMX><PART>one</PART>');
+
+  const { calls, fetchImpl } = prepareFetch({
+    fmx4Uri,
+    downloadUrls,
+    xml: '<unused />',
+  });
+  const service = makeService(dir);
+  const result = await withMockFetch(fetchImpl, () => service.prepareLawPayload('32024R1689', 'ENG'));
+
+  assert.deepEqual(calls.map((call) => call.method), ['GET', 'GET']);
+  assert.equal(
+    fs.readFileSync(result.servePath, 'utf8'),
+    '<?xml version="1.0" encoding="UTF-8"?>\n<COMBINED.FMX>\n<PART>one</PART>\n<PART>two</PART>\n</COMBINED.FMX>'
+  );
+});
+
+test('orphaned temporary cache files are cleaned when the service starts', () => {
+  const dir = makeCacheDir();
+  const tempPath = path.join(dir, 'L_202401689.ENG.fmx4.1.xml.12345.tmp');
+  fs.writeFileSync(tempPath, 'partial write');
+
+  makeService(dir);
+
+  assert.equal(fs.existsSync(tempPath), false);
+});
+
+test('orphaned temporary cache files are cleaned before an eviction pass', async () => {
+  const dir = makeCacheDir();
+  const service = makeService(dir);
+  const tempPath = path.join(dir, 'L_202401689.ENG.fmx4.1.xml.12345.tmp');
+  fs.writeFileSync(tempPath, 'partial write');
+
+  const fmx4Uri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4`;
+  const downloadUri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4.1.xml`;
+  const cachedPath = path.join(dir, path.basename(downloadUri));
+  fs.writeFileSync(cachedPath, '<?xml version="1.0"?><FMX><ARTICLE>1</ARTICLE></FMX>');
+  const { fetchImpl } = prepareFetch({
+    fmx4Uri,
+    downloadUrls: [downloadUri],
+    xml: '<unused />',
+  });
+
+  await withMockFetch(fetchImpl, () => service.prepareLawPayload('32024R1689', 'ENG'));
+
+  assert.equal(fs.existsSync(tempPath), false);
+});
+
+test('a persisted serve-path memo avoids Cellar probes after restart', async () => {
+  const dir = makeCacheDir();
+  const fmx4Uri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4`;
+  const downloadUri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4.1.xml`;
+  const firstFetch = prepareFetch({
+    fmx4Uri,
+    downloadUrls: [downloadUri],
+    xml: '<?xml version="1.0"?><FMX><ARTICLE>1</ARTICLE></FMX>',
+  });
+  const firstService = makeService(dir);
+  const first = await withMockFetch(firstFetch.fetchImpl, () => (
+    firstService.prepareLawPayload('32024R1689', 'ENG')
+  ));
+
+  assert.equal(fs.existsSync(path.join(dir, 'fmx-paths-v1.json')), true);
+
+  const secondService = makeService(dir);
+  await withMockFetch(async () => {
+    throw new Error('Cellar should not be queried for a valid memo hit');
+  }, async () => {
+    const second = await secondService.prepareLawPayload('32024R1689', 'ENG');
+    assert.equal(second.servePath, first.servePath);
+  });
+});
+
+test('the serve-path memo keeps languages separate', async () => {
+  const dir = makeCacheDir();
+  const service = makeService(dir);
+  const english = prepareFetch({
+    fmx4Uri: `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4`,
+    downloadUrls: [`${CELLAR_BASE}/oj/L_202401689.ENG.fmx4.1.xml`],
+    xml: '<?xml version="1.0"?><FMX><ARTICLE>ENG</ARTICLE></FMX>',
+  });
+  await withMockFetch(english.fetchImpl, () => service.prepareLawPayload('32024R1689', 'ENG'));
+
+  const german = prepareFetch({
+    fmx4Uri: `${CELLAR_BASE}/oj/L_202401689.DEU.fmx4`,
+    downloadUrls: [`${CELLAR_BASE}/oj/L_202401689.DEU.fmx4.1.xml`],
+    xml: '<?xml version="1.0"?><FMX><ARTICLE>DEU</ARTICLE></FMX>',
+  });
+  const result = await withMockFetch(german.fetchImpl, () => (
+    service.prepareLawPayload('32024R1689', 'DEU')
+  ));
+
+  assert.equal(german.calls.length, 4);
+  assert.notEqual(result.servePath, path.join(dir, 'L_202401689.ENG.fmx4.1.xml'));
+  assert.match(fs.readFileSync(result.servePath, 'utf8'), /DEU/);
+});
+
+for (const [label, invalidate] of [
+  ['missing', (servePath) => fs.unlinkSync(servePath)],
+  ['corrupt', (servePath) => fs.writeFileSync(servePath, '<?xml version="1.0"?><FMX><ARTICLE>1</ARTICLE>')],
+]) {
+  test(`a ${label} persisted memo entry falls through to a fresh probe`, async () => {
+    const dir = makeCacheDir();
+    const fmx4Uri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4`;
+    const downloadUri = `${CELLAR_BASE}/oj/L_202401689.ENG.fmx4.1.xml`;
+    const firstFetch = prepareFetch({
+      fmx4Uri,
+      downloadUrls: [downloadUri],
+      xml: '<?xml version="1.0"?><FMX><ARTICLE>1</ARTICLE></FMX>',
+    });
+    const firstService = makeService(dir);
+    const first = await withMockFetch(firstFetch.fetchImpl, () => (
+      firstService.prepareLawPayload('32024R1689', 'ENG')
+    ));
+    invalidate(first.servePath);
+
+    const secondFetch = prepareFetch({
+      fmx4Uri,
+      downloadUrls: [downloadUri],
+      xml: '<?xml version="1.0"?><FMX><ARTICLE>2</ARTICLE></FMX>',
+    });
+    const secondService = makeService(dir);
+    const second = await withMockFetch(secondFetch.fetchImpl, () => (
+      secondService.prepareLawPayload('32024R1689', 'ENG')
+    ));
+
+    assert.equal(secondFetch.calls.length, 4);
+    assert.equal(fs.readFileSync(second.servePath, 'utf8'), '<?xml version="1.0"?><FMX><ARTICLE>2</ARTICLE></FMX>');
+  });
+}

--- a/backend/shared/law-queries.js
+++ b/backend/shared/law-queries.js
@@ -18,6 +18,21 @@ const {
   parseCitationsToRefs,
 } = require('./case-law-parser');
 
+function writeFileAtomically(filePath, data, encoding) {
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
+  try {
+    fs.writeFileSync(tempPath, data, encoding);
+    fs.renameSync(tempPath, filePath);
+  } catch (error) {
+    try {
+      fs.unlinkSync(tempPath);
+    } catch {
+      // The write may have failed before creating the temporary file.
+    }
+    throw error;
+  }
+}
+
 // Kept in step with parseInForce() in search/in-force-enrich.js: a shape change
 // upstream must surface as "unknown", never as a default.
 function parseInForceLiteral(value) {
@@ -396,7 +411,8 @@ function loadCaseLawCache(cacheDir, { readOnly = false } = {}) {
       }
       if (!readOnly) {
         try {
-          fs.writeFileSync(filePath, JSON.stringify(migrated, null, 2), 'utf8');
+          fs.mkdirSync(cacheDir, { recursive: true });
+          writeFileAtomically(filePath, JSON.stringify(migrated, null, 2), 'utf8');
         } catch {
           // best-effort; we'll re-migrate next load
         }
@@ -415,7 +431,7 @@ function loadCaseLawCache(cacheDir, { readOnly = false } = {}) {
         }
         const seedBytes = zlib.gunzipSync(fs.readFileSync(CASE_LAW_CACHE_SEED));
         fs.mkdirSync(cacheDir, { recursive: true });
-        fs.writeFileSync(filePath, seedBytes);
+        writeFileAtomically(filePath, seedBytes);
         const seeded = readCaseLawCacheFile(filePath);
         if (seeded) return seeded;
       } catch {
@@ -431,7 +447,8 @@ function loadCaseLawCache(cacheDir, { readOnly = false } = {}) {
 function saveCaseLawCache(cacheDir, cache) {
   try {
     const filePath = path.join(cacheDir, CASE_LAW_CACHE_FILE);
-    fs.writeFileSync(filePath, JSON.stringify(cache, null, 2), 'utf8');
+    fs.mkdirSync(cacheDir, { recursive: true });
+    writeFileAtomically(filePath, JSON.stringify(cache, null, 2), 'utf8');
     // Refresh the memo in place so the next request doesn't re-parse ~50 MB.
     const stat = fs.statSync(filePath);
     caseLawCacheMemo = { path: filePath, mtimeMs: stat.mtimeMs, size: stat.size, cache };


### PR DESCRIPTION
Closes the durability half of #192 and part 2 of #206. They are one change because they are one question: **when may we trust a file that is already on disk?**

## #192 — non-atomic writes

Every site that wrote straight to its final path now writes to a temp path and renames, following the exemplar already in `shared/ai-digest-utils.js:66-68`:

- each downloaded Formex part (`fmx-service.js:312`)
- both ZIP combiners (`combineZipWithUnzip`, `combineZipWithAdmZip`)
- the multi-file `.combined.xml` in `prepareLawPayload`
- `saveCaseLawCache`'s ~50 MB JSON (`law-queries.js`)
- `reenrich-cache.js`'s `search-cache.json`

Rename alone does not heal a volume that has already taken a bad write, which is why the issue flagged this as more than a mechanical substitution. So the `existsSync` guards are replaced by `isValidCachedFile()` — a cheap both-ends probe (non-empty; opens with a tag; closes with the matching root element, or `</COMBINED.FMX>` for combined files, or a ZIP end-of-central-directory signature). A truncated file now reads as a **miss** and is rebuilt, instead of being served forever.

The other non-mechanical part: `.tmp` leftovers were invisible to eviction, which sizes itself from `.xml`/`.zip` names, so a crashed write leaked disk permanently. Eviction now sweeps them first.

## #206 part 2 — two Cellar round trips per law request

`downloadFmx` always resolved the manifestation URI and its download URLs — two sequential RDF round trips, ~0.3–1 s — before looking at the local file. Every cold law view paid for them, and serving an already-cached law hard-depended on Cellar being up.

`prepareLawPayload` now memoizes `celex+lang → servePath`, in memory and in a `fmx-paths-v1.json` sidecar so restarts keep it.

**The memo is validated, not trusted.** A hit must re-state the CELEX and language it was written for, resolve inside the cache root, match the file's current size, and pass the same `isValidCachedFile()` check as any other cache hit. Anything else drops the entry and falls through to the normal probe-and-download path. A wrong memo hit would serve a different law's text — far worse than the latency it saves — so each of those checks is load-bearing, and validating against `existsSync` alone would have inherited #192's bug and made it stickier.

## Testing

- `cd backend && npm test` — **573 pass, 0 fail, 2 skipped** (run independently of the authoring agent, not just reported by it)
- `npm run lint` — clean
- `shared/fmx-service.test.js` grew from 3 to 17 tests, covering the failure modes that motivated this: a truncated `.combined.xml` is not served; a crashed write does not later read as a valid hit; `.tmp` leftovers are evictable; a memo entry pointing at a missing, resized, or corrupt file falls through to a re-probe rather than erroring.

## Notes for review

- **No cache-version constant bumped**, deliberately — no cached output shape changes, the parser is untouched, and the new sidecar carries its own version in both its filename and its payload.
- `writeFileAtomically` is now a third local copy of a helper that already exists in `ai-digest-utils.js`, `in-force-recheck.js` and `law-corpus-store.js`. That is consistent with existing practice here rather than new debt, but it is a fair candidate for the #194 consolidation pass.
- `combineZipWithUnzip`'s `execFileSync` is still synchronous. It was optional in scope and asyncifying it would have widened this change; the #206 minor checklist still covers it.
- One narrow race worth knowing about: `cleanupTempFiles` would delete a `.tmp` belonging to a *concurrently running* process sharing the same volume. The rename is atomic so this cannot corrupt output — the losing writer fails its rename and throws — and the API runs as a single process today, but it is a constraint on ever running multiple instances against one cache volume.

Drafted by an agent, then reviewed and tested by me before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnV2b7DxhnM87X2zZm2eqD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnV2b7DxhnM87X2zZm2eqD)_