### PR TITLE
Return 200 from /info for acts published without Formex

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -237,7 +237,7 @@ cat input.xml | parse-fmx > output.json
 | `GET` | `/api/laws` | List cached FMX files |
 | `GET` | `/api/laws/:celex?lang=ENG` | Download raw Formex XML by CELEX (falls back to EUR-Lex HTML when FMX isn't available) |
 | `GET` | `/api/laws/:celex/parsed?lang=ENG` | **Parsed law as structured JSON** |
-| `GET` | `/api/laws/:celex/info?lang=ENG` | Law type and format metadata |
+| `GET` | `/api/laws/:celex/info?lang=ENG` | Law type and format metadata. Returns `200` with `formexAvailable: false` (and `type: null`) for acts EUR-Lex publishes without Formex — those still parse via the HTML fallback. `404` means the CELEX itself is unknown to Cellar. |
 | `GET` | `/api/laws/:celex/metadata` | SPARQL metadata (entry into force, ELI, etc.) |
 | `GET` | `/api/laws/:celex/amendments` | Amendment and corrigendum history |
 | `GET` | `/api/laws/:celex/consolidated` | Consolidated ("as amended") versions EUR-Lex publishes for the act, oldest first. Future-dated versions are included — the caller decides which one is current. |

--- a/backend/routes/api-routes.js
+++ b/backend/routes/api-routes.js
@@ -453,14 +453,32 @@ function registerApiRoutes(app, deps) {
         return res.status(400).json({ error: `Invalid language code: ${rawLang}` });
       }
 
-      const fmx4Uri = await findFmx4Uri(celex, lang);
-      const { type } = await findDownloadUrls(fmx4Uri);
+      // An act with no Formex manifestation is not a missing act: `/parsed`
+      // serves it through the EUR-Lex HTML fallback, and several acts in the
+      // corpus (e.g. 31987L0372) only exist that way. Answering 404 here made
+      // the two endpoints disagree about whether the law exists at all, so
+      // any consumer using `/info` as an existence check got a false negative
+      // on exactly those acts. Report the absence in the body instead, and
+      // keep 404 for the one thing it should mean — Cellar has no such CELEX
+      // (`celex_not_found`, raised before we ever look for a manifestation).
+      let type = null;
+      let formexAvailable = true;
+      try {
+        const fmx4Uri = await findFmx4Uri(celex, lang);
+        ({ type } = await findDownloadUrls(fmx4Uri));
+      } catch (err) {
+        if (!(err instanceof ClientError) || err.statusCode !== 404 || err.code !== 'fmx_not_found') {
+          throw err;
+        }
+        formexAvailable = false;
+      }
 
       res.json({
         celex,
         lang,
         name: CELEX_NAMES[celex] || null,
-        type
+        type,
+        formexAvailable
       });
     } catch (err) {
       safeErrorResponse(res, err, 'Failed to fetch law metadata');
@@ -929,7 +947,7 @@ function registerApiRoutes(app, deps) {
         'GET /api/laws': 'List cached FMX files',
         'GET /api/laws/:celex?lang=ENG': 'Get raw FMX XML by CELEX (fetches & caches)',
         'GET /api/laws/:celex/parsed?lang=ENG': 'Get parsed law as structured JSON (articles, recitals, definitions, annexes, cross-references)',
-        'GET /api/laws/:celex/info': 'Get metadata only',
+        'GET /api/laws/:celex/info': 'Get metadata only (formexAvailable: false when the act has no Formex; 404 only for an unknown CELEX)',
         'GET /api/laws/:celex/procedure': 'Resolve the official EUR-Lex legislative procedure overview',
         'GET /api/laws/by-reference?actType=directive&year=2018&number=1972&lang=ENG': 'Resolve an official reference and fetch the matching FMX',
         'GET /api/laws/:celex/case-law': 'List CJEU judgments that interpret this law',

--- a/backend/routes/api-routes.test.js
+++ b/backend/routes/api-routes.test.js
@@ -1237,3 +1237,69 @@ test("GET /api/fulltext-search is registered with rate limiting and delegates bo
   assert.equal(res.payload.celex, "32016R0679");
   assert.deepEqual(calls, [{ query: "data", options: { limit: "1", celex: "32016R0679" } }]);
 });
+
+test("GET /api/laws/:celex/info reports Formex availability", async () => {
+  const { app } = registerTestRoutes({ CELEX_NAMES: { "32016R0679": "GDPR" } });
+  const handler = app.routes.get("/api/laws/:celex/info");
+  const res = createResponseRecorder();
+
+  await handler({ params: { celex: "32016R0679" }, query: {} }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.payload, {
+    celex: "32016R0679",
+    lang: "ENG",
+    name: "GDPR",
+    type: "xml",
+    formexAvailable: true,
+  });
+});
+
+test("GET /api/laws/:celex/info answers 200 with formexAvailable: false for an act served by the HTML fallback", async () => {
+  const { app } = registerTestRoutes({
+    findFmx4Uri: async () => {
+      throw new ClientError("No Formex data available for this law in language ENG", 404, "fmx_not_found");
+    },
+  });
+  const handler = app.routes.get("/api/laws/:celex/info");
+  const res = createResponseRecorder();
+
+  await handler({ params: { celex: "31987L0372" }, query: {} }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.payload.formexAvailable, false);
+  assert.equal(res.payload.type, null);
+  assert.equal(res.payload.celex, "31987L0372");
+});
+
+test("GET /api/laws/:celex/info answers 200 with formexAvailable: false when the manifestation lists no downloadable files", async () => {
+  const { app } = registerTestRoutes({
+    findDownloadUrls: async () => {
+      throw new ClientError("No downloadable Formex files found for this law", 404, "fmx_not_found");
+    },
+  });
+  const handler = app.routes.get("/api/laws/:celex/info");
+  const res = createResponseRecorder();
+
+  await handler({ params: { celex: "31987L0372" }, query: {} }, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(res.payload.formexAvailable, false);
+  assert.equal(res.payload.type, null);
+});
+
+test("GET /api/laws/:celex/info still 404s when Cellar has no such CELEX", async () => {
+  const { app } = registerTestRoutes({
+    findFmx4Uri: async () => {
+      throw new ClientError("Law not found in EUR-Lex Cellar", 404, "celex_not_found");
+    },
+  });
+  const handler = app.routes.get("/api/laws/:celex/info");
+  const res = createResponseRecorder();
+
+  await handler({ params: { celex: "39999R9999" }, query: {} }, res);
+
+  assert.equal(res.statusCode, 404);
+  assert.equal(res.payload.error, "Law not found in EUR-Lex Cellar");
+  assert.equal(res.payload.code, "celex_not_found");
+});

--- a/backend/shared/fmx-service.js
+++ b/backend/shared/fmx-service.js
@@ -292,7 +292,7 @@ function createFmxService({
     const response = await fetchWithTimeout(url, {
       headers: { Accept: '*/*', 'Accept-Language': 'eng' }
     });
-    if (response.status === 404) throw new ClientError('Law not found in EUR-Lex Cellar', 404);
+    if (response.status === 404) throw new ClientError('Law not found in EUR-Lex Cellar', 404, 'celex_not_found');
     if (!response.ok) throw new Error(`HTTP ${response.status} for ${url}`);
     return response.text();
   }
@@ -334,7 +334,7 @@ function createFmxService({
       }
     }
 
-    if (!fmx4) throw new ClientError(`No Formex data available for this law in language ${lang}`, 404);
+    if (!fmx4) throw new ClientError(`No Formex data available for this law in language ${lang}`, 404, 'fmx_not_found');
     return fmx4;
   }
 
@@ -361,7 +361,7 @@ function createFmxService({
     const docXmls = uris.filter((uri) => uri.endsWith('.doc.xml'));
     if (docXmls.length) return { type: 'xml', urls: docXmls };
 
-    throw new ClientError('No downloadable Formex files found for this law', 404);
+    throw new ClientError('No downloadable Formex files found for this law', 404, 'fmx_not_found');
   }
 
   function combineZipToXml(zipPath) {


### PR DESCRIPTION
## The bug

`GET /api/laws/:celex/info` and `GET /api/laws/:celex/parsed` disagreed about whether a law exists.

```
$ curl -s https://api.legalviz.eu/api/laws/31987L0372/info      # 404
{"error":"No Formex data available for this law in language ENG"}

$ curl -s https://api.legalviz.eu/api/laws/31987L0372/parsed    # 200, 5 articles, source: eurlex-html
```

`/info` calls `findFmx4Uri`, which throws a 404 when Cellar publishes no Formex manifestation for the act. `resolveParsedLaw` reads that same 404 as "this act has no Formex" and parses EUR-Lex HTML instead — which is why `/parsed` renders the act fine. But `/info` surfaced the 404 unchanged, so 404 there meant two different things: "no such law" and "no Formex for a law that does exist". Any consumer using `/info` as an existence check gets a false negative on exactly the acts served by the HTML fallback (7 in the sampled slice).

## The fix

`/info` now reports the absence in the body instead of in the status code:

```json
{"celex":"31987L0372","lang":"ENG","name":null,"type":null,"formexAvailable":false}
```

`formexAvailable: true` is on the success payload too, so the field is always present rather than only on the negative answer.

404 is kept for the one thing it should mean — a CELEX Cellar does not know:

```json
{"error":"Law not found in EUR-Lex Cellar","code":"celex_not_found"}
```

Telling those two 404s apart needs a discriminator, since both were bare `ClientError(…, 404)`. `shared/fmx-service.js` now stamps codes on them:

- `getRdf` → `celex_not_found` (Cellar itself 404s)
- `findFmx4Uri` / `findDownloadUrls` → `fmx_not_found`, matching the code `prepareLawPayload` already used for the same condition

The route only swallows `fmx_not_found`; everything else propagates as before. No other route branches on these codes, so adding them is additive — the response bodies gain a `code` field, nothing changes shape.

## Scope

Backend only, no cache-version bump needed (`/info` isn't cached). No frontend consumer of `/info` exists; the only references were the docs table and the root endpoint listing, both updated.

## Testing

- `node --test search/*.test.js shared/*.test.js routes/*.test.js bin/*.test.js mcp/*.test.js` — 650 pass, 2 skipped, 0 fail
- 4 new tests in `backend/routes/api-routes.test.js`: Formex present, no manifestation, manifestation with no downloadable files, unknown CELEX still 404
- `npx eslint` clean on the changed files

Frontend vitest not run — no `src/` files touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VPNc5ciaE7xhVLHZ4Bn9TZ)_