### PR TITLE
Start reading the amended text when the overview toggle is clicked

### DIFF
--- a/src/components/LawViewer.jsx
+++ b/src/components/LawViewer.jsx
@@ -50,6 +50,7 @@ import { LawOverviewPage } from "./law-viewer/LawOverviewPage.jsx";
 import { ConsolidatedFallbackNotice } from "./law-viewer/ConsolidatedFallbackNotice.jsx";
 import { DefinitionComparisonSheet } from "./law-viewer/DefinitionComparisonSheet.jsx";
 import { ConsolidationNotice } from "./ConsolidationNotice.jsx";
+import { buildVersionReadTarget } from "../utils/law-viewer/versionNavigation.js";
 
 export function LawViewer() {
   const { locale: routeLocale, slug, key, kind, id } = useParams();
@@ -209,6 +210,21 @@ export function LawViewer() {
     else nextParams.delete("version");
     setSearchParams(nextParams);
   }, [searchParams, setSearchParams]);
+
+  // The overview's version toggle: switch to the consolidated text *and*
+  // start reading it. `buildVersionReadTarget` explains why one gesture, not
+  // two, and returns null for the directions that are just a param change
+  // (clearing the version, or a document with nothing readable) — those fall
+  // through to `setVersion`. The search string is passed explicitly because
+  // `navigateToCanonical` would otherwise reuse the pre-toggle one.
+  const setVersionAndRead = React.useCallback((nextVersion) => {
+    const target = buildVersionReadTarget(primaryDocument.data, searchParams, nextVersion);
+    if (!target) {
+      setVersion(nextVersion);
+      return;
+    }
+    source.navigateToCanonical(target.kind, target.id, { search: target.search });
+  }, [primaryDocument.data, searchParams, setVersion, source]);
 
   const definitionComparison = definitionTerm ? {
     term: definitionTerm,
@@ -417,7 +433,7 @@ export function LawViewer() {
                   version={requestedVersion}
                   versionUnavailable={derived.versionUnavailable}
                   versionDate={derived.versionDate}
-                  onToggleVersion={setVersion}
+                  onToggleVersion={setVersionAndRead}
                   t={t}
                 />
               ) : (

--- a/src/hooks/law-viewer/useLawViewerSource.js
+++ b/src/hooks/law-viewer/useLawViewerSource.js
@@ -49,10 +49,17 @@ export function useLawViewerSource({
     return getCanonicalLawRoute(currentLaw, kind, id, routeLocale || locale);
   }, [currentLaw, currentLawSlug, kind, id, routeLocale, locale]);
 
+  // `search` overrides the query string carried along with the jump. Callers
+  // that change a search param *and* the route in one gesture (reading the
+  // consolidated text, which sets `?version=current` and lands on the first
+  // article) must pass it: `locationSearch` is a render behind a
+  // `setSearchParams` in the same handler, so navigating without it would
+  // silently drop the param that was just set.
   const navigateToCanonical = useCallback((kindName, targetId, options = {}) => {
     if (!currentLawSlug) return;
+    const { search, ...navOptions } = options;
     const nextPath = getCanonicalLawRoute(currentLaw, kindName, targetId, routeLocale || locale);
-    navigate(`${nextPath}${locationSearch}`, options);
+    navigate(`${nextPath}${search ?? locationSearch}`, navOptions);
   }, [currentLaw, currentLawSlug, locale, locationSearch, navigate, routeLocale]);
 
   const retryLoad = useCallback(() => {

--- a/src/hooks/law-viewer/useLawViewerSource.test.jsx
+++ b/src/hooks/law-viewer/useLawViewerSource.test.jsx
@@ -203,4 +203,47 @@ describe("useLawViewerSource", () => {
       celex: "32015L2366",
     }));
   });
+
+  it("navigateToCanonical carries an explicit search string instead of the current one", async () => {
+    const navigate = vi.fn();
+    mockGetCanonicalLawRoute.mockReturnValue("/regulation-2006-1367/article/1");
+
+    const props = {
+      slug: "regulation-2006-1367",
+      key: undefined,
+      kind: null,
+      id: null,
+      importCelex: "32006R1367",
+      sourceUrl: null,
+      locale: "en",
+      routeLocale: "en",
+      pathname: "/regulation-2006-1367",
+      locationSearch: "?lang=EN",
+      navigate,
+      formexLang: "EN",
+      t: (key) => key,
+      localizePath: (value) => value,
+    };
+
+    await act(async () => {
+      root.render(<Probe {...props} />);
+      await flushEffects();
+    });
+
+    await act(async () => {
+      latestValue.navigateToCanonical("article", "1", { search: "?lang=EN&version=current" });
+    });
+
+    expect(navigate).toHaveBeenCalledWith(
+      "/regulation-2006-1367/article/1?lang=EN&version=current",
+      {}
+    );
+
+    navigate.mockClear();
+    await act(async () => {
+      latestValue.navigateToCanonical("article", "2");
+    });
+
+    expect(navigate).toHaveBeenCalledWith("/regulation-2006-1367/article/1?lang=EN", {});
+  });
 });

