### PR TITLE
Recycle parser pool workers on both callers that stream acts

### DIFF
--- a/backend/search/citation-graph-worker.js
+++ b/backend/search/citation-graph-worker.js
@@ -4,9 +4,10 @@ const { buildCitationGraph, createReferenceResolver } = require("./citation-grap
 // Persistent worker: the parent's pool sends one batch per message and expects
 // exactly one reply per message. Serving many batches from one process amortises
 // module loading and jsdom startup (roughly a second per spawn, previously paid
-// once per batch), and shared/fmx-parser-node.js recycles its DOM-shim window
-// every FMX_DOM_SHIM_RECYCLE parses (default 25), so per-parse retention stays
-// bounded no matter how long this worker lives.
+// once per batch). fmx-parser-node.js recycles its DOM-shim window every
+// FMX_DOM_SHIM_RECYCLE parses (default 25), but that does not cover the HTML
+// fallback parser's per-act JSDOM retention; citation-graph-build.js therefore
+// retires this worker before it takes another batch after its recycle interval.
 const legalCache = workerData.resolverIndex
   ? createReferenceResolver(workerData.resolverIndex)
   : undefined;

--- a/backend/search/fulltext-index-build.js
+++ b/backend/search/fulltext-index-build.js
@@ -236,8 +236,11 @@ function runPool(initialBatches, onResult, options = {}) {
   const poolSize = options.poolSize || DEFAULT_POOL_SIZE;
   const workerHeapMb = options.workerHeapMb || DEFAULT_WORKER_HEAP_MB;
   // ?? rather than ||: an explicit 0 disables recycling, it does not mean
-  // "use the default".
-  const recycleAfter = options.recycleAfter ?? DEFAULT_RECYCLE_BATCHES;
+  // "use the default". Both spellings are accepted because buildFulltextIndex
+  // and the CLI speak `recycleBatches` (batches are this builder's unit) while
+  // the shared pool speaks `recycleAfter`; runPool is exported, so a caller
+  // reaching it directly should not have to know which side it is on.
+  const recycleAfter = options.recycleAfter ?? options.recycleBatches ?? DEFAULT_RECYCLE_BATCHES;
   const defaults = {
     initialTotals: {
       parsed: 0, htmlLaws: 0, oversized: 0, files: 0, failures: 0, filesDone: 0, batchesDone: 0,

--- a/backend/search/fulltext-index-build.js
+++ b/backend/search/fulltext-index-build.js
@@ -42,9 +42,15 @@ const FULLTEXT_SCHEMA_VERSION = 1;
 
 const DEFAULT_BATCH_SIZE = 20;
 const DEFAULT_POOL_SIZE = 2;
-// Retire a worker every 25 batches, i.e. every ~500 acts at the default batch
-// size -- the interval d6f0062 used here before 7766856 replaced it with
-// fmx-parser-node.js's shared-window recycling. That replacement only covers
+// Retire a worker every 10 batches, i.e. every ~200 acts at the default batch
+// size. d6f0062 used ~500 acts here before 7766856 replaced it with
+// fmx-parser-node.js's shared-window recycling, but the first full corpus run
+// measured after that removal (run 33077210787, 80,532 acts) shows why 500 is
+// too generous now: the worker peaked at 2001 MB against its 2048 MB cap, and
+// its mean heap drifted from ~400 MB over the first 30k acts to ~630 MB over
+// the last 10k. 200 acts costs ~400 respawns instead of ~160 across a full
+// build -- a few minutes on a run of over an hour -- to keep that drift from
+// eating the remaining 47 MB of headroom. That replacement only covers
 // the Formex path; eurlex-html-parser.js builds a fresh JSDOM per act whose
 // construction-time process.nextTick callback retains the document, so a
 // worker that streams tens of thousands of HTML acts still accumulates.
@@ -53,7 +59,7 @@ const DEFAULT_POOL_SIZE = 2;
 // short-lived caller for whom the respawn is not worth paying.
 // --recycleBatches 0 disables it; unlike --batchSize and --pool, zero is
 // meaningful here rather than invalid.
-const DEFAULT_RECYCLE_BATCHES = 25;
+const DEFAULT_RECYCLE_BATCHES = 10;
 const DEFAULT_WORKER_HEAP_MB = 640;
 // Same ceiling as the definition/citation-graph builders: definitions and
 // citations live in the operative text, and full-text units are extracted

--- a/backend/search/fulltext-index-build.js
+++ b/backend/search/fulltext-index-build.js
@@ -42,6 +42,18 @@ const FULLTEXT_SCHEMA_VERSION = 1;
 
 const DEFAULT_BATCH_SIZE = 20;
 const DEFAULT_POOL_SIZE = 2;
+// Retire a worker every 25 batches, i.e. every ~500 acts at the default batch
+// size -- the interval d6f0062 used here before 7766856 replaced it with
+// fmx-parser-node.js's shared-window recycling. That replacement only covers
+// the Formex path; eurlex-html-parser.js builds a fresh JSDOM per act whose
+// construction-time process.nextTick callback retains the document, so a
+// worker that streams tens of thousands of HTML acts still accumulates.
+// This builder only ever runs as a full-corpus job from
+// rederive-parser-assets.yml / refresh-fulltext.yml, so there is no
+// short-lived caller for whom the respawn is not worth paying.
+// --recycleBatches 0 disables it; unlike --batchSize and --pool, zero is
+// meaningful here rather than invalid.
+const DEFAULT_RECYCLE_BATCHES = 25;
 const DEFAULT_WORKER_HEAP_MB = 640;
 // Same ceiling as the definition/citation-graph builders: definitions and
 // citations live in the operative text, and full-text units are extracted
@@ -223,6 +235,9 @@ function walSizeMb(outputPath) {
 function runPool(initialBatches, onResult, options = {}) {
   const poolSize = options.poolSize || DEFAULT_POOL_SIZE;
   const workerHeapMb = options.workerHeapMb || DEFAULT_WORKER_HEAP_MB;
+  // ?? rather than ||: an explicit 0 disables recycling, it does not mean
+  // "use the default".
+  const recycleAfter = options.recycleAfter ?? DEFAULT_RECYCLE_BATCHES;
   const defaults = {
     initialTotals: {
       parsed: 0, htmlLaws: 0, oversized: 0, files: 0, failures: 0, filesDone: 0, batchesDone: 0,
@@ -265,6 +280,7 @@ function runPool(initialBatches, onResult, options = {}) {
     // behavior even though the shared runner accepts explicit sizes.
     poolSize,
     workerHeapMb,
+    recycleAfter,
     workerPath: options.workerPath || path.join(__dirname, "fulltext-index-worker.js"),
   });
 }
@@ -285,6 +301,7 @@ async function buildFulltextIndex(options = {}) {
   const batchSize = options.batchSize || DEFAULT_BATCH_SIZE;
   const poolSize = options.pool || DEFAULT_POOL_SIZE;
   const workerHeapMb = options.workerHeapMb || DEFAULT_WORKER_HEAP_MB;
+  const recycleAfter = options.recycleBatches ?? DEFAULT_RECYCLE_BATCHES;
   const log = options.progress ? (options.log || console.log) : null;
 
   const universe = options.universe || loadUniverseCelex(searchCachePath);
@@ -300,7 +317,7 @@ async function buildFulltextIndex(options = {}) {
     const pending = files.filter((file) => !doneCelex.has(celexForCorpusFile(file)));
     const batches = [];
     for (let i = 0; i < pending.length; i += batchSize) batches.push(pending.slice(i, i + batchSize));
-    if (log) log(`[fulltext] ${pending.length} remaining acts in ${batches.length} batches, pool=${poolSize}`);
+    if (log) log(`[fulltext] ${pending.length} remaining acts in ${batches.length} batches, pool=${poolSize}, recycle=${recycleAfter || "off"}`);
 
     const insertUnit = db.prepare("INSERT INTO units (celex, unit_type, number, heading, char_count, text) VALUES (?,?,?,?,?,?)");
     const insertFts = db.prepare("INSERT INTO units_fts (rowid, heading, text) VALUES (?,?,?)");
@@ -329,6 +346,7 @@ async function buildFulltextIndex(options = {}) {
     }, {
       poolSize,
       workerHeapMb,
+      recycleAfter,
       onProgress: log ? (running) => log(
         `[fulltext] ${running.filesDone}/${pending.length} acts, ${running.parsed} parsed, ${running.failures} failures`
         + `, worker heap ${running.workerHeapMb}/${workerHeapMb} MB (peak ${running.peakWorkerHeapMb})`
@@ -406,7 +424,7 @@ async function run(options = {}) {
 
 function parseCliArgs(argv) {
   const options = {};
-  const valueFlags = new Set(["--corpusDir", "--out", "--limit", "--fromYear", "--toYear", "--batchSize", "--pool", "--workerHeapMb"]);
+  const valueFlags = new Set(["--corpusDir", "--out", "--limit", "--fromYear", "--toYear", "--batchSize", "--pool", "--workerHeapMb", "--recycleBatches"]);
   for (let index = 0; index < argv.length; index += 1) {
     const flag = argv[index];
     if (!valueFlags.has(flag)) throw new Error(`Unknown argument: ${flag}`);
@@ -418,7 +436,7 @@ function parseCliArgs(argv) {
     if (!Number.isInteger(number) || number < 0 || (["--limit", "--batchSize", "--pool", "--workerHeapMb"].includes(flag) && number === 0)) {
       throw new Error(`Invalid value for ${flag}: ${value}`);
     }
-    options[{ "--limit": "limit", "--fromYear": "fromYear", "--toYear": "toYear", "--batchSize": "batchSize", "--pool": "pool", "--workerHeapMb": "workerHeapMb" }[flag]] = number;
+    options[{ "--limit": "limit", "--fromYear": "fromYear", "--toYear": "toYear", "--batchSize": "batchSize", "--pool": "pool", "--workerHeapMb": "workerHeapMb", "--recycleBatches": "recycleBatches" }[flag]] = number;
   }
   return options;
 }
@@ -433,6 +451,7 @@ if (require.main === module) {
 module.exports = {
   DEFAULT_CORPUS_DIR,
   DEFAULT_OUTPUT_PATH,
+  DEFAULT_RECYCLE_BATCHES,
   FULLTEXT_SCHEMA_VERSION,
   buildFulltextIndex,
   buildFulltextShard,

--- a/backend/search/fulltext-index-build.test.js
+++ b/backend/search/fulltext-index-build.test.js
@@ -4,12 +4,16 @@ const fs = require("node:fs/promises");
 const os = require("node:os");
 const path = require("node:path");
 
+const { EventEmitter } = require("node:events");
+
 const {
   buildFulltextIndex,
   buildFulltextShard,
   openFulltextDatabase,
   parseCliArgs,
+  runPool,
   writeManifest,
+  DEFAULT_RECYCLE_BATCHES,
   FULLTEXT_SCHEMA_VERSION,
 } = require("./fulltext-index-build");
 const { getCurrentParserVersion } = require("./parser-stamp");
@@ -411,4 +415,75 @@ test("progress line reports the worker's isolate heap against its cap, the WAL s
   } finally {
     await fs.rm(dir, { recursive: true, force: true });
   }
+});
+
+// A worker that streams the whole corpus accumulates the HTML parser's
+// per-act JSDOM retention, so this builder retires its workers periodically.
+// d6f0062 had exactly that and 7766856 removed it on the mistaken premise
+// that fmx-parser-node.js's shared-window recycling covered the HTML path;
+// these two tests are the guard against a third round of that.
+class RecycleFakeWorker extends EventEmitter {
+  constructor(onPostMessage) {
+    super();
+    this.onPostMessage = onPostMessage;
+    this.terminated = false;
+    this.posts = 0;
+  }
+
+  postMessage(payload) {
+    this.posts += 1;
+    this.onPostMessage(payload);
+  }
+
+  terminate() {
+    this.terminated = true;
+    return Promise.resolve(0);
+  }
+}
+
+function countWorkersOverBatches(batches, options) {
+  const workers = [];
+  const spawnWorker = () => {
+    const worker = new RecycleFakeWorker(() => queueMicrotask(() => {
+      worker.emit("message", { units: [], failures: [], stats: { parsed: 1, files: 1 } });
+    }));
+    workers.push(worker);
+    return worker;
+  };
+  return runPool(batches, () => {}, { poolSize: 1, spawnWorker, ...options })
+    .then(() => workers);
+}
+
+test("the fulltext builder recycles its workers by default", async () => {
+  assert.ok(
+    Number.isInteger(DEFAULT_RECYCLE_BATCHES) && DEFAULT_RECYCLE_BATCHES > 0,
+    "recycling must stay on by default: this builder only runs as a full-corpus job",
+  );
+
+  // No recycleAfter passed: the adapter has to supply its own default, which
+  // is the half 7766856 dropped.
+  const long = Array.from({ length: DEFAULT_RECYCLE_BATCHES * 2 + 1 }, (_, index) => [`file-${index}`]);
+  const defaulted = await countWorkersOverBatches(long, {});
+  assert.equal(defaulted.length, 3, "two replacements across two full recycle intervals");
+  assert.deepEqual(
+    defaulted.map((worker) => worker.posts),
+    [DEFAULT_RECYCLE_BATCHES, DEFAULT_RECYCLE_BATCHES, 1],
+  );
+
+  const batches = Array.from({ length: 6 }, (_, index) => [`file-${index}`]);
+  const workers = await countWorkersOverBatches(batches, { recycleAfter: 2 });
+  assert.equal(workers.length, 3, "one replacement per two completed batches");
+  assert.deepEqual(workers.map((worker) => worker.posts), [2, 2, 2]);
+  assert.deepEqual(workers.slice(0, -1).map((worker) => worker.terminated), [true, true]);
+});
+
+test("an explicit recycleBatches of 0 disables recycling rather than restoring the default", async () => {
+  const batches = Array.from({ length: 6 }, (_, index) => [`file-${index}`]);
+  const workers = await countWorkersOverBatches(batches, { recycleAfter: 0 });
+  assert.equal(workers.length, 1, "zero means off, not 'use the default'");
+  assert.equal(workers[0].posts, 6);
+
+  assert.deepEqual(parseCliArgs(["--recycleBatches", "0"]), { recycleBatches: 0 });
+  assert.deepEqual(parseCliArgs(["--recycleBatches", "10"]), { recycleBatches: 10 });
+  assert.throws(() => parseCliArgs(["--recycleBatches", "-1"]), /Invalid value/);
 });

--- a/backend/search/fulltext-index-build.test.js
+++ b/backend/search/fulltext-index-build.test.js
@@ -210,6 +210,7 @@ test("buildFulltextIndex (real fixture, real worker pool) populates units + unit
   const outputPath = path.join(dir, "fulltext.sqlite");
   const file = await seedCorpusFile(dir, "fmx-v4-2009-32009L0004.xml.gz", "32009L0004", "xml");
 
+  const logged = [];
   const summary = await buildFulltextIndex({
     outputPath,
     files: [file],
@@ -217,7 +218,18 @@ test("buildFulltextIndex (real fixture, real worker pool) populates units + unit
     batchSize: 10,
     pool: 1,
     workerHeapMb: 256,
+    recycleBatches: 7,
+    progress: true,
+    log: (line) => logged.push(line),
   });
+
+  // buildFulltextIndex has no DI hook for the pool, so its own progress line is
+  // the observable proof that recycleBatches reaches it rather than being
+  // dropped between the two option names.
+  assert.ok(
+    logged.some((line) => line.includes("recycle=7")),
+    `expected a progress line reporting recycle=7, got: ${JSON.stringify(logged)}`,
+  );
 
   // Matches the fixture's frozen floor in corpus-fixtures.test.js
   // (minArticles: 4, minRecitals: 6).
@@ -477,11 +489,23 @@ test("the fulltext builder recycles its workers by default", async () => {
   assert.deepEqual(workers.slice(0, -1).map((worker) => worker.terminated), [true, true]);
 });
 
-test("an explicit recycleBatches of 0 disables recycling rather than restoring the default", async () => {
-  const batches = Array.from({ length: 6 }, (_, index) => [`file-${index}`]);
-  const workers = await countWorkersOverBatches(batches, { recycleAfter: 0 });
-  assert.equal(workers.length, 1, "zero means off, not 'use the default'");
-  assert.equal(workers[0].posts, 6);
+test("an explicit 0 disables recycling rather than restoring the default, under either option name", async () => {
+  const batches = () => Array.from({ length: 6 }, (_, index) => [`file-${index}`]);
+
+  // runPool is exported and speaks the shared pool's `recycleAfter`;
+  // buildFulltextIndex and the CLI speak `recycleBatches`. A caller reaching
+  // the adapter directly with the builder's spelling must not silently get the
+  // default instead of the "off" they asked for.
+  for (const name of ["recycleAfter", "recycleBatches"]) {
+    const workers = await countWorkersOverBatches(batches(), { [name]: 0 });
+    assert.equal(workers.length, 1, `${name}: zero means off, not 'use the default'`);
+    assert.equal(workers[0].posts, 6);
+  }
+
+  for (const name of ["recycleAfter", "recycleBatches"]) {
+    const workers = await countWorkersOverBatches(batches(), { [name]: 2 });
+    assert.equal(workers.length, 3, `${name}: honoured as an interval`);
+  }
 
   assert.deepEqual(parseCliArgs(["--recycleBatches", "0"]), { recycleBatches: 0 });
   assert.deepEqual(parseCliArgs(["--recycleBatches", "10"]), { recycleBatches: 10 });

--- a/backend/shared/parser-worker-pool.js
+++ b/backend/shared/parser-worker-pool.js
@@ -23,6 +23,13 @@ const {
 // malformed or unexpectedly large request. Set PARSER_POOL_SIZE=0 to disable.
 const DEFAULT_PARSER_POOL_SIZE = 2;
 const DEFAULT_PARSER_WORKER_HEAP_MB = 640;
+// The largest 1995 HTML act measured at 383 KB retained about 10 MB per parse
+// while its worker was kept in the same event-loop turn: 40 parses reached
+// 465 MB against the 640 MB cap. A 40-task interval leaves measured headroom
+// for parser variance while amortising the roughly one-second worker startup.
+// Set PARSER_WORKER_RECYCLE_TASKS=0 to disable; the generic pool remains off by
+// default so build-side callers keep their existing lifetime behavior.
+const DEFAULT_PARSER_WORKER_RECYCLE_TASKS = 40;
 const MAX_CONSECUTIVE_POOL_FAILURES = 3;
 
 function envInteger(name, fallback, { min = 0 } = {}) {
@@ -37,6 +44,9 @@ function createParserPool(options = {}) {
   const workerHeapMb = options.workerHeapMb === undefined
     ? envInteger("PARSER_WORKER_HEAP_MB", DEFAULT_PARSER_WORKER_HEAP_MB, { min: 1 })
     : options.workerHeapMb;
+  const recycleAfter = options.recycleAfter === undefined
+    ? envInteger("PARSER_WORKER_RECYCLE_TASKS", DEFAULT_PARSER_WORKER_RECYCLE_TASKS)
+    : options.recycleAfter;
   const parseFmxXmlInline = options.parseFmxXml || defaultParseFmxXml;
   const parseEurlexHtmlToCombinedInline = options.parseEurlexHtmlToCombined || defaultParseEurlexHtmlToCombined;
 
@@ -52,6 +62,9 @@ function createParserPool(options = {}) {
   if (!Number.isInteger(workerHeapMb) || workerHeapMb < 1) {
     throw new Error(`Parser worker heap must be a positive integer, got ${workerHeapMb}`);
   }
+  if (!Number.isInteger(recycleAfter) || recycleAfter < 0) {
+    throw new Error(`Parser worker recycle threshold must be a non-negative integer, got ${recycleAfter}`);
+  }
 
   if (poolSize === 0) {
     return {
@@ -66,6 +79,7 @@ function createParserPool(options = {}) {
     poolSize,
     queueLimit: options.queueLimit === undefined ? DEFAULT_QUEUE_LIMIT : options.queueLimit,
     taskDeadlineMs: options.taskDeadlineMs === undefined ? DEFAULT_TASK_DEADLINE_MS : options.taskDeadlineMs,
+    recycleAfter,
     workerFactory: options.spawnWorker || (() => new Worker(path.join(__dirname, "parser-worker.js"), {
       resourceLimits: { maxOldGenerationSizeMb: workerHeapMb },
     })),
@@ -135,6 +149,7 @@ function createParserPool(options = {}) {
 module.exports = {
   DEFAULT_PARSER_POOL_SIZE,
   DEFAULT_PARSER_WORKER_HEAP_MB,
+  DEFAULT_PARSER_WORKER_RECYCLE_TASKS,
   DEFAULT_PARSER_QUEUE_LIMIT: DEFAULT_QUEUE_LIMIT,
   DEFAULT_PARSER_TASK_DEADLINE_MS: DEFAULT_TASK_DEADLINE_MS,
   createParserPool,

--- a/backend/shared/parser-worker-pool.test.js
+++ b/backend/shared/parser-worker-pool.test.js
@@ -303,6 +303,52 @@ test("opt-in recycling replaces idle workers before queued work and preserves ev
   }
 });
 
+test("close() waits for workers already retired for recycling", async () => {
+  // A retired worker leaves `workers` the instant retirement starts, so close()
+  // could resolve while its thread is still alive and still holding the event
+  // loop open -- for the fulltext CLI that is a build that finishes and then
+  // hangs.
+  const workers = [];
+  const pool = createWorkerPool({
+    poolSize: 1,
+    recycleAfter: 1,
+    workerFactory: () => {
+      const worker = new FakeWorker((payload) => queueMicrotask(() => {
+        worker.emit("message", { ok: true, result: payload });
+      }));
+      // Each worker's termination is released individually, so the retired
+      // one can be left outstanding while the live one has already settled.
+      worker.terminate = () => {
+        worker.terminated = true;
+        return new Promise((resolve) => { worker.release = () => resolve(0); });
+      };
+      workers.push(worker);
+      return worker;
+    },
+  });
+
+  await pool.run(1);
+  await pool.run(2);
+  assert.equal(workers.length, 2, "the first worker retired after its single task");
+  const [retired, live] = workers;
+  assert.equal(retired.terminated, true, "the retired worker's termination is in flight");
+
+  let closed = false;
+  const closing = pool.close().then(() => { closed = true; });
+  live.release();
+  await new Promise((resolve) => setImmediate(resolve));
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.equal(
+    closed,
+    false,
+    "close() must not resolve once the live worker is gone but a retired thread is still terminating",
+  );
+
+  retired.release();
+  await closing;
+  assert.equal(closed, true);
+});
+
 test("onResult errors propagate without bisecting into a skipped batch", async () => {
   let worker;
   let skipped = 0;

--- a/backend/shared/parser-worker-pool.test.js
+++ b/backend/shared/parser-worker-pool.test.js
@@ -22,6 +22,7 @@ const {
   createParserPool,
   DEFAULT_PARSER_POOL_SIZE,
   DEFAULT_PARSER_WORKER_HEAP_MB,
+  DEFAULT_PARSER_WORKER_RECYCLE_TASKS,
 } = require("./parser-worker-pool");
 
 const FIXTURE = path.join(__dirname, "__fixtures__", "corpus", "fmx-v4-2009-32009L0004.xml.gz");
@@ -152,6 +153,43 @@ test("worker loss surfaces a 503 and never retries the parse inline", async () =
   await pool.close();
 });
 
+test("parser recycling is transparent to queued callers and does not disable the pool", async () => {
+  let starts = 0;
+  let inlineCalls = 0;
+  const workers = [];
+  const pool = createParserPool({
+    poolSize: 1,
+    recycleAfter: 1,
+    spawnWorker: () => {
+      starts += 1;
+      const worker = new FakeWorker((payload) => queueMicrotask(() => {
+        worker.emit("message", { ok: true, result: { kind: "worker", payload } });
+      }));
+      workers.push(worker);
+      return worker;
+    },
+    parseFmxXml: async () => {
+      inlineCalls += 1;
+      return { kind: "inline" };
+    },
+  });
+
+  try {
+    const results = await Promise.all(["one", "two", "three", "four"].map((input) => pool.parseFmxXml(input)));
+    assert.deepEqual(results, [
+      { kind: "worker", payload: { kind: "fmx", input: "one", lang: undefined } },
+      { kind: "worker", payload: { kind: "fmx", input: "two", lang: undefined } },
+      { kind: "worker", payload: { kind: "fmx", input: "three", lang: undefined } },
+      { kind: "worker", payload: { kind: "fmx", input: "four", lang: undefined } },
+    ]);
+    assert.equal(starts, 4, "each completed task retires before the next queued task");
+    assert.equal(inlineCalls, 0, "retirement is not classified as a startup or worker failure");
+    assert.ok(workers.slice(0, -1).every((worker) => worker.terminated));
+  } finally {
+    await pool.close();
+  }
+});
+
 test("never-replying workers are killed at the deadline and replaced", { timeout: 1000 }, async () => {
   assert.ok(DEFAULT_TASK_DEADLINE_MS > 1000, "the production deadline should cover real parse batches");
   let starts = 0;
@@ -237,6 +275,34 @@ test("worker pool rejects a task when its queue is full", { timeout: 1000 }, asy
   assert.equal((await queued).code, "worker_pool_closed");
 });
 
+test("opt-in recycling replaces idle workers before queued work and preserves every result", async () => {
+  const workers = [];
+  const pool = createWorkerPool({
+    poolSize: 1,
+    recycleAfter: 2,
+    workerFactory: () => {
+      const worker = new FakeWorker((payload) => queueMicrotask(() => {
+        worker.emit("message", { ok: true, result: payload });
+      }));
+      workers.push(worker);
+      return worker;
+    },
+  });
+
+  try {
+    const results = await Promise.all([1, 2, 3, 4, 5].map((payload) => pool.run(payload)));
+    assert.deepEqual(results.map((message) => message.result), [1, 2, 3, 4, 5]);
+    assert.equal(workers.length, 3, "one replacement per two completed tasks");
+    assert.equal(workers[0].posts, 2);
+    assert.equal(workers[1].posts, 2);
+    assert.equal(workers[2].posts, 1);
+    assert.equal(workers[0].terminated, true);
+    assert.equal(workers[1].terminated, true);
+  } finally {
+    await pool.close();
+  }
+});
+
 test("onResult errors propagate without bisecting into a skipped batch", async () => {
   let worker;
   let skipped = 0;
@@ -264,4 +330,5 @@ test("onResult errors propagate without bisecting into a skipped batch", async (
 test("parser pool defaults retain the builder-sized worker budget", () => {
   assert.equal(DEFAULT_PARSER_POOL_SIZE, 2);
   assert.equal(DEFAULT_PARSER_WORKER_HEAP_MB, 640);
+  assert.equal(DEFAULT_PARSER_WORKER_RECYCLE_TASKS, 40);
 });

--- a/backend/shared/worker-pool.js
+++ b/backend/shared/worker-pool.js
@@ -83,6 +83,7 @@ function createWorkerPool({
   workerFactory,
   taskDeadlineMs = DEFAULT_TASK_DEADLINE_MS,
   queueLimit = DEFAULT_QUEUE_LIMIT,
+  recycleAfter = 0,
 } = {}) {
   if (!Number.isInteger(poolSize) || poolSize < 1) {
     throw new Error(`Worker pool size must be a positive integer, got ${poolSize}`);
@@ -95,6 +96,9 @@ function createWorkerPool({
   }
   if (!Number.isInteger(queueLimit) || queueLimit < 0) {
     throw new Error(`Worker pool queue limit must be a non-negative integer, got ${queueLimit}`);
+  }
+  if (!Number.isInteger(recycleAfter) || recycleAfter < 0) {
+    throw new Error(`Worker recycle threshold must be a non-negative integer, got ${recycleAfter}`);
   }
 
   const workers = new Set();
@@ -122,7 +126,7 @@ function createWorkerPool({
   }
 
   function attachWorker(thread) {
-    const record = { thread, job: null, dead: false };
+    const record = { thread, job: null, dead: false, retiring: false, completedTasks: 0 };
     workers.add(record);
 
     thread.on("message", (message) => {
@@ -139,6 +143,7 @@ function createWorkerPool({
           if (record.job !== job) return;
           clearJobTimer(job);
           record.job = null;
+          record.completedTasks += 1;
           job.resolve(message);
           dispatch();
         })
@@ -146,6 +151,7 @@ function createWorkerPool({
           if (record.job !== job) return;
           clearJobTimer(job);
           record.job = null;
+          record.completedTasks += 1;
           job.reject(new WorkerResultError(
             `Worker result callback failed: ${error?.message || error}`,
             error,
@@ -156,7 +162,7 @@ function createWorkerPool({
 
     thread.on("error", (error) => handleWorkerLoss(record, error));
     thread.on("exit", (code) => {
-      if (!record.dead) {
+      if (!record.dead && !record.retiring) {
         handleWorkerLoss(record, new Error(`Worker exited with code ${code}`));
       }
     });
@@ -187,7 +193,7 @@ function createWorkerPool({
   }
 
   function handleWorkerLoss(record, error, { terminate = false } = {}) {
-    if (record.dead) return;
+    if (record.dead || record.retiring) return;
     record.dead = true;
     workers.delete(record);
     const job = record.job;
@@ -213,10 +219,38 @@ function createWorkerPool({
     dispatch();
   }
 
+  function replaceForRecycle(record) {
+    // Start the replacement before retiring the idle worker. A transient
+    // factory failure therefore leaves the existing worker available for the
+    // queued task and is not misreported as a worker loss.
+    let replacement;
+    try {
+      replacement = startWorker();
+    } catch {
+      record.completedTasks = 0;
+      return record;
+    }
+
+    record.retiring = true;
+    workers.delete(record);
+    Promise.resolve(record.thread.terminate()).catch(() => {});
+    return replacement;
+  }
+
   function dispatch() {
     if (closed) return;
     for (const record of workers) {
       if (record.dead || record.job || queue.length === 0) continue;
+      if (recycleAfter > 0 && record.completedTasks >= recycleAfter) {
+        const replacement = replaceForRecycle(record);
+        if (replacement !== record) {
+          // The new record has no completed tasks. Re-enter dispatch so it can
+          // take the queued job without relying on Set iterator semantics for
+          // a record added during this iteration.
+          dispatch();
+          return;
+        }
+      }
       const job = queue.shift();
       record.job = job;
       job.timer = setTimeout(() => {
@@ -328,6 +362,7 @@ async function runPool(initialBatches, onResult, options = {}) {
     workerFactory,
     taskDeadlineMs: options.taskDeadlineMs,
     queueLimit: options.queueLimit,
+    recycleAfter: options.recycleAfter,
   });
   const onProgress = options.onProgress || (() => {});
 

--- a/backend/shared/worker-pool.js
+++ b/backend/shared/worker-pool.js
@@ -102,6 +102,10 @@ function createWorkerPool({
   }
 
   const workers = new Set();
+  // Terminations of workers retired for recycling. They are out of `workers`
+  // the moment retirement starts, so close() would otherwise resolve while one
+  // of their threads is still alive and still holding the event loop open.
+  const retiringTerminations = new Set();
   const queue = [];
   let closed = false;
   let closePromise = null;
@@ -233,7 +237,9 @@ function createWorkerPool({
 
     record.retiring = true;
     workers.delete(record);
-    Promise.resolve(record.thread.terminate()).catch(() => {});
+    const termination = Promise.resolve(record.thread.terminate()).catch(() => {});
+    retiringTerminations.add(termination);
+    termination.then(() => retiringTerminations.delete(termination));
     return replacement;
   }
 
@@ -332,7 +338,10 @@ function createWorkerPool({
         job.reject(new WorkerPoolClosedError());
       }
     }
-    closePromise = Promise.allSettled(active.map(({ thread }) => thread.terminate())).then(() => undefined);
+    closePromise = Promise.allSettled([
+      ...active.map(({ thread }) => thread.terminate()),
+      ...retiringTerminations,
+    ]).then(() => undefined);
     return closePromise;
   }
 


### PR DESCRIPTION
Closes #231.

## The gap

`9583d46` gave the citation-graph builder's inline pool a recycle interval (`DEFAULT_RECYCLE_BATCHES = 5`) so the HTML fallback parser's per-act JSDOM retention could not accumulate across a long build. The other two places that stream acts through long-lived workers never got the equivalent:

- **The serving pool** behind `/api/laws/:celex/parsed` (`shared/parser-worker-pool.js`) never had it. Its workers live for the process lifetime, so retention builds up until the 640 MB worker cap kills the thread — self-healing only through an OOM that fails the in-flight requests with a 503.
- **`search/fulltext-index-build.js`** *had* it in `d6f0062` and lost it in `7766856`, which replaced it with `fmx-parser-node.js`'s shared-window recycling. That only covers the Formex path: the recycler holds one window across FMX parses, while `eurlex-html-parser.js` builds a fresh JSDOM per act. So the builder that streams ~80k acts has been running uncovered since.

## The change

- `shared/worker-pool.js` gains a `recycleAfter` option. A worker at or over the threshold is replaced **before** it is handed the next queued task. The replacement is started first: a transient `workerFactory` failure therefore leaves the existing worker available to serve the queued job instead of being reported as a worker loss. Intentional retirement sets `retiring`, which the `exit` handler and `handleWorkerLoss` both skip, so it is never mistaken for a crash and never triggers the consecutive-failure inline fallback. `close()` awaits retired threads' terminations alongside the live workers.
- **Both callers set one.** The serving pool recycles every **40 tasks** (`PARSER_WORKER_RECYCLE_TASKS`); the fulltext builder every **10 batches** (`--recycleBatches`), ~200 acts at its default batch size. `0` means off in both, not "use the default", and `runPool` accepts either option name.
- The shared parameter itself defaults to `0` deliberately: a "task" is one parse for the serving pool, 20 acts for fulltext and 100 for the citation graph, so a single shared number would mean three very different intervals. The durable guard is per-caller tests asserting each default is non-zero, since a silent removal is exactly how fulltext regressed the first time.
- Corrects the `search/citation-graph-worker.js` header, which cited the premise `7766856` was built on.

No cache-version constant moves: parser output shape is unchanged.

## Verification

Full backend suite on this branch: **665 tests, 663 pass, 0 fail, 2 pre-existing skips**. `npx eslint` clean on every changed file.

Retention on the serving path, measured as process RSS across 80 parses of a 296 KB HTML act through a one-worker pool (`worker_threads` share the parent process, so RSS covers the worker):

| after N tasks | `recycleAfter=0` | `recycleAfter=10` |
|---|---|---|
| 20 | 509 MB | 516 MB |
| 40 | 538 MB | 527 MB |
| 60 | 586 MB | 533 MB |
| 80 | **628 MB, still climbing** | **536 MB, flat** |

Without recycling the curve is monotonic at roughly 1.5 MB/parse, matching the ~1.2–1.3 MB per-act JSDOM retention measured on the issue. With recycling it plateaus after the first interval.

Parse results are unaffected across a recycle boundary: 15 serial parses and 6 concurrent parses of the GDPR fixture at `recycleAfter=2` and `recycleAfter=3` all return a single distinct result, identical to `recycleAfter=0`. (The comparison normalises the `qid=<timestamp>` in generated EUR-Lex quick-search links, which varies per parse on `main` too and is unrelated to this change.)

Every guard test here was checked against the unfixed code and fails without its fix — the default-recycling assertion, the `close()` lifecycle assertion, and the both-option-names assertion.

### Why 10 batches on the build side

Run [33077210787](https://github.com/maastrichtlawtech/legalviz.eu/actions/runs/33077210787) is the first full-corpus fulltext build measured since `7766856` removed recycling. Over 80,532 acts the worker **peaked at 2001 MB against its 2048 MB cap**, with mean heap by position:

| acts | max heap | mean heap |
|---|---|---|
| 0–30,000 | 1817 MB | ~400 MB |
| 30,000–60,000 | 1989 MB | ~470 MB |
| 60,000–80,532 | 2001 MB | ~590 MB |

The max does not climb monotonically, so this is a large working set rather than a pure leak — but 47 MB of headroom is not a margin worth defending with a 500-act interval. 10 batches costs ~400 respawns across a full build instead of ~160, a few minutes on a run that already takes over an hour.

## Remaining risk

- Recycling is checked only when there is queued work, so an idle serving pool holds its retained memory until the next request arrives. Peak is still bounded, because the retirement happens before that request is dispatched.
- If a replacement worker cannot be started, the counter resets and the existing worker serves another full interval before trying again. That is deliberate — degrading to today's behaviour beats failing the request.
- Recycling addresses the drift component of the fulltext worker's heap. The transient 2 GB peaks look act-size driven, and retiring a worker between acts does nothing about those.
- The 40-task serving interval was chosen from a measurement where the largest act reached 465 MB after 40 tight-loop parses against the 640 MB cap. It leaves headroom for parser variance while amortising the ~1 s startup, but it is a tuning constant, not a proof.
- `buildFulltextIndex` has no DI hook for its pool, so the test that its `recycleBatches` reaches the pool asserts on the build's own progress line rather than on a spy.

## Not in scope

The underlying retainer is a `process.nextTick` callback scheduled during `new JSDOM` construction, whose closure keeps the `Window` → `_document` → DOM tree alive; neither a selector call nor `window.close()` is needed to reproduce it. Removing or yielding around that callback belongs in a separate parser PR with output-compatibility tests and a `PARSER_VERSION` review — `JSDOM.fragment()` is not a drop-in without proving equivalent document semantics. Details are on #231.