### PR TITLE
Parse number-first official references, and capture the parenthesised suffix

### DIFF
--- a/src/utils/officialReferences.js
+++ b/src/utils/officialReferences.js
@@ -14,9 +14,9 @@ export function parseOfficialReference(text = "") {
 
   const numberPatterns = [
     // Modern format: year/number — e.g. "(EU) 2016/679" or plain "2016/679"
-    /\b(?:\((EU|EC|EEC|EURATOM|JHA)\)\s*)?(\d{4})\/(\d{1,4})(?:\/([A-Z]+))?\b/i,
+    /(?<!\bno\s)(?<!\bno\.\s)(?:\((EU|EC|EEC|EURATOM|JHA)\)\s*)?\b(\d{4})\/(\d{1,4})(?:\/([A-Z]+))?\b/i,
     // "No. N/YYYY" format — e.g. "No. 46/95"
-    /\bno\.?\s+(\d{1,4})\/(\d{2,4})(?:\/([A-Z]+))?\b/i,
+    /(?:\((EU|EC|EEC|EURATOM|JHA)\)\s*)?\bno\.?\s+(\d{1,4})\/(\d{2,4})(?:\/([A-Z]+))?\b/i,
     // Old-style number/year without "No." — e.g. "95/46/EC", "1612/68/EEC"
     /\b(\d{1,4})\/(\d{2,4})(?:\/([A-Z]+))?\b/i,
   ];
@@ -43,21 +43,27 @@ export function parseOfficialReference(text = "") {
   } else {
     const second = raw.match(numberPatterns[1]);
     if (second) {
-      year = second[2].length === 2 ? `19${second[2]}` : second[2];
-      number = second[1];
-      suffix = (second[3] || "").toUpperCase() || null;
+      year = second[3].length === 2 ? `19${second[3]}` : second[3];
+      number = second[2];
+      suffix = (second[4] || second[1] || "").toUpperCase() || null;
     } else {
       const third = raw.match(numberPatterns[2]);
       if (third) {
-        // Pattern 1 already handles YYYY/N (4-digit year first), so here
-        // the first number is always a short (1-3 digit) year: "95/46/EC",
-        // "93/13" → year comes first even in old-style references.
         const a = third[1];
         const b = third[2];
         suffix = (third[3] || "").toUpperCase() || null;
-        const y = parseInt(a, 10);
-        year = a.length === 2 ? String(y >= 50 ? 1900 + y : 2000 + y) : a;
-        number = b;
+        const firstIsPlausibleYear = a.length === 4 && parseInt(a, 10) >= 1950 && parseInt(a, 10) <= 2100;
+        const secondIsPlausibleYear = b.length === 4 && parseInt(b, 10) >= 1950 && parseInt(b, 10) <= 2100;
+
+        if (secondIsPlausibleYear && !firstIsPlausibleYear) {
+          year = b;
+          number = a;
+        } else {
+          // Short-year-first interpretation: "95/46/EC", "93/13".
+          const y = parseInt(a, 10);
+          year = a.length === 2 ? String(y >= 50 ? 1900 + y : 2000 + y) : a;
+          number = b;
+        }
       }
     }
   }

--- a/src/utils/officialReferences.test.js
+++ b/src/utils/officialReferences.test.js
@@ -2,6 +2,50 @@ import { describe, it, expect } from "vitest";
 import { parseOfficialReference, getReferenceLabel } from "./officialReferences.js";
 
 describe("parseOfficialReference", () => {
+  it.each([
+    ["Decision 676/2002/EC", { actType: "decision", year: "2002", number: "676", suffix: "EC" }],
+    ["Decision 460/2004/EC", { actType: "decision", year: "2004", number: "460", suffix: "EC" }],
+    ["Decision No 243/2012/EU", { actType: "decision", year: "2012", number: "243", suffix: "EU" }],
+    ["Directive 95/46/EC", { actType: "directive", year: "1995", number: "46", suffix: "EC" }],
+    ["Directive 93/13", { actType: "directive", year: "1993", number: "13", suffix: null }],
+    ["Regulation 1612/68/EEC", { actType: "regulation", year: "1968", number: "1612", suffix: "EEC" }],
+    ["Regulation (EU) 2016/679", { actType: "regulation", year: "2016", number: "679", suffix: "EU" }],
+    ["Directive 2002/58/EC", { actType: "directive", year: "2002", number: "58", suffix: "EC" }],
+  ])("keeps the official reference shape for %s", (input, expected) => {
+    expect(parseOfficialReference(input)).toMatchObject(expected);
+  });
+
+  it.each(["EU", "EC", "EEC", "EURATOM", "JHA"])("captures a parenthesised %s suffix", (suffix) => {
+    expect(parseOfficialReference(`Regulation (${suffix}) 2016/679`)).toMatchObject({
+      year: "2016",
+      number: "679",
+      suffix,
+    });
+  });
+
+  it("captures a parenthesised suffix before the No. form", () => {
+    expect(parseOfficialReference("Regulation (EC) No 1924/2006")).toMatchObject({
+      year: "2006",
+      number: "1924",
+      suffix: "EC",
+    });
+  });
+
+  it("prefers an explicit trailing suffix over a parenthesised suffix", () => {
+    expect(parseOfficialReference("Regulation (EU) 2016/679/EC").suffix).toBe("EC");
+  });
+
+  it.each([
+    ["Decision 1949/2002/EC", "1949"],
+    ["Decision 2101/2002/EC", "2101"],
+  ])("does not read boundary first component %s as a year", (input, number) => {
+    expect(parseOfficialReference(input)).toMatchObject({
+      year: "2002",
+      number,
+      suffix: "EC",
+    });
+  });
+
   it("parses standard regulation format: Regulation (EU) 2016/679", () => {
     const result = parseOfficialReference("Regulation (EU) 2016/679");
     expect(result).toMatchObject({
@@ -109,6 +153,7 @@ describe("parseOfficialReference", () => {
       actType: "regulation",
       year: "2006",
       number: "1907",
+      suffix: "EC",
     });
   });
 });


### PR DESCRIPTION
Closes #218.

`parseOfficialReference("Decision 676/2002/EC")` returned **year 676, number 2002** — the Radio Spectrum Decision, and any act written as `<number>/<4-digit year>/<suffix>` without a `No` marker.

Pattern 1 requires a 4-digit *first* component, so these fell through to the old-style pattern (`officialReferences.js:50-61`), whose comment asserted the first component "is always a short year". That doesn't hold for `676/2002/EC`, `460/2004/EC` and friends. The branch now checks whether the *second* component is a plausible year (4 digits, 1950–2100) while the first is not, mirroring the implausible-year branch pattern 1 already had.

## Second defect, same function

The parenthesised suffix was silently dropped for the modern form: `Regulation (EU) 2016/679` returned `suffix: null`.

Pattern 1 opened with `\b` immediately before `\(`. `(` is a non-word character, so when the suffix is preceded by a space there is no word boundary at that position and the optional group could never participate — the match simply started at the digits instead. Pattern 2 had no suffix group at all, so `(EC) No 1924/2006` lost it too. Both now capture it, keeping the existing precedence where an explicit trailing `/EC` beats a leading `(EU)`.

## Verified

Every row checked directly against the built function, not only via the suite:

| Reference | Before | After |
|---|---|---|
| `Decision 676/2002/EC` | 676 / 2002 / EC ❌ | **2002 / 676 / EC** |
| `Decision 460/2004/EC` | 460 / 2004 / EC ❌ | **2004 / 460 / EC** |
| `Regulation (EU) 2016/679` | suffix `null` ❌ | **suffix `EU`** |
| `Regulation (EC) No 1924/2006` | suffix `null` ❌ | **suffix `EC`** |
| `Decision No 243/2012/EU` | 2012 / 243 / EU | unchanged |
| `Directive 95/46/EC` | 1995 / 46 / EC | unchanged |
| `Directive 93/13` | 1993 / 13 | unchanged |
| `Regulation 1612/68/EEC` | 1968 / 1612 / EEC | unchanged |
| `Directive 2002/58/EC` | 2002 / 58 / EC | unchanged |
| `Council Framework Decision 2002/584/JHA` | 2002 / 584 / JHA | unchanged |

Plus boundary locks (a first component of `1949` or `2101` must not be read as a year) in the test file.

- `npm run test:web` — **625 pass** across 56 files.
- `npm run lint` — clean.
- Checked the `suffix` consumers (`hooks/law-viewer/useLawViewerInteractions.js:95,111`, `utils/library.js`); populating a previously-null field is additive for both.

## Notes for review

- **No cache version bumped**, deliberately: `parseOfficialReference` output is not persisted under any versioned cache key. I confirmed this rather than assuming it.
- Scope is `src/utils/officialReferences.js` only. The backend's separate reference grammar is #195 (PR #227) and #220 — different files, no overlap with this.

Drafted by an agent, then reviewed, independently re-verified and tested by me before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CnV2b7DxhnM87X2zZm2eqD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CnV2b7DxhnM87X2zZm2eqD)_