--- a/src/utils/law-viewer/versionNavigation.js
+++ b/src/utils/law-viewer/versionNavigation.js
@@ -1,0 +1,36 @@
+/**
+ * Where "read this law as amended" should land, and with what query string.
+ *
+ * The overview's version toggle promises reading. Flipping `?version=current`
+ * on its own kept the reader on the overview, whose AI summary still opens
+ * with "this overview describes the law as adopted" — the consolidated text
+ * was loaded but nothing on screen showed it, so the click read as a no-op
+ * (reported by a reader on Regulation (EC) No 1367/2006). The toggle
+ * therefore switches the version *and* enters the text in one navigation.
+ *
+ * Returns `null` when there is nothing to enter — no version requested (the
+ * "back to as adopted" direction is not a request to start reading), or a
+ * document with no readable entry at all — and the caller should fall back to
+ * setting the search params alone.
+ */
+export function buildVersionReadTarget(data, searchParams, version) {
+  if (!version) return null;
+
+  // Same order as the overview's "start reading" button: an act with no
+  // articles (rare, but recital- or annex-only documents exist) still has
+  // something to open.
+  const entry = data?.articles?.[0]
+    ? { kind: "article", id: data.articles[0].article_number }
+    : data?.recitals?.[0]
+      ? { kind: "recital", id: data.recitals[0].recital_number }
+      : data?.annexes?.[0]
+        ? { kind: "annex", id: data.annexes[0].annex_id }
+        : null;
+  if (!entry) return null;
+
+  const nextParams = new URLSearchParams(searchParams);
+  nextParams.set("version", version);
+  const query = nextParams.toString();
+
+  return { ...entry, search: query ? `?${query}` : "" };
+}

--- a/src/utils/law-viewer/versionNavigation.test.js
+++ b/src/utils/law-viewer/versionNavigation.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { buildVersionReadTarget } from "./versionNavigation.js";
+
+const data = {
+  articles: [{ article_number: "1" }, { article_number: "2" }],
+  recitals: [{ recital_number: "1" }],
+  annexes: [{ annex_id: "I" }],
+};
+
+describe("buildVersionReadTarget", () => {
+  it("targets the first article and keeps the other query params", () => {
+    expect(buildVersionReadTarget(data, new URLSearchParams("lang=EN"), "current")).toEqual({
+      kind: "article",
+      id: "1",
+      search: "?lang=EN&version=current",
+    });
+  });
+
+  it("replaces an existing version rather than appending a second one", () => {
+    const target = buildVersionReadTarget(data, new URLSearchParams("version=current"), "current");
+    expect(target.search).toBe("?version=current");
+  });
+
+  it("falls back to a recital, then an annex, when there are no articles", () => {
+    expect(buildVersionReadTarget({ recitals: data.recitals, annexes: data.annexes }, new URLSearchParams(), "current"))
+      .toEqual({ kind: "recital", id: "1", search: "?version=current" });
+    expect(buildVersionReadTarget({ annexes: data.annexes }, new URLSearchParams(), "current"))
+      .toEqual({ kind: "annex", id: "I", search: "?version=current" });
+  });
+
+  it("returns null when clearing the version — going back is not a request to read", () => {
+    expect(buildVersionReadTarget(data, new URLSearchParams("version=current"), null)).toBeNull();
+  });
+
+  it("returns null when the document has nothing readable", () => {
+    expect(buildVersionReadTarget({ articles: [], recitals: [], annexes: [] }, new URLSearchParams(), "current"))
+      .toBeNull();
+  });
+});


### PR DESCRIPTION
## The report

A reader on `https://legalviz.eu/regulation-2006-1367` clicked **"Read this law as amended"** and reported that it "automatically sends me to a page saying 'this overview describes the law as adopted'" — then went looking for the text, found only the summary's numbers, and ended up on the EUR-Lex link.

They were doing nothing wrong. From the overview, the toggle only set `?version=current` on the URL. The consolidated document *did* load, but the overview page renders identically either way — its one visible reaction is the AI summary's honest "This overview describes the law as adopted" note, which reads as a contradiction of the button that was just pressed. The click looked like a no-op.

## The change

The overview's toggle now switches the version **and** opens the text, in one navigation:

- `src/utils/law-viewer/versionNavigation.js` — new `buildVersionReadTarget(data, searchParams, version)` picks the landing spot (first article, else recital, else annex — the same order as the "Start reading" button) and builds the query string. It returns `null` for the directions that are only a param change: clearing the version (the "back to as adopted" link is not a request to start reading) and a document with nothing readable. Those fall through to the existing `setVersion`.
- `src/components/LawViewer.jsx` — `setVersionAndRead` wires that up and is passed to `LawOverviewPage` in place of `setVersion`.
- `src/hooks/law-viewer/useLawViewerSource.js` — `navigateToCanonical` takes a `search` override. It otherwise reuses `locationSearch`, which is a render behind a `setSearchParams` issued in the same handler, so the version just set would have been dropped on the way in.

The inline notice shown while reading an article is untouched — there the toggle already lands on text, and re-navigating would throw away the reader's position.

## Tests

- `src/utils/law-viewer/versionNavigation.test.js` (new, 5 cases): target selection and fallbacks, param preservation, no duplicate `version`, and both null paths.
- `src/hooks/law-viewer/useLawViewerSource.test.jsx`: a case covering the `search` override and the unchanged default.
- `npm run test:web` — 636 passed / 57 files. `npm run lint` — clean.

## Not covered

No cache constants are touched, so nothing to bump. The summary's "as adopted" note stays as-is: it is accurate, and it is no longer the only thing that happens when the button is pressed. It can still be reached by opening a shared `?version=current` overview URL directly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UyEHwHn4UBaFZiXYBJxxTp)_