### PR TITLE
Stop the memory-watch sampler deleting the samples file it is sampling into

### DIFF
--- a/.github/scripts/memory-watch.sh
+++ b/.github/scripts/memory-watch.sh
@@ -63,7 +63,15 @@ fi
 shift
 
 samples=$(mktemp)
-trap 'rm -f "$samples"' EXIT
+# Guard the cleanup on being the top-level shell. Subshells inherit this trap,
+# and the sampler below is killed while it may still be inside bash code rather
+# than blocked in `sleep` -- bash then handles the signal and runs the inherited
+# EXIT trap, removing the samples file before the summary awk reads it. The
+# summary comes out empty and the trace this wrapper exists to leave is lost.
+# The race needs the watched command to exit almost immediately, which is why
+# the selftest (`-- true`) hit it perceptibly and long rebuilds did not; a
+# command that dies fast is exactly the OOM case worth having a trace for.
+trap 'if [ "$BASHPID" = "$$" ]; then rm -f "$samples"; fi' EXIT
 
 interval="${MEMORY_WATCH_INTERVAL:-30}"
 


### PR DESCRIPTION
Fixes a flake in the `test` job's first step. Split out of #237, where it turned up — that PR touches nothing under `.github/`, and this fix is unrelated to its subject.

## The symptom

`.github/scripts/memory-watch.sh selftest` fails intermittently on an unmodified checkout of `main` — **2 runs in 15** locally, so roughly 15–20% of CI runs on any PR:

```
FAIL - writes a step summary: expected '1', got '0'
```

## The cause

The samples file is already gone when the summary is computed, so the final `awk` reads nothing, `$summary` comes out empty, and nothing is appended to `GITHUB_STEP_SUMMARY`.

The deleter is the script's own cleanup trap, run by the **sampler subshell** instead of the top-level shell:

```bash
samples=$(mktemp)
trap 'rm -f "$samples"' EXIT      # inherited by the ( … ) & sampler
…
( while :; do … done ) &
sampler=$!
"$@"
kill "$sampler"                    # sampler may run the EXIT trap here
summary=$(awk … "$samples")        # …and the file is already gone
```

`kill` sends SIGTERM. If the sampler is blocked in `sleep`, bash dies without running traps — the common case, and why this isn't a constant failure. If SIGTERM instead lands while the sampler is inside bash code, bash handles it and runs the inherited EXIT trap.

Instrumenting the trap to log `BASHPID` against `$$` across 30 runs gave **7 subshell-level fires against exactly the 7 failing runs** — 7/7, no unexplained failures.

## Why it's worth fixing beyond the red check

The race needs the watched command to exit almost immediately, which is why `selftest` (`-- true`) surfaced it and four-hour rebuilds did not. But *a command that dies fast is exactly the OOM case this wrapper exists for* — and the memory trace is precisely what goes missing. The flaky check is the visible symptom of a real hole in the tool.

## The fix

Guard the cleanup on being the top-level shell:

```diff
-trap 'rm -f "$samples"' EXIT
+trap 'if [ "$BASHPID" = "$$" ]; then rm -f "$samples"; fi' EXIT
```

The `if` form rather than `[ … ] && rm -f …` keeps the trap from ever returning non-zero, so the forwarded exit status the build steps read via `PIPESTATUS` stays untouched.

For the record, the more obvious `( trap - EXIT; while :; … )` only takes it from ~23% to ~5% — the command-substitution subshells inside the sampler still carry the trap — so the `BASHPID` guard is the one that actually closes it.

## Verification

| | unpatched | patched |
|---|---|---|
| summary step, isolated | 3 failures / 100 | **0 / 100** |
| full `selftest` | 2 failures / 15 | **0 / 15** |

Also re-checked, since the trap is on the exit path the build steps depend on:

- exit status forwarded unchanged — `7` for a failing command, `0` for a passing one.
- no temp-file leak: `/tmp/tmp.*` count identical before and after three runs.
- the other four selftest assertions still pass, including "leaves no sampler behind".

---
_Generated by [Claude Code](https://claude.ai/code/session_014Xkve9Rc3bhttb2xLbKpqM)_