### PR TITLE
Give the MCP test fixture a per-test cache directory

### DIFF
--- a/backend/mcp/register-tools.test.js
+++ b/backend/mcp/register-tools.test.js
@@ -44,8 +44,11 @@ const FIXTURE_LAW = {
   crossReferences: { 17: [{ type: 'article', target: '4' }] },
 };
 
+const ownedCacheDirs = new WeakMap();
+
 function makeDeps(overrides = {}) {
-  return {
+  const cacheDir = overrides.FMX_DIR ?? fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-test-'));
+  const deps = {
     legalCacheStore: {
       searchLaws: () => [{ celex: '32016R0679', title: 'GDPR', type: 'regulation', matchReason: 'title_exact' }],
       searchFulltextUnits: () => [],
@@ -55,7 +58,7 @@ function makeDeps(overrides = {}) {
     resolveEurlexUrl: async (url) => ({ sourceUrl: url, resolved: { celex: '32016R0679', source: 'search-cache' }, tried: [], fallback: null }),
     runSparqlQuery: async () => ({ results: { bindings: [] } }),
     resolveParsedLaw: async () => FIXTURE_LAW,
-    FMX_DIR: path.join(os.tmpdir(), 'mcp-test-nonexistent'),
+    FMX_DIR: cacheDir,
     analytics: { recordMcpTool: () => {} },
     citationGraphStore: {
       isReady: () => true,
@@ -64,19 +67,36 @@ function makeDeps(overrides = {}) {
     },
     ...overrides,
   };
+  if (overrides.FMX_DIR === undefined) ownedCacheDirs.set(deps, cacheDir);
+  return deps;
+}
+
+function cleanupDeps(deps) {
+  const cacheDir = ownedCacheDirs.get(deps);
+  if (cacheDir === undefined) return;
+  ownedCacheDirs.delete(deps);
+  fs.rmSync(cacheDir, { recursive: true, force: true });
 }
 
 async function withClient(deps, fn) {
   const server = new McpServer({ name: 'eurlex-test', version: '1.0.0' });
-  registerTools(server, deps);
-  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  const client = new Client({ name: 'test', version: '1.0.0' });
-  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  let client;
   try {
+    registerTools(server, deps);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: 'test', version: '1.0.0' });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
     return await fn(client);
   } finally {
-    await client.close();
-    await server.close();
+    try {
+      if (client) await client.close();
+    } finally {
+      try {
+        await server.close();
+      } finally {
+        cleanupDeps(deps);
+      }
+    }
   }
 }
 
@@ -441,10 +461,7 @@ test('get_law_part recital stays cached-only even when an OpenRouter key is conf
   const prevKey = process.env.OPENROUTER_API_KEY;
   const originalFetch = global.fetch;
   const fetched = [];
-  // A dedicated empty dir, not makeDeps' shared fixed path: this test drives a
-  // cache *miss* with a fetch stub that would succeed, so writing into the
-  // shared path would leave a generated title behind and break every later run
-  // on this machine.
+  // A dedicated empty dir keeps this cache-miss test isolated from other tests.
   const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-cached-only-'));
   process.env.OPENROUTER_API_KEY = 'test-key-should-be-ignored';
   global.fetch = async (url, options) => {
@@ -496,11 +513,15 @@ test('get_law_part structure surfaces cached recital titles', async () => {
   };
   fs.writeFileSync(path.join(cacheDir, 'recital-title-cache-v1.json'), JSON.stringify(cache));
 
-  await withClient(makeDeps({ FMX_DIR: cacheDir }), async (client) => {
-    const body = parseResult(await client.callTool({ name: 'get_law_part', arguments: { celex: '32016R0679', part: 'structure' } }));
-    const first = body.recitals.find((r) => r.number === '1');
-    assert.equal(first.title, 'Protection of natural persons');
-  });
+  try {
+    await withClient(makeDeps({ FMX_DIR: cacheDir }), async (client) => {
+      const body = parseResult(await client.callTool({ name: 'get_law_part', arguments: { celex: '32016R0679', part: 'structure' } }));
+      const first = body.recitals.find((r) => r.number === '1');
+      assert.equal(first.title, 'Protection of natural persons');
+    });
+  } finally {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  }
 });
 
 test('get_law_relations merges amendments and implementing acts', async () => {


### PR DESCRIPTION
Closes #196.

## The defect

`makeDeps` in `backend/mcp/register-tools.test.js` pointed `FMX_DIR` at a fixed `os.tmpdir()/mcp-test-nonexistent`. The name encodes the assumption — every test using it expects a cache **miss** — but nothing enforced it. Any run that reached a code path which *writes* a cache entry created `/tmp/mcp-test-nonexistent/recital-title-cache-v1.json`, `os.tmpdir()` is stable across runs, and no test cleaned it up. From then on every later run on that machine read a populated cache where it expected a miss. It does not reproduce on a fresh checkout or in CI, which is what makes it expensive to debug.

## The change

Test-fixture hygiene only — **no production file is touched**.

- `makeDeps` mints an `fs.mkdtempSync` directory per call; `withClient` removes it in a `finally`, so a write can never outlive the test that made it.
- Ownership is tracked in a `WeakMap`, so a caller-supplied `FMX_DIR` (two tests pass their own) is never deleted on the caller's behalf.
- All 28 fixtures reach that cleanup; the seeded-cache test gained the cleanup it was missing.
- `withClient` also became exception-safe: a failure during `registerTools`/`connect` used to leak the server and the directory.

## Verification

Seed `/tmp/mcp-test-nonexistent` with a recital-title entry carrying a **valid** `contentHash` for the fixture law (so it is genuinely servable, not inert), then run the file both ways:

| fixture | result |
|---|---|
| previous (fixed shared path) | 28 tests, **1 fail** |
| this PR | 28 tests, **0 fail** |

Full backend suite on this branch: 648 tests, 646 pass, 0 fail, 2 skipped. `npx eslint backend` clean. No `/tmp/mcp-*` directories survive a run.

A repo-wide sweep for the same pattern found no other writable fixed temp fixture: the remaining `/tmp` literals (`/tmp/defs.json`, `/tmp/fulltext.sqlite`, `/tmp/pw`, `legalviz-no-such-corpus`) are CLI-argument assertions and a Playwright env string, never written to.

## Notes

No cache-version constant moves — this changes no production behaviour, output shape, or cache entry.

Implementation was delegated to a Codex/Luna agent from a written spec; the diff, the poisoned-path acceptance test above, and the suite run were verified independently in this session.

---
_Generated by [Claude Code](https://claude.ai/code/session_016yJMS3KFkfRCH43ELAj88S)